### PR TITLE
Include a proper SignUp response

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ fields.put("city", "Buenos Aires");
 SignUpRequest request = auth.signUp("user@domain.com", "username", "password123", "Username-Password-Authentication")
     .setCustomFields(fields);
 try {
-    request.execute();
+    CreatedUser user = request.execute();
 } catch (APIException exception) {
     // api error
 } catch (Auth0Exception exception) {

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -244,7 +244,7 @@ public class AuthAPI {
     public SignUpRequest signUp(String email, String username, String password, String connection) {
         Asserts.assertNotNull(username, "username");
 
-        VoidRequest request = (VoidRequest) this.signUp(email, password, connection);
+        CreateUserRequest request = (CreateUserRequest) this.signUp(email, password, connection);
         request.addParameter(KEY_USERNAME, username);
         return request;
     }
@@ -284,7 +284,7 @@ public class AuthAPI {
                 .addPathSegment("signup")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, "POST");
+        CreateUserRequest request = new CreateUserRequest(client, url);
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_EMAIL, email);
         request.addParameter(KEY_PASSWORD, password);

--- a/src/main/java/com/auth0/json/auth/CreatedUser.java
+++ b/src/main/java/com/auth0/json/auth/CreatedUser.java
@@ -1,0 +1,44 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that holds the data of a newly created User. Obtained after a call to {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String)}
+ * or {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String, String)}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreatedUser {
+
+    @JsonProperty("_id")
+    private String userId;
+    @JsonProperty("email")
+    private String email;
+    @JsonProperty("username")
+    private String username;
+    @JsonProperty("email_verified")
+    private Boolean emailVerified;
+
+    @JsonProperty("_id")
+    public String getUserId() {
+        return userId;
+    }
+
+    @JsonProperty("email")
+    public String getEmail() {
+        return email;
+    }
+
+    @JsonProperty("username")
+    public String getUsername() {
+        return username;
+    }
+
+    @JsonProperty("email_verified")
+    public Boolean isEmailVerified() {
+        return emailVerified;
+    }
+
+}

--- a/src/main/java/com/auth0/json/auth/UserInfo.java
+++ b/src/main/java/com/auth0/json/auth/UserInfo.java
@@ -9,7 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Class that holds the Information related to a User's Access Token. Obtained after a call to {@link com.auth0.client.auth.AuthAPI#userInfo(String)}.
+ * Class that holds the Information related to a User's Access Token. Obtained after a call to {@link com.auth0.client.auth.AuthAPI#userInfo(String)},
+ * {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String)} or {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String, String)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/auth0/net/CreateUserRequest.java
+++ b/src/main/java/com/auth0/net/CreateUserRequest.java
@@ -1,0 +1,21 @@
+package com.auth0.net;
+
+import com.auth0.json.auth.UserInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.OkHttpClient;
+
+import java.util.Map;
+
+public class CreateUserRequest extends CustomRequest<UserInfo> implements SignUpRequest {
+
+    public CreateUserRequest(OkHttpClient client, String url) {
+        super(client, url, "POST", new TypeReference<UserInfo>() {
+        });
+    }
+
+    @Override
+    public SignUpRequest setCustomFields(Map<String, String> customFields) {
+        super.addParameter("user_metadata", customFields);
+        return this;
+    }
+}

--- a/src/main/java/com/auth0/net/CreateUserRequest.java
+++ b/src/main/java/com/auth0/net/CreateUserRequest.java
@@ -1,15 +1,15 @@
 package com.auth0.net;
 
-import com.auth0.json.auth.UserInfo;
+import com.auth0.json.auth.CreatedUser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 
 import java.util.Map;
 
-public class CreateUserRequest extends CustomRequest<UserInfo> implements SignUpRequest {
+public class CreateUserRequest extends CustomRequest<CreatedUser> implements SignUpRequest {
 
     public CreateUserRequest(OkHttpClient client, String url) {
-        super(client, url, "POST", new TypeReference<UserInfo>() {
+        super(client, url, "POST", new TypeReference<CreatedUser>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/SignUpRequest.java
+++ b/src/main/java/com/auth0/net/SignUpRequest.java
@@ -1,11 +1,14 @@
 package com.auth0.net;
 
+import com.auth0.json.auth.UserInfo;
+
 import java.util.Map;
 
 /**
  * Class that represents a Create User call.
  */
-public interface SignUpRequest extends Request<Void> {
+@SuppressWarnings("UnusedReturnValue")
+public interface SignUpRequest extends Request<UserInfo> {
 
     /**
      * Setter for the additional fields to set when creating a user.

--- a/src/main/java/com/auth0/net/SignUpRequest.java
+++ b/src/main/java/com/auth0/net/SignUpRequest.java
@@ -1,6 +1,6 @@
 package com.auth0.net;
 
-import com.auth0.json.auth.UserInfo;
+import com.auth0.json.auth.CreatedUser;
 
 import java.util.Map;
 
@@ -8,7 +8,7 @@ import java.util.Map;
  * Class that represents a Create User call.
  */
 @SuppressWarnings("UnusedReturnValue")
-public interface SignUpRequest extends Request<UserInfo> {
+public interface SignUpRequest extends Request<CreatedUser> {
 
     /**
      * Setter for the additional fields to set when creating a user.

--- a/src/main/java/com/auth0/net/VoidRequest.java
+++ b/src/main/java/com/auth0/net/VoidRequest.java
@@ -7,7 +7,7 @@ import okhttp3.Response;
 
 import java.util.Map;
 
-public class VoidRequest extends CustomRequest<Void> implements SignUpRequest {
+public class VoidRequest extends CustomRequest<Void> {
 
     public VoidRequest(OkHttpClient client, String url, String method) {
         super(client, url, method, new TypeReference<Void>() {
@@ -20,11 +20,5 @@ public class VoidRequest extends CustomRequest<Void> implements SignUpRequest {
             throw super.createResponseException(response);
         }
         return null;
-    }
-
-    @Override
-    public VoidRequest setCustomFields(Map<String, String> customFields) {
-        super.addParameter("user_metadata", customFields);
-        return this;
     }
 }

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -18,6 +18,7 @@ public class MockServer {
     public static final String AUTH_USER_INFO = "src/test/resources/auth/user_info.json";
     public static final String AUTH_RESET_PASSWORD = "src/test/resources/auth/reset_password.json";
     public static final String AUTH_SIGN_UP = "src/test/resources/auth/sign_up.json";
+    public static final String AUTH_SIGN_UP_USERNAME = "src/test/resources/auth/sign_up_username.json";
     public static final String AUTH_TOKENS = "src/test/resources/auth/tokens.json";
     public static final String AUTH_ERROR_WITH_ERROR_DESCRIPTION = "src/test/resources/auth/error_with_error_description.json";
     public static final String AUTH_ERROR_WITH_ERROR = "src/test/resources/auth/error_with_error.json";

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1,6 +1,7 @@
 package com.auth0.client.auth;
 
 import com.auth0.client.MockServer;
+import com.auth0.json.auth.CreatedUser;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.json.auth.UserInfo;
 import com.auth0.net.AuthRequest;
@@ -384,7 +385,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_SIGN_UP_USERNAME, 200);
-        UserInfo response = request.execute();
+        CreatedUser response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -398,11 +399,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("client_id", (Object) CLIENT_ID));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getValues(), hasKey("_id"));
-        assertThat((String) response.getValues().get("_id"), not(isEmptyOrNullString()));
-        assertThat(response.getValues(), hasEntry("email", (Object) "me@auth0.com"));
-        assertThat(response.getValues(), hasEntry("email_verified", (Object) false));
-        assertThat(response.getValues(), hasEntry("username", (Object) "me"));
+        assertThat(response.getUserId(), is("58457fe6b27"));
+        assertThat(response.getEmail(), is("me@auth0.com"));
+        assertThat(response.isEmailVerified(), is(false));
+        assertThat(response.getUsername(), is("me"));
     }
 
     @Test
@@ -411,7 +411,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        UserInfo response = request.execute();
+        CreatedUser response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -425,11 +425,10 @@ public class AuthAPITest {
         assertThat(body, not(hasKey("username")));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getValues(), hasKey("_id"));
-        assertThat((String) response.getValues().get("_id"), not(isEmptyOrNullString()));
-        assertThat(response.getValues(), hasEntry("email", (Object) "me@auth0.com"));
-        assertThat(response.getValues(), hasEntry("email_verified", (Object) false));
-        assertThat(response.getValues(), not(hasKey("username")));
+        assertThat(response.getUserId(), is("58457fe6b27"));
+        assertThat(response.getEmail(), is("me@auth0.com"));
+        assertThat(response.isEmailVerified(), is(false));
+        assertThat(response.getUsername(), is(nullValue()));
     }
 
     @Test
@@ -442,7 +441,7 @@ public class AuthAPITest {
         request.setCustomFields(customFields);
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        UserInfo response = request.execute();
+        CreatedUser response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -460,11 +459,10 @@ public class AuthAPITest {
         assertThat(body, not(hasKey("username")));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getValues(), hasEntry("email", (Object) "me@auth0.com"));
-        assertThat(response.getValues(), hasEntry("email_verified", (Object) false));
-        assertThat(response.getValues(), hasKey("_id"));
-        assertThat((String) response.getValues().get("_id"), not(isEmptyOrNullString()));
-        assertThat(response.getValues(), not(hasKey("username")));
+        assertThat(response.getUserId(), is("58457fe6b27"));
+        assertThat(response.getEmail(), is("me@auth0.com"));
+        assertThat(response.isEmailVerified(), is(false));
+        assertThat(response.getUsername(), is(nullValue()));
     }
 
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -383,8 +383,8 @@ public class AuthAPITest {
         SignUpRequest request = api.signUp("me@auth0.com", "me", "p455w0rd", "db-connection");
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(AUTH_SIGN_UP, 200);
-        Void response = request.execute();
+        server.jsonResponse(AUTH_SIGN_UP_USERNAME, 200);
+        UserInfo response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -397,7 +397,12 @@ public class AuthAPITest {
         assertThat(body, hasEntry("connection", (Object) "db-connection"));
         assertThat(body, hasEntry("client_id", (Object) CLIENT_ID));
 
-        assertThat(response, is(nullValue()));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getValues(), hasKey("_id"));
+        assertThat((String) response.getValues().get("_id"), not(isEmptyOrNullString()));
+        assertThat(response.getValues(), hasEntry("email", (Object) "me@auth0.com"));
+        assertThat(response.getValues(), hasEntry("email_verified", (Object) false));
+        assertThat(response.getValues(), hasEntry("username", (Object) "me"));
     }
 
     @Test
@@ -406,7 +411,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        Void response = request.execute();
+        UserInfo response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -419,7 +424,12 @@ public class AuthAPITest {
         assertThat(body, hasEntry("client_id", (Object) CLIENT_ID));
         assertThat(body, not(hasKey("username")));
 
-        assertThat(response, is(nullValue()));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getValues(), hasKey("_id"));
+        assertThat((String) response.getValues().get("_id"), not(isEmptyOrNullString()));
+        assertThat(response.getValues(), hasEntry("email", (Object) "me@auth0.com"));
+        assertThat(response.getValues(), hasEntry("email_verified", (Object) false));
+        assertThat(response.getValues(), not(hasKey("username")));
     }
 
     @Test
@@ -432,7 +442,7 @@ public class AuthAPITest {
         request.setCustomFields(customFields);
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        Void response = request.execute();
+        UserInfo response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -449,7 +459,12 @@ public class AuthAPITest {
         assertThat(metadata, hasEntry("address", "123, fake street"));
         assertThat(body, not(hasKey("username")));
 
-        assertThat(response, is(nullValue()));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getValues(), hasEntry("email", (Object) "me@auth0.com"));
+        assertThat(response.getValues(), hasEntry("email_verified", (Object) false));
+        assertThat(response.getValues(), hasKey("_id"));
+        assertThat((String) response.getValues().get("_id"), not(isEmptyOrNullString()));
+        assertThat(response.getValues(), not(hasKey("username")));
     }
 
 

--- a/src/test/java/com/auth0/net/CreateUserRequestTest.java
+++ b/src/test/java/com/auth0/net/CreateUserRequestTest.java
@@ -1,7 +1,7 @@
 package com.auth0.net;
 
 import com.auth0.client.MockServer;
-import com.auth0.json.auth.UserInfo;
+import com.auth0.json.auth.CreatedUser;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
@@ -32,7 +32,7 @@ public class CreateUserRequestTest {
         request.addParameter("non_empty", "body");
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        UserInfo execute = request.execute();
+        CreatedUser execute = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(execute, is(notNullValue()));

--- a/src/test/java/com/auth0/net/CreateUserRequestTest.java
+++ b/src/test/java/com/auth0/net/CreateUserRequestTest.java
@@ -1,0 +1,63 @@
+package com.auth0.net;
+
+import com.auth0.client.MockServer;
+import com.auth0.json.auth.UserInfo;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.auth0.client.MockServer.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class CreateUserRequestTest {
+
+    private OkHttpClient client;
+    private MockServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new OkHttpClient();
+        server = new MockServer();
+    }
+
+    @Test
+    public void shouldCreatePOSTRequest() throws Exception {
+        CreateUserRequest request = new CreateUserRequest(client, server.getBaseUrl());
+        assertThat(request, is(notNullValue()));
+        request.addParameter("non_empty", "body");
+
+        server.jsonResponse(AUTH_SIGN_UP, 200);
+        UserInfo execute = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(execute, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldSetSignUpCustomFields() throws Exception {
+        CreateUserRequest request = new CreateUserRequest(client, server.getBaseUrl());
+        assertThat(request, is(notNullValue()));
+        Map<String, String> customFields = new HashMap<>();
+        customFields.put("name", "john");
+        customFields.put("age", "25");
+        request.setCustomFields(customFields);
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        Map<String, Object> values = bodyFromRequest(recordedRequest);
+        assertThat(values, is(notNullValue()));
+        assertThat(values, hasKey("user_metadata"));
+        Map<String, String> fields = (Map<String, String>) values.get("user_metadata");
+        assertThat(fields, hasEntry("name", "john"));
+        assertThat(fields, hasEntry("age", "25"));
+    }
+
+
+}

--- a/src/test/java/com/auth0/net/VoidRequestTest.java
+++ b/src/test/java/com/auth0/net/VoidRequestTest.java
@@ -6,11 +6,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.auth0.client.MockServer.AUTH_TOKENS;
-import static com.auth0.client.MockServer.bodyFromRequest;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
@@ -47,27 +43,6 @@ public class VoidRequestTest {
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(execute, is(nullValue()));
-    }
-
-    @Test
-    public void shouldSetSignUpCustomFields() throws Exception {
-        VoidRequest request = new VoidRequest(client, server.getBaseUrl(), "POST");
-        assertThat(request, is(notNullValue()));
-        Map<String, String> customFields = new HashMap<>();
-        customFields.put("name", "john");
-        customFields.put("age", "25");
-        request.setCustomFields(customFields);
-
-        server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        Map<String, Object> values = bodyFromRequest(recordedRequest);
-        assertThat(values, is(notNullValue()));
-        assertThat(values, hasKey("user_metadata"));
-        Map<String, String> fields = (Map<String, String>) values.get("user_metadata");
-        assertThat(fields, hasEntry("name", "john"));
-        assertThat(fields, hasEntry("age", "25"));
     }
 
 }

--- a/src/test/resources/auth/sign_up.json
+++ b/src/test/resources/auth/sign_up.json
@@ -1,5 +1,5 @@
 {
-  "_id": "58457fe6b27...",
+  "_id": "58457fe6b27",
   "email_verified": false,
   "email": "me@auth0.com"
 }

--- a/src/test/resources/auth/sign_up_username.json
+++ b/src/test/resources/auth/sign_up_username.json
@@ -1,5 +1,6 @@
 {
   "_id": "58457fe6b27...",
   "email_verified": false,
-  "email": "me@auth0.com"
+  "email": "me@auth0.com",
+  "username": "me"
 }

--- a/src/test/resources/auth/sign_up_username.json
+++ b/src/test/resources/auth/sign_up_username.json
@@ -1,5 +1,5 @@
 {
-  "_id": "58457fe6b27...",
+  "_id": "58457fe6b27",
   "email_verified": false,
   "email": "me@auth0.com",
   "username": "me"


### PR DESCRIPTION
To the reviewer:
- Name of the `SignUpRequest` interface's implementation class. I used `CreateUserRequest`. User's will receive an instance with the interface name instead (as that's what the method signature defines), but because all the request classes are public scoped I'd like to leave this well. To be honest I could just name it "SignUpRequestImpl".
- Type of signup response. I'm using the one from the /userinfo endpoint, which it's just a generic `Map<String, Object>` holder with a getter for "all values". The alternative is to create a new class with the 4 parameters returned by the signup endpoint.
- Evaluate the impact of this PR as a breaking change. Because the method was returning a wrong object I would consider this as a fix and break it anyway. But the fix included even more changes on other classes than I thought at first.

Should close https://github.com/auth0/auth0-java/issues/86