### PR TITLE
Do not add request body if there's nothing to add

### DIFF
--- a/auth0/src/main/java/com/auth0/request/internal/BaseRequest.java
+++ b/auth0/src/main/java/com/auth0/request/internal/BaseRequest.java
@@ -98,7 +98,11 @@ abstract class BaseRequest<T> implements ParameterizableRequest<T>, Authorizable
     }
 
     protected RequestBody buildBody() throws RequestBodyBuildException {
-        return JsonRequestBodyBuilder.createBody(builder.asDictionary(), writer);
+        Map<String, Object> dictionary = builder.asDictionary();
+        if (!dictionary.isEmpty()) {
+            return JsonRequestBodyBuilder.createBody(dictionary, writer);
+        }
+        return null;
     }
 
     protected APIException parseUnsuccessfulResponse(Response response) {


### PR DESCRIPTION
Without this the GET method of RequestFactory is useless.

I need this for management api: https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id