### PR TITLE
Add email-templates endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ The Management API is divided into different entities. Each of them have the lis
 * **User Blocks:** See [Docs](https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks). Access the methods by calling `mgmt.userBlocks()`.
 * **Users:** See [this](https://auth0.com/docs/api/management/v2#!/Users/get_users) and [this](https://auth0.com/docs/api/management/v2#!/Users_By_Email) doc. Access the methods by calling `mgmt.users()`.
 * **Blacklists:** See [Docs](https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens). Access the methods by calling `mgmt.blacklists()`.
-* **Emails:** See [Docs](https://auth0.com/docs/api/management/v2#!/Emails/get_provider). Access the methods by calling `mgmt.emailProvider()`.
+* **Email Providers:** See [Docs](https://auth0.com/docs/api/management/v2#!/Emails/get_provider). Access the methods by calling `mgmt.emailProvider()`.
+* **Email Templates:** See [Docs](https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName). Access the methods by calling `mgmt.emailTemplates()`.
 * **Guardian:** See [Docs](https://auth0.com/docs/api/management/v2#!/Guardian/get_factors). Access the methods by calling `mgmt.guardian()`.
 * **Stats:** See [Docs](https://auth0.com/docs/api/management/v2#!/Stats/get_active_users). Access the methods by calling `mgmt.stats()`.
 * **Tenants:** See [Docs](https://auth0.com/docs/api/management/v2#!/Tenants/get_settings). Access the methods by calling `mgmt.tenants()`.

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -74,30 +74,6 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
      * Patches the existing Email Template. A token with scope update:email_templates is needed.
      * See https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
      *
-     * @param templateName the name of the template to patch. You can use any of the constants defined in {@link EmailTemplatesEntity}
-     * @param template     the email template data to set.
-     * @return a Request to execute.
-     */
-    public Request<EmailTemplate> patch(String templateName, EmailTemplate template) {
-        Asserts.assertNotNull(templateName, "template name");
-        Asserts.assertNotNull(template, "template");
-
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/email-templates")
-                .build()
-                .toString();
-        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, "PATCH", new TypeReference<EmailTemplate>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        request.setBody(template);
-        return request;
-    }
-
-    /**
-     * Update the existing Email Template. A token with scope update:email_templates is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Email_Templates/put_email_templates_by_templateName
-     *
      * @param templateName the name of the template to update. You can use any of the constants defined in {@link EmailTemplatesEntity}
      * @param template     the email template data to set.
      * @return a Request to execute.
@@ -109,9 +85,10 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
         String url = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/email-templates")
+                .addPathSegment(templateName)
                 .build()
                 .toString();
-        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, "PUT", new TypeReference<EmailTemplate>() {
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, "PATCH", new TypeReference<EmailTemplate>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(template);

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -1,0 +1,120 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.json.mgmt.EmailTemplate;
+import com.auth0.net.CustomRequest;
+import com.auth0.net.Request;
+import com.auth0.utils.Asserts;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+
+/**
+ * Class that provides an implementation of the Email Templates methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Email_Templates
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class EmailTemplatesEntity extends BaseManagementEntity {
+
+    public static final String TEMPLATE_VERIFY_EMAIL = "verify_email";
+    public static final String TEMPLATE_RESET_EMAIL = "reset_email";
+    public static final String TEMPLATE_WELCOME_EMAIL = "welcome_email";
+    public static final String TEMPLATE_BLOCKED_ACCOUNT = "blocked_account";
+    public static final String TEMPLATE_STOLEN_CREDENTIALS = "stolen_credentials";
+    public static final String TEMPLATE_ENROLLMENT_EMAIL = "enrollment_email";
+    public static final String TEMPLATE_CHANGE_PASSWORD = "change_password";
+    public static final String TEMPLATE_PASSWORD_RESET = "password_reset";
+    public static final String TEMPLATE_MFA_OOB_CODE = "mfa_oob_code";
+
+    EmailTemplatesEntity(OkHttpClient client, HttpUrl baseUrl, String apiToken) {
+        super(client, baseUrl, apiToken);
+    }
+
+    /**
+     * Request the Email Templates. A token with scope read:email_templates is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName
+     *
+     * @param templateName the template name to request. You can use any of the constants defined in {@link EmailTemplatesEntity}
+     * @return a Request to execute.
+     */
+    public Request<EmailTemplate> get(String templateName) {
+        Asserts.assertNotNull(templateName, "template name");
+        HttpUrl.Builder builder = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/email-templates")
+                .addPathSegment(templateName);
+        String url = builder.build().toString();
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(client, url, "GET", new TypeReference<EmailTemplate>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Create a Rule. A token with scope create:rules is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Rules/post_rules
+     *
+     * @param template the template data to set
+     * @return a Request to execute.
+     */
+    public Request<EmailTemplate> create(EmailTemplate template) {
+        Asserts.assertNotNull(template, "template");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/email-templates")
+                .build()
+                .toString();
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, "POST", new TypeReference<EmailTemplate>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(template);
+        return request;
+    }
+
+    /**
+     * Patches the existing Email Template. A token with scope update:email_templates is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
+     *
+     * @param templateName the name of the template to patch. You can use any of the constants defined in {@link EmailTemplatesEntity}
+     * @param template     the email template data to set.
+     * @return a Request to execute.
+     */
+    public Request<EmailTemplate> patch(String templateName, EmailTemplate template) {
+        Asserts.assertNotNull(templateName, "template name");
+        Asserts.assertNotNull(template, "template");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/email-templates")
+                .build()
+                .toString();
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, "PATCH", new TypeReference<EmailTemplate>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(template);
+        return request;
+    }
+
+    /**
+     * Update the existing Email Template. A token with scope update:email_templates is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Email_Templates/put_email_templates_by_templateName
+     *
+     * @param templateName the name of the template to update. You can use any of the constants defined in {@link EmailTemplatesEntity}
+     * @param template     the email template data to set.
+     * @return a Request to execute.
+     */
+    public Request<EmailTemplate> update(String templateName, EmailTemplate template) {
+        Asserts.assertNotNull(templateName, "template name");
+        Asserts.assertNotNull(template, "template");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/email-templates")
+                .build()
+                .toString();
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, "PUT", new TypeReference<EmailTemplate>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(template);
+        return request;
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -49,8 +49,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
     }
 
     /**
-     * Create a Rule. A token with scope create:rules is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Rules/post_rules
+     * Create an Email Template. A token with scope create:email_templates is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Email_Templates/post_email_templates
      *
      * @param template the template data to set
      * @return a Request to execute.

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -170,6 +170,15 @@ public class ManagementAPI {
     }
 
     /**
+     * Getter for the Email Templates entity.
+     *
+     * @return the Email Templates entity.
+     */
+    public EmailTemplatesEntity emailTemplates() {
+        return new EmailTemplatesEntity(client, baseUrl, apiToken);
+    }
+
+    /**
      * Getter for the Email Provider entity.
      *
      * @return the Email Provider entity.
@@ -219,7 +228,7 @@ public class ManagementAPI {
      *
      * @return the Resource Servers entity.
      */
-    public ResourceServerEntity resourceServers(){
+    public ResourceServerEntity resourceServers() {
         return new ResourceServerEntity(client, baseUrl, apiToken);
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
@@ -1,77 +1,189 @@
 package com.auth0.json.mgmt;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents an Auth0 Guardian Factor object. Related to the {@link com.auth0.client.mgmt.GuardianEntity} entity.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class EmailTemplate {
 
-    private String template;
+    @JsonProperty("template")
+    private String name;
+    @JsonProperty("body")
     private String body;
+    @JsonProperty("from")
     private String from;
+    @JsonProperty("resultUrl")
     private String resultUrl;
+    @JsonProperty("subject")
     private String subject;
+    @JsonProperty("syntax")
     private String syntax;
-    private int urlLifetimeInSeconds;
-    private boolean enabled;
+    @JsonProperty("urlLifetimeInSeconds")
+    private Integer urlLifetimeInSeconds;
+    @JsonProperty("enabled")
+    private Boolean enabled;
 
-    public String getTemplate() {
-        return template;
+    /**
+     * Getter for the name of the template.
+     *
+     * @return the name.
+     */
+    @JsonProperty("template")
+    public String getName() {
+        return name;
     }
 
-    public void setTemplate(String template) {
-        this.template = template;
+    /**
+     * Sets the name of the template.
+     */
+    @JsonProperty("template")
+    public void setName(String name) {
+        this.name = name;
     }
 
+    /**
+     * Getter for the template code.
+     *
+     * @return the template code.
+     */
+    @JsonProperty("body")
     public String getBody() {
         return body;
     }
 
+    /**
+     * Sets the template code
+     *
+     * @param body the code this template will have
+     */
+    @JsonProperty("body")
     public void setBody(String body) {
         this.body = body;
     }
 
+    /**
+     * Getter for the sender of the email
+     *
+     * @return the sender of the email
+     */
+    @JsonProperty("from")
     public String getFrom() {
         return from;
     }
 
+    /**
+     * Sets the sender of the email
+     *
+     * @param from the sender of the email
+     */
+    @JsonProperty("from")
     public void setFrom(String from) {
         this.from = from;
     }
 
+    /**
+     * Getter the URL to redirect the user to after a successful action.
+     *
+     * @return the URL to redirect the user to after a successful action.
+     */
+    @JsonProperty("resultUrl")
     public String getResultUrl() {
         return resultUrl;
     }
 
+    /**
+     * Sets the URL to redirect the user to after a successful action.
+     *
+     * @param resultUrl the URL to redirect the user to after a successful action.
+     */
+    @JsonProperty("resultUrl")
     public void setResultUrl(String resultUrl) {
         this.resultUrl = resultUrl;
     }
 
+    /**
+     * Getter for the subject of the email.
+     *
+     * @return the subject of the email.
+     */
+    @JsonProperty("subject")
     public String getSubject() {
         return subject;
     }
 
+    /**
+     * Sets the subject of the email.
+     *
+     * @param subject the subject of the email.
+     */
+    @JsonProperty("subject")
     public void setSubject(String subject) {
         this.subject = subject;
     }
 
+    /**
+     * Getter for the syntax used in the template's code.
+     *
+     * @return the syntax used in the template's code.
+     */
+    @JsonProperty("syntax")
     public String getSyntax() {
         return syntax;
     }
 
+    /**
+     * Sets for the syntax to be used in the template's code.
+     *
+     * @param syntax the syntax to be used in the template's code.
+     */
+    @JsonProperty("syntax")
     public void setSyntax(String syntax) {
         this.syntax = syntax;
     }
 
-    public int getUrlLifetimeInSeconds() {
+    /**
+     * Getter for the lifetime in seconds that the link within the email will be valid for.
+     *
+     * @return the lifetime in seconds that the link within the email will be valid for.
+     */
+    @JsonProperty("urlLifetimeInSeconds")
+    public Integer getUrlLifetimeInSeconds() {
         return urlLifetimeInSeconds;
     }
 
-    public void setUrlLifetimeInSeconds(int urlLifetimeInSeconds) {
+    /**
+     * Sets the lifetime in seconds that the link within the email will be valid for.
+     *
+     * @param urlLifetimeInSeconds the lifetime in seconds that the link within the email will be valid for.
+     */
+    @JsonProperty("urlLifetimeInSeconds")
+    public void setUrlLifetimeInSeconds(Integer urlLifetimeInSeconds) {
         this.urlLifetimeInSeconds = urlLifetimeInSeconds;
     }
 
-    public boolean isEnabled() {
+    /**
+     * Whether or not this template is enabled.
+     *
+     * @return true if this template is enabled, false otherwise.
+     */
+    @JsonProperty("enabled")
+    public Boolean isEnabled() {
         return enabled;
     }
 
-    public void setEnabled(boolean enabled) {
+    /**
+     * Enables or disables this template.
+     *
+     * @param enabled whether this template is enabled or not.
+     */
+    @JsonProperty("enabled")
+    public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
     }
 

--- a/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
@@ -1,0 +1,78 @@
+package com.auth0.json.mgmt;
+
+public class EmailTemplate {
+
+    private String template;
+    private String body;
+    private String from;
+    private String resultUrl;
+    private String subject;
+    private String syntax;
+    private int urlLifetimeInSeconds;
+    private boolean enabled;
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(String template) {
+        this.template = template;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getResultUrl() {
+        return resultUrl;
+    }
+
+    public void setResultUrl(String resultUrl) {
+        this.resultUrl = resultUrl;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void setSyntax(String syntax) {
+        this.syntax = syntax;
+    }
+
+    public int getUrlLifetimeInSeconds() {
+        return urlLifetimeInSeconds;
+    }
+
+    public void setUrlLifetimeInSeconds(int urlLifetimeInSeconds) {
+        this.urlLifetimeInSeconds = urlLifetimeInSeconds;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
@@ -29,6 +29,11 @@ public class EmailTemplate {
     @JsonProperty("enabled")
     private Boolean enabled;
 
+    public EmailTemplate() {
+        //Only here to set the syntax default value
+        this.syntax = "liquid";
+    }
+
     /**
      * Getter for the name of the template.
      *
@@ -139,6 +144,7 @@ public class EmailTemplate {
 
     /**
      * Sets for the syntax to be used in the template's code.
+     * Default value is 'liquid'
      *
      * @param syntax the syntax to be used in the template's code.
      */

--- a/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Class that represents an Auth0 Guardian Factor object. Related to the {@link com.auth0.client.mgmt.GuardianEntity} entity.
+ * Class that represents an Email Template object. Related to the {@link com.auth0.client.mgmt.EmailTemplatesEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -45,6 +45,7 @@ public class MockServer {
     public static final String MGMT_USER_BLOCKS = "src/test/resources/mgmt/user_blocks.json";
     public static final String MGMT_BLACKLISTED_TOKENS_LIST = "src/test/resources/mgmt/blacklisted_tokens_list.json";
     public static final String MGMT_EMAIL_PROVIDER = "src/test/resources/mgmt/email_provider.json";
+    public static final String MGMT_EMAIL_TEMPLATE = "src/test/resources/mgmt/email_template.json";
     public static final String MGMT_USERS_LIST = "src/test/resources/mgmt/users_list.json";
     public static final String MGMT_USERS_PAGED_LIST = "src/test/resources/mgmt/users_paged_list.json";
     public static final String MGMT_USER = "src/test/resources/mgmt/user.json";

--- a/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
@@ -1,0 +1,127 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.json.mgmt.EmailTemplate;
+import com.auth0.net.Request;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.auth0.client.MockServer.*;
+import static com.auth0.client.RecordedRequestMatcher.hasHeader;
+import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+@SuppressWarnings("RedundantThrows")
+public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {
+    @Test
+    public void shouldGetEmailTemplate() throws Exception {
+        Request<EmailTemplate> request = api.emailTemplates().get("welcome_email");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_EMAIL_TEMPLATE, 200);
+        EmailTemplate response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/email-templates/welcome_email"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnGetEmailTemplateWithNullName() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'template name' cannot be null!");
+        api.emailTemplates().get(null);
+    }
+
+    @Test
+    public void shouldCreateEmailTemplate() throws Exception {
+        EmailTemplate template = new EmailTemplate();
+        template.setName("welcome_email");
+        template.setBody("Welcome!!");
+        template.setFrom("auth0.com");
+        template.setSubject("Welcome");
+        template.setSyntax("liquid");
+        template.setEnabled(true);
+
+        Request<EmailTemplate> request = api.emailTemplates().create(template);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
+        EmailTemplate response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/email-templates"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(6));
+        assertThat(body, hasEntry("template", (Object) "welcome_email"));
+        assertThat(body, hasEntry("body", (Object) "Welcome!!"));
+        assertThat(body, hasEntry("from", (Object) "auth0.com"));
+        assertThat(body, hasEntry("syntax", (Object) "liquid"));
+        assertThat(body, hasEntry("subject", (Object) "Welcome"));
+        assertThat(body, hasEntry("enabled", (Object) true));
+        assertThat(body, not(hasKey("resultUrl")));
+        assertThat(body, not(hasKey("urlLifetimeInSeconds")));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnCreateEmailTemplateWithNullData() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'template' cannot be null!");
+        api.emailTemplates().create(null);
+    }
+
+    @Test
+    public void shouldPatchEmailTemplate() throws Exception {
+        EmailTemplate template = new EmailTemplate();
+        template.setBody("<html>New</html>");
+        template.setUrlLifetimeInSeconds(123);
+        template.setResultUrl("https://somewhere.com");
+
+        Request<EmailTemplate> request = api.emailTemplates().update("welcome_email", template);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
+        EmailTemplate response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/email-templates/welcome_email"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(3));
+        assertThat(body, hasEntry("resultUrl", (Object) "https://somewhere.com"));
+        assertThat(body, hasEntry("body", (Object) "<html>New</html>"));
+        assertThat(body, hasEntry("urlLifetimeInSeconds", (Object) 123));
+        assertThat(body, not(hasKey("template")));
+        assertThat(body, not(hasKey("from")));
+        assertThat(body, not(hasKey("syntax")));
+        assertThat(body, not(hasKey("enabled")));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnPatchEmailTemplateWithNullData() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'template' cannot be null!");
+        api.emailTemplates().update("welcome_email", null);
+    }
+
+    @Test
+    public void shouldThrowOnPatchEmailTemplateWithNullName() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'template' cannot be null!");
+        api.emailTemplates().update(null, new EmailTemplate());
+    }
+}

--- a/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
@@ -99,13 +99,13 @@ public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body.size(), is(3));
+        assertThat(body.size(), is(4));
         assertThat(body, hasEntry("resultUrl", (Object) "https://somewhere.com"));
         assertThat(body, hasEntry("body", (Object) "<html>New</html>"));
+        assertThat(body, hasEntry("syntax", (Object) "liquid"));
         assertThat(body, hasEntry("urlLifetimeInSeconds", (Object) 123));
         assertThat(body, not(hasKey("template")));
         assertThat(body, not(hasKey("from")));
-        assertThat(body, not(hasKey("syntax")));
         assertThat(body, not(hasKey("enabled")));
 
         assertThat(response, is(notNullValue()));

--- a/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
@@ -121,7 +121,7 @@ public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldThrowOnPatchEmailTemplateWithNullName() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'template' cannot be null!");
+        exception.expectMessage("'template name' cannot be null!");
         api.emailTemplates().update(null, new EmailTemplate());
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/EmailTemplateTest.java
+++ b/src/test/java/com/auth0/json/mgmt/EmailTemplateTest.java
@@ -1,0 +1,57 @@
+package com.auth0.json.mgmt;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class EmailTemplateTest extends JsonTest<EmailTemplate> {
+
+    private static final String json = "{\"template\": \"welcome_email\", \"from\": \"you@auth0.com\", \"subject\": \"Some subject\", \"syntax\": \"liquid\", \"body\": \"<html> </html>\", \"enabled\": true}";
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        EmailTemplate template = new EmailTemplate();
+        template.setResultUrl("https://auth0.com");
+        template.setUrlLifetimeInSeconds(993311);
+        template.setBody("SOME HTML");
+        template.setEnabled(false);
+        template.setSyntax("html");
+        template.setSubject("Hello world");
+        template.setFrom("me@auth0.com");
+        template.setName("farewell");
+
+        String serialized = toJSON(template);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("resultUrl", "https://auth0.com"));
+        assertThat(serialized, JsonMatcher.hasEntry("urlLifetimeInSeconds", 993311));
+        assertThat(serialized, JsonMatcher.hasEntry("body", "SOME HTML"));
+        assertThat(serialized, JsonMatcher.hasEntry("enabled", false));
+        assertThat(serialized, JsonMatcher.hasEntry("syntax", "html"));
+        assertThat(serialized, JsonMatcher.hasEntry("subject", "Hello world"));
+        assertThat(serialized, JsonMatcher.hasEntry("from", "me@auth0.com"));
+        assertThat(serialized, JsonMatcher.hasEntry("template", "farewell"));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        EmailTemplate template = fromJSON(json, EmailTemplate.class);
+
+        assertThat(template, is(notNullValue()));
+        assertThat(template.getName(), is("welcome_email"));
+        assertThat(template.getFrom(), is("you@auth0.com"));
+        assertThat(template.getSubject(), is("Some subject"));
+        assertThat(template.getSyntax(), is("liquid"));
+        assertThat(template.getBody(), is("<html> </html>"));
+        assertThat(template.isEnabled(), is(true));
+    }
+
+    @Test
+    public void shouldHaveDefaults() {
+        EmailTemplate template = new EmailTemplate();
+        assertThat(template.getSyntax(), is("liquid"));
+    }
+}

--- a/src/test/resources/mgmt/email_template.json
+++ b/src/test/resources/mgmt/email_template.json
@@ -1,0 +1,8 @@
+{
+  "template": "welcome_email",
+  "from": "me@auth0.com",
+  "subject": "Some subject",
+  "syntax": "liquid",
+  "body": "<html> </html>",
+  "enabled": false
+}


### PR DESCRIPTION
Add the email-templates endpoints 
https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName

Things open to discuss:
- The use of constants. They can be provided by us or not. The problem is that the endpoint only accepts a given set of values. We can also use an Enum class instead. I've added this:

```java
 public static final String TEMPLATE_VERIFY_EMAIL = "verify_email";
 public static final String TEMPLATE_RESET_EMAIL = "reset_email";
 public static final String TEMPLATE_WELCOME_EMAIL = "welcome_email";
 public static final String TEMPLATE_BLOCKED_ACCOUNT = "blocked_account";
 public static final String TEMPLATE_STOLEN_CREDENTIALS = "stolen_credentials";
 public static final String TEMPLATE_ENROLLMENT_EMAIL = "enrollment_email";
 public static final String TEMPLATE_CHANGE_PASSWORD = "change_password";
 public static final String TEMPLATE_PASSWORD_RESET = "password_reset";
 public static final String TEMPLATE_MFA_OOB_CODE = "mfa_oob_code";
```

- Method visibility (scope) of the values that can't be changed once set. The template name ("template" property in the object) can't be changed once set. Since the same `Template` class is used on the create and update methods, does it make sense to have 2 constructors, one that accepts all the values required for creation (4 or 5 values, can be seen on the corresponding test) and one without any values so people uses the first one for creation and the other for existing templates update?

- The methods were added following a REST pattern of parameters `doAction(id, data)`. In this particular case, the "Template Id" is the template's name, used on the path. And it must match the one defined in `data.template`, or that property should be ignored at all when updating templates. WDYT?