### PR TITLE
Fix "q" query parameter encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,13 +59,13 @@ test {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp3:okhttp:3.5.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
+    compile 'com.squareup.okhttp3:okhttp:3.7.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.7.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.5'
     compile 'commons-codec:commons-codec:1.10'
 
     testCompile 'org.mockito:mockito-core:2.5.4'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.5.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.7.0'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'junit:junit:4.11'

--- a/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
@@ -12,6 +12,8 @@ import okhttp3.OkHttpClient;
 
 import java.util.Map;
 
+import static com.auth0.client.mgmt.filter.QueryFilter.KEY_QUERY;
+
 /**
  * Class that provides an implementation of the Events methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Logs
  */
@@ -35,7 +37,11 @@ public class LogEventsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/logs");
         if (filter != null) {
             for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
-                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                if (KEY_QUERY.equals(e.getKey())) {
+                    builder.addEncodedQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                } else {
+                    builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                }
             }
         }
         String url = builder.build().toString();

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -20,6 +20,8 @@ import okhttp3.OkHttpClient;
 import java.util.List;
 import java.util.Map;
 
+import static com.auth0.client.mgmt.filter.QueryFilter.KEY_QUERY;
+
 /**
  * Class that provides an implementation of the Users methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Users
  */
@@ -44,7 +46,11 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users");
         if (filter != null) {
             for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
-                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                if (KEY_QUERY.equals(e.getKey())) {
+                    builder.addEncodedQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                } else {
+                    builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                }
             }
         }
         String url = builder.build().toString();

--- a/src/main/java/com/auth0/client/mgmt/filter/LogEventFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/LogEventFilter.java
@@ -1,5 +1,7 @@
 package com.auth0.client.mgmt.filter;
 
+import java.io.UnsupportedEncodingException;
+
 /**
  * Class used to filter the results received when calling the Logs endpoint. Related to the {@link com.auth0.client.mgmt.LogEventsEntity} entity.
  */
@@ -25,7 +27,7 @@ public class LogEventFilter extends QueryFilter {
     }
 
     @Override
-    public LogEventFilter withQuery(String query) {
+    public LogEventFilter withQuery(String query) throws UnsupportedEncodingException {
         super.withQuery(query);
         return this;
     }

--- a/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
@@ -1,6 +1,11 @@
 package com.auth0.client.mgmt.filter;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 public class QueryFilter extends FieldsFilter {
+
+    public static final String KEY_QUERY = "q";
 
     /**
      * Filter by a query
@@ -8,8 +13,9 @@ public class QueryFilter extends FieldsFilter {
      * @param query the query expression using the following syntax https://auth0.com/docs/api/management/v2/query-string-syntax.
      * @return this filter instance
      */
-    public QueryFilter withQuery(String query) {
-        parameters.put("q", query);
+    public QueryFilter withQuery(String query) throws UnsupportedEncodingException {
+        String encodedQuery = URLEncoder.encode(query, "UTF-8");
+        parameters.put(KEY_QUERY, encodedQuery);
         return this;
     }
 

--- a/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
@@ -1,5 +1,7 @@
 package com.auth0.client.mgmt.filter;
 
+import java.io.UnsupportedEncodingException;
+
 /**
  * Class used to filter the results received when calling the Users endpoint. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
  */
@@ -19,7 +21,7 @@ public class UserFilter extends QueryFilter {
     }
 
     @Override
-    public UserFilter withQuery(String query) {
+    public UserFilter withQuery(String query) throws UnsupportedEncodingException {
         super.withQuery(query);
         return this;
     }

--- a/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
@@ -95,7 +95,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListLogEventsWithQuery() throws Exception {
-        LogEventFilter filter = new LogEventFilter().withQuery("sample");
+        LogEventFilter filter = new LogEventFilter().withQuery("email:\\*@gmail.com");
         Request<LogEventsPage> request = api.logEvents().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -106,12 +106,11 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("q", "sample"));
+        assertThat(recordedRequest, hasQueryParameter("q", "email%3A%5C*%40gmail.com"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(2));
     }
-
 
     @Test
     public void shouldListLogEventsWithCheckpoint() throws Exception {

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -104,7 +104,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListUsersWithQuery() throws Exception {
-        UserFilter filter = new UserFilter().withQuery("sample");
+        UserFilter filter = new UserFilter().withQuery("email:\\*@gmail.com");
         Request<UsersPage> request = api.users().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -116,7 +116,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
         assertThat(recordedRequest, hasQueryParameter("search_engine", "v2"));
-        assertThat(recordedRequest, hasQueryParameter("q", "sample"));
+        assertThat(recordedRequest, hasQueryParameter("q", "email%3A%5C*%40gmail.com"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(2));

--- a/src/test/java/com/auth0/client/mgmt/filter/LogEventFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/LogEventFilterTest.java
@@ -42,7 +42,7 @@ public class LogEventFilterTest {
 
         assertThat(filter, is(instance));
         assertThat(filter.getAsMap(), is(notNullValue()));
-        assertThat(filter.getAsMap(), Matchers.hasEntry("q", (Object) "id=log123"));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("q", (Object) "id%3Dlog123"));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/filter/QueryFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/QueryFilterTest.java
@@ -32,7 +32,7 @@ public class QueryFilterTest {
 
         assertThat(filter, is(instance));
         assertThat(filter.getAsMap(), is(notNullValue()));
-        assertThat(filter.getAsMap(), Matchers.hasEntry("q", (Object) "id=log123"));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("q", (Object) "id%3Dlog123"));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
@@ -38,7 +38,7 @@ public class UserFilterTest {
 
         assertThat(filter, is(instance));
         assertThat(filter.getAsMap(), is(notNullValue()));
-        assertThat(filter.getAsMap(), Matchers.hasEntry("q", (Object) "id=log123"));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("q", (Object) "id%3Dlog123"));
     }
 
     @Test


### PR DESCRIPTION
It seems that OkHttp it's not really URL encoding the query parameters, or that some chars are missing from that implementation, which affects both the `UsersEntity#list` and `LogsEntity#list` methods. This PR encodes the query value (and only that case) using `java.net.URLEncoder`. The client/entity later, only for that parameter, adds it to the request as a pre-encoded query parameter, in order to avoid OkHttp to encode again the `%` escaped chars.

Personally I don't like being checking in the `for` loop for a specific parameter name and adding it in a different way. Maybe it's better that the whole networking impl uses the `URLEncoder` first for all parameters and then adds them as "already encoded" to the request. Opinions?


Fixes https://github.com/auth0/auth0-java/issues/54