### PR TITLE
Add getter for User and ProfileData extra properties

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/users/ProfileData.java
+++ b/src/main/java/com/auth0/json/mgmt/users/ProfileData.java
@@ -1,8 +1,9 @@
 package com.auth0.json.mgmt.users;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -25,7 +26,11 @@ public class ProfileData {
     private Boolean phoneVerified;
     @JsonProperty("family_name")
     private String familyName;
+    private Map<String, Object> values;
 
+    public ProfileData() {
+        values = new HashMap<>();
+    }
 
     @JsonProperty("email")
     public String getEmail() {
@@ -65,5 +70,15 @@ public class ProfileData {
     @JsonProperty("family_name")
     public String getFamilyName() {
         return familyName;
+    }
+
+    @JsonAnySetter
+    void setValue(String key, Object value) {
+        values.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getValues() {
+        return values;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/users/User.java
+++ b/src/main/java/com/auth0/json/mgmt/users/User.java
@@ -3,6 +3,7 @@ package com.auth0.json.mgmt.users;
 import com.fasterxml.jackson.annotation.*;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,9 +72,15 @@ public class User {
     private Integer loginsCount;
     @JsonProperty("blocked")
     private Boolean blocked;
+    private Map<String, Object> values;
+
+    User() {
+        this(null);
+    }
 
     @JsonCreator
     public User(@JsonProperty("connection") String connection) {
+        this.values = new HashMap<>();
         this.connection = connection;
     }
 
@@ -508,5 +515,15 @@ public class User {
     @JsonProperty("connection")
     String getConnection() {
         return connection;
+    }
+
+    @JsonAnySetter
+    void setValue(String key, Object value) {
+        values.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getValues() {
+        return values;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/ProfileDataTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/ProfileDataTest.java
@@ -6,10 +6,11 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 public class ProfileDataTest extends JsonTest<ProfileData> {
 
-    private static final String json = "{\"email\":\"me@auth0.com\",\"email_verified\":true,\"name\":\"John\", \"username\":\"usr\", \"given_name\":\"John\", \"family_name\":\"Walker\", \"phone_number\":\"1234567890\", \"phone_verified\":true}";
+    private static final String json = "{\"email\":\"me@auth0.com\",\"email_verified\":true,\"name\":\"John\", \"username\":\"usr\", \"given_name\":\"John\", \"family_name\":\"Walker\", \"phone_number\":\"1234567890\", \"phone_verified\":true, \"description\":\"My description\"}";
 
     @Test
     public void shouldDeserialize() throws Exception {
@@ -24,5 +25,7 @@ public class ProfileDataTest extends JsonTest<ProfileData> {
         assertThat(data.getFamilyName(), is("Walker"));
         assertThat(data.getPhoneNumber(), is("1234567890"));
         assertThat(data.isPhoneVerified(), is(true));
+        assertThat(data.getValues(), is(notNullValue()));
+        assertThat(data.getValues(), hasEntry("description", (Object) "My description"));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -9,10 +9,11 @@ import java.util.Collections;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 public class UserTest extends JsonTest<User> {
 
-    private static final String json = "{\"connection\":\"auth0\",\"client_id\":\"client123\",\"password\":\"pwd\",\"verify_password\":true,\"username\":\"usr\",\"email\":\"me@auth0.com\",\"email_verified\":true,\"verify_email\":true,\"phone_number\":\"1234567890\",\"phone_verified\":true,\"verify_phone_number\":true,\"picture\":\"https://pic.ture/12\",\"name\":\"John\",\"nickname\":\"Johny\",\"given_name\":\"John\",\"family_name\":\"Walker\",\"app_metadata\":{},\"user_metadata\":{},\"blocked\":true}";
+    private static final String json = "{\"connection\":\"auth0\",\"client_id\":\"client123\",\"password\":\"pwd\",\"verify_password\":true,\"username\":\"usr\",\"email\":\"me@auth0.com\",\"email_verified\":true,\"verify_email\":true,\"phone_number\":\"1234567890\",\"phone_verified\":true,\"verify_phone_number\":true,\"picture\":\"https://pic.ture/12\",\"name\":\"John\",\"nickname\":\"Johny\",\"given_name\":\"John\",\"family_name\":\"Walker\",\"app_metadata\":{},\"user_metadata\":{},\"blocked\":true,\"context\":\"extra information\"}";
     private static final String readOnlyJson = "{\"user_id\":\"user|123\",\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[]}";
 
     @Test
@@ -85,6 +86,8 @@ public class UserTest extends JsonTest<User> {
         assertThat(user.getUserMetadata(), is(notNullValue()));
         assertThat(user.getAppMetadata(), is(notNullValue()));
         assertThat(user.isBlocked(), is(true));
+        assertThat(user.getValues(), is(notNullValue()));
+        assertThat(user.getValues(), hasEntry("context", (Object) "extra information"));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -17,6 +17,16 @@ public class UserTest extends JsonTest<User> {
     private static final String readOnlyJson = "{\"user_id\":\"user|123\",\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[]}";
 
     @Test
+    public void shouldHaveEmptyValuesByDefault() throws Exception{
+        User user = new User();
+        assertThat(user.getValues(), is(notNullValue()));
+
+        User user2 = new User("my-connection");
+        assertThat(user2.getConnection(), is("my-connection"));
+        assertThat(user2.getValues(), is(notNullValue()));
+    }
+
+    @Test
     public void shouldSerialize() throws Exception {
         User user = new User("auth0");
         user.setPassword("pwd");

--- a/src/test/resources/mgmt/user.json
+++ b/src/test/resources/mgmt/user.json
@@ -9,10 +9,27 @@
   "updated_at": "",
   "identities": [
     {
-      "connection": "Initial-Connection",
-      "user_id": "5457edea1b8f22891a000004",
-      "provider": "auth0",
-      "isSocial": false
+      "provider": "facebook",
+      "user_id": "5457edea1b8f2289",
+      "connection": "facebook",
+      "isSocial": true
+    },
+    {
+      "profileData": {
+        "name": "Auth0️",
+        "picture": "https://pbs.twimg.com/profile_images/auth0/5457ed_normal.jpg",
+        "created_at": "Fri May 20 17:13:23 +0000 2011",
+        "description": "My twitter bio",
+        "lang": "es",
+        "location": "Palermo, Buenos Aires.",
+        "screen_name": "auth0",
+        "time_zone": "Buenos Aires",
+        "utc_offset": -10800
+      },
+      "provider": "twitter",
+      "user_id": "5457ed",
+      "connection": "twitter",
+      "isSocial": true
     }
   ],
   "app_metadata": {},

--- a/src/test/resources/mgmt/users_list.json
+++ b/src/test/resources/mgmt/users_list.json
@@ -10,10 +10,27 @@
     "updated_at": "",
     "identities": [
       {
-        "connection": "Initial-Connection",
-        "user_id": "5457edea1b8f22891a000004",
-        "provider": "auth0",
-        "isSocial": false
+        "provider": "facebook",
+        "user_id": "5457edea1b8f2289",
+        "connection": "facebook",
+        "isSocial": true
+      },
+      {
+        "profileData": {
+          "name": "Auth0️",
+          "picture": "https://pbs.twimg.com/profile_images/auth0/5457ed_normal.jpg",
+          "created_at": "Fri May 20 17:13:23 +0000 2011",
+          "description": "My twitter bio",
+          "lang": "es",
+          "location": "Palermo, Buenos Aires.",
+          "screen_name": "auth0",
+          "time_zone": "Buenos Aires",
+          "utc_offset": -10800
+        },
+        "provider": "twitter",
+        "user_id": "5457ed",
+        "connection": "twitter",
+        "isSocial": true
       }
     ],
     "app_metadata": {},
@@ -40,10 +57,27 @@
     "updated_at": "",
     "identities": [
       {
-        "connection": "Initial-Connection",
-        "user_id": "5457edea1b8f22891a000004",
-        "provider": "auth0",
-        "isSocial": false
+        "provider": "facebook",
+        "user_id": "5457edea1b8f2289",
+        "connection": "facebook",
+        "isSocial": true
+      },
+      {
+        "profileData": {
+          "name": "Auth0️",
+          "picture": "https://pbs.twimg.com/profile_images/auth0/5457ed_normal.jpg",
+          "created_at": "Fri May 20 17:13:23 +0000 2011",
+          "description": "My twitter bio",
+          "lang": "es",
+          "location": "Palermo, Buenos Aires.",
+          "screen_name": "auth0",
+          "time_zone": "Buenos Aires",
+          "utc_offset": -10800
+        },
+        "provider": "twitter",
+        "user_id": "5457ed",
+        "connection": "twitter",
+        "isSocial": true
       }
     ],
     "app_metadata": {},

--- a/src/test/resources/mgmt/users_paged_list.json
+++ b/src/test/resources/mgmt/users_paged_list.json
@@ -15,10 +15,27 @@
       "updated_at": "",
       "identities": [
         {
-          "connection": "Initial-Connection",
-          "user_id": "5457edea1b8f22891a000004",
-          "provider": "auth0",
-          "isSocial": false
+          "provider": "facebook",
+          "user_id": "5457edea1b8f2289",
+          "connection": "facebook",
+          "isSocial": true
+        },
+        {
+          "profileData": {
+            "name": "Auth0️",
+            "picture": "https://pbs.twimg.com/profile_images/auth0/5457ed_normal.jpg",
+            "created_at": "Fri May 20 17:13:23 +0000 2011",
+            "description": "My twitter bio",
+            "lang": "es",
+            "location": "Palermo, Buenos Aires.",
+            "screen_name": "auth0",
+            "time_zone": "Buenos Aires",
+            "utc_offset": -10800
+          },
+          "provider": "twitter",
+          "user_id": "5457ed",
+          "connection": "twitter",
+          "isSocial": true
         }
       ],
       "app_metadata": {},
@@ -45,10 +62,27 @@
       "updated_at": "",
       "identities": [
         {
-          "connection": "Initial-Connection",
-          "user_id": "5457edea1b8f22891a000004",
-          "provider": "auth0",
-          "isSocial": false
+          "provider": "facebook",
+          "user_id": "5457edea1b8f2289",
+          "connection": "facebook",
+          "isSocial": true
+        },
+        {
+          "profileData": {
+            "name": "Auth0️",
+            "picture": "https://pbs.twimg.com/profile_images/auth0/5457ed_normal.jpg",
+            "created_at": "Fri May 20 17:13:23 +0000 2011",
+            "description": "My twitter bio",
+            "lang": "es",
+            "location": "Palermo, Buenos Aires.",
+            "screen_name": "auth0",
+            "time_zone": "Buenos Aires",
+            "utc_offset": -10800
+          },
+          "provider": "twitter",
+          "user_id": "5457ed",
+          "connection": "twitter",
+          "isSocial": true
         }
       ],
       "app_metadata": {},


### PR DESCRIPTION
When logging in with a social provider like Facebook, most of the profile properties go to the `user` root. Also when linking accounts, some of these properties end up inside `indentity.profileData`. This PR solves both by adding generic getters for all those values that are not already obtainable with a getter.
Related conversation in https://github.com/auth0/auth0-java/pull/45