### PR TITLE
Add public User constructor without parameters

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/users/User.java
+++ b/src/main/java/com/auth0/json/mgmt/users/User.java
@@ -74,7 +74,7 @@ public class User {
     private Boolean blocked;
     private Map<String, Object> values;
 
-    User() {
+    public User() {
         this(null);
     }
 


### PR DESCRIPTION
User **must have a connection** when they are first created, but then if you want to change a property you must set a connection again (which **cannot** be changed). Related: https://github.com/auth0/auth0-java/issues/58#issuecomment-307226536