### PR TITLE
Parse extra Auth0 Identity values

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/users/Identity.java
+++ b/src/main/java/com/auth0/json/mgmt/users/Identity.java
@@ -1,8 +1,9 @@
 package com.auth0.json.mgmt.users;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -21,6 +22,21 @@ public class Identity {
     private String accessToken;
     @JsonProperty("profileData")
     private ProfileData profileData;
+    private Map<String, Object> values;
+
+    public Identity() {
+        values = new HashMap<>();
+    }
+
+    @JsonAnySetter
+    void setValue(String key, Object value) {
+        values.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getValues() {
+        return values;
+    }
 
     @JsonProperty("connection")
     public String getConnection() {

--- a/src/test/java/com/auth0/json/mgmt/users/IdentityTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/IdentityTest.java
@@ -4,12 +4,11 @@ import com.auth0.json.JsonTest;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class IdentityTest extends JsonTest<Identity> {
 
-    private static final String json = "{\"connection\":\"auth0\",\"user_id\":\"user|123\",\"isSocial\":true,\"provider\":\"oauth\",\"access_token\":\"aTokEn\",\"profileData\":{}}";
+    private static final String json = "{\"connection\":\"auth0\",\"user_id\":\"user|123\",\"isSocial\":true,\"provider\":\"oauth\",\"access_token\":\"aTokEn\",\"profileData\":{},\"access_token_secret\":\"s3cr3t\"}";
 
     @Test
     public void shouldDeserialize() throws Exception {
@@ -22,5 +21,7 @@ public class IdentityTest extends JsonTest<Identity> {
         assertThat(identity.getProvider(), is("oauth"));
         assertThat(identity.getAccessToken(), is("aTokEn"));
         assertThat(identity.getProfileData(), is(notNullValue()));
+        assertThat(identity.getValues(), is(notNullValue()));
+        assertThat(identity.getValues(), hasEntry("access_token_secret", (Object) "s3cr3t"));
     }
 }


### PR DESCRIPTION
Parse extra values contained in the received Identity into a Map.
I've found that `access_token_secret`, `expires_in` and `refresh_token` might be included in the Identities object. We might think about having those specific getters instead of the proposed generic Map.

Fixes https://github.com/auth0/auth0-java/issues/41