### PR TITLE
Close ResponseBody buffer after read

### DIFF
--- a/src/main/java/com/auth0/net/VoidRequest.java
+++ b/src/main/java/com/auth0/net/VoidRequest.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 
-import java.util.Map;
-
 public class VoidRequest extends CustomRequest<Void> {
 
     public VoidRequest(OkHttpClient client, String url, String method) {
@@ -19,6 +17,7 @@ public class VoidRequest extends CustomRequest<Void> {
         if (!response.isSuccessful()) {
             throw super.createResponseException(response);
         }
+        response.close();
         return null;
     }
 }


### PR DESCRIPTION
Wish I could test this in an easy way but that would require extending OkHttp classes to store the "closed" state. 
Will fix https://github.com/auth0/auth0-java/issues/100