### PR TITLE
Add support for provisioning_ticket_url property to Connection POJO

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/Connection.java
@@ -26,6 +26,8 @@ public class Connection {
     private String strategy;
     @JsonProperty("enabled_clients")
     private List<String> enabledClients = null;
+    @JsonProperty("provisioning_ticket_url")
+    private String provisioningTicketUrl;
 
     public Connection() {
     }
@@ -104,6 +106,16 @@ public class Connection {
     @JsonProperty("enabled_clients")
     public void setEnabledClients(List<String> enabledClients) {
         this.enabledClients = enabledClients;
+    }
+    
+    /**
+     * Getter for the ad/ldap connection's ticket url.
+     *
+     * @return the provisioning ticket url.
+     */
+    @JsonProperty("provisioning_ticket_url")
+    public String getProvisioningTicketUrl() {
+        return provisioningTicketUrl;
     }
 
 }

--- a/src/test/java/com/auth0/json/mgmt/ConnectionTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ConnectionTest.java
@@ -15,6 +15,8 @@ public class ConnectionTest extends JsonTest<Connection> {
     private static final String json = "{\"name\":\"my-connection\",\"strategy\":\"auth0\",\"options\":{},\"enabled_clients\":[\"client1\",\"client2\"]}";
     private static final String readOnlyJson = "{\"id\":\"connectionId\"}";
 
+    private static final String jsonAd = "{\"name\":\"my-ad-connection\",\"strategy\":\"ad\",\"provisioning_ticket_url\":\"https://demo.auth0.com/p/ad/ddQTRlVt\",\"options\":{},\"enabled_clients\":[\"client1\",\"client2\"]}";
+
     @Test
     public void shouldSerialize() throws Exception {
         Connection connection = new Connection("my-connection", "auth0");
@@ -27,6 +29,7 @@ public class ConnectionTest extends JsonTest<Connection> {
         assertThat(serialized, JsonMatcher.hasEntry("strategy", "auth0"));
         assertThat(serialized, JsonMatcher.hasEntry("options", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("enabled_clients", Arrays.asList("client1", "client2")));
+        assertThat(serialized, JsonMatcher.hasEntry("provisioning_ticket_url", null));
     }
 
     @Test
@@ -38,6 +41,19 @@ public class ConnectionTest extends JsonTest<Connection> {
         assertThat(connection.getOptions(), is(notNullValue()));
         assertThat(connection.getStrategy(), is("auth0"));
         assertThat(connection.getEnabledClients(), contains("client1", "client2"));
+        assertThat(connection.getProvisioningTicketUrl(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldDeserializeAd() throws Exception {
+        Connection connection = fromJSON(jsonAd, Connection.class);
+
+        assertThat(connection, is(notNullValue()));
+        assertThat(connection.getName(), is("my-ad-connection"));
+        assertThat(connection.getOptions(), is(notNullValue()));
+        assertThat(connection.getStrategy(), is("ad"));
+        assertThat(connection.getEnabledClients(), contains("client1", "client2"));
+        assertThat(connection.getProvisioningTicketUrl(), is("https://demo.auth0.com/p/ad/ddQTRlVt"));
     }
 
     @Test


### PR DESCRIPTION
Create a string property for the pojo to support provisioning_ticket_url json property of the management api v2.
To be linked to this issue: https://github.com/auth0/auth0-java/issues/66