### PR TITLE
Fix so that the Java API seed project works with Angular seed project…

### DIFF
--- a/examples/java-api/src/main/webapp/WEB-INF/web.xml
+++ b/examples/java-api/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,10 @@
      <filter>
         <filter-name>CORS Filter</filter-name>
         <filter-class>org.ebaysf.web.cors.CORSFilter</filter-class>
+	<init-param>
+        	<param-name>cors.allowed.headers</param-name>
+        	<param-value>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization</param-value>
+    	</init-param>
       </filter>
       <filter-mapping>
         <filter-name>CORS Filter</filter-name>


### PR DESCRIPTION
…. Added Authorization as part of the cors.allowed.headers.

Before this change, connecting with the Angular seed app was giving a CORS error "No Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:3000 is therefore not allowed access.

The OPTIONS request was failing with 403 Forbidden. With this change it's all good.