### PR TITLE
removed unmotivated throwing of UnsupportedEncodingException

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/filter/LogEventFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/LogEventFilter.java
@@ -1,7 +1,5 @@
 package com.auth0.client.mgmt.filter;
 
-import java.io.UnsupportedEncodingException;
-
 /**
  * Class used to filter the results received when calling the Logs endpoint. Related to the {@link com.auth0.client.mgmt.LogEventsEntity} entity.
  */
@@ -27,7 +25,7 @@ public class LogEventFilter extends QueryFilter {
     }
 
     @Override
-    public LogEventFilter withQuery(String query) throws UnsupportedEncodingException {
+    public LogEventFilter withQuery(String query) {
         super.withQuery(query);
         return this;
     }

--- a/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
@@ -13,10 +13,21 @@ public class QueryFilter extends FieldsFilter {
      * @param query the query expression using the following syntax https://auth0.com/docs/api/management/v2/query-string-syntax.
      * @return this filter instance
      */
-    public QueryFilter withQuery(String query) throws UnsupportedEncodingException {
-        String encodedQuery = URLEncoder.encode(query, "UTF-8");
-        parameters.put(KEY_QUERY, encodedQuery);
-        return this;
+    public QueryFilter withQuery(String query) {
+        try {
+            String encodedQuery = urlEncode(query);
+            parameters.put(KEY_QUERY, encodedQuery);
+            return this;
+        } catch (UnsupportedEncodingException ex) {
+            //"Every implementation of the Java platform is required to support the following standard charsets [...]: UTF-8"
+            //cf. https://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html
+            throw new IllegalStateException("UTF-8 encoding not supported by current Java platform implementation.", ex);
+        }
+        
+    }
+
+    String urlEncode(String query) throws UnsupportedEncodingException {
+        return URLEncoder.encode(query, "UTF-8");
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
@@ -23,11 +23,6 @@ public class QueryFilter extends FieldsFilter {
             //cf. https://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html
             throw new IllegalStateException("UTF-8 encoding not supported by current Java platform implementation.", ex);
         }
-        
-    }
-
-    String urlEncode(String query) throws UnsupportedEncodingException {
-        return URLEncoder.encode(query, "UTF-8");
     }
 
     /**
@@ -69,6 +64,11 @@ public class QueryFilter extends FieldsFilter {
     public QueryFilter withFields(String fields, boolean includeFields) {
         super.withFields(fields, includeFields);
         return this;
+    }
+    
+    //Visible for testing
+    String urlEncode(String query) throws UnsupportedEncodingException {
+        return URLEncoder.encode(query, "UTF-8");
     }
 
 }

--- a/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
@@ -1,7 +1,5 @@
 package com.auth0.client.mgmt.filter;
 
-import java.io.UnsupportedEncodingException;
-
 /**
  * Class used to filter the results received when calling the Users endpoint. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
  */
@@ -21,7 +19,7 @@ public class UserFilter extends QueryFilter {
     }
 
     @Override
-    public UserFilter withQuery(String query) throws UnsupportedEncodingException {
+    public UserFilter withQuery(String query) {
         super.withQuery(query);
         return this;
     }

--- a/src/test/java/com/auth0/client/mgmt/filter/QueryFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/QueryFilterTest.java
@@ -6,9 +6,20 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import java.io.UnsupportedEncodingException;
+
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 public class QueryFilterTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     private QueryFilter filter;
 
@@ -73,4 +84,16 @@ public class QueryFilterTest {
         assertThat(filter.getAsMap(), Matchers.hasEntry("fields", (Object) "a,b,c"));
         assertThat(filter.getAsMap(), Matchers.hasEntry("include_fields", (Object) false));
     }
+
+    @Test
+    public void shouldThrowIllegalStateExceptionWhenUtf8IsNotSupported() throws Exception {
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("UTF-8 encoding not supported by current Java platform implementation.");
+        exception.expectCause(isA(UnsupportedEncodingException.class));
+        String value = "my test value";
+        QueryFilter filter = spy(new QueryFilter());
+        doThrow(UnsupportedEncodingException.class).when(filter).urlEncode(value);
+        filter.withQuery(value);
+    }
+
 }


### PR DESCRIPTION
With this small fix, the API is easier to use, since the consumer does not have to handle the UnsupportedEncodingException which is neither motivated nor documented in javadoc.
