### PR TITLE
Support pagination on the Clients entity

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -1,6 +1,8 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.mgmt.filter.ClientFilter;
 import com.auth0.json.mgmt.client.Client;
+import com.auth0.json.mgmt.client.ClientsPage;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.EmptyBodyRequest;
 import com.auth0.net.Request;
@@ -11,6 +13,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Class that provides an implementation of the Application methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Clients
@@ -35,6 +38,29 @@ public class ClientsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
         CustomRequest<List<Client>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<Client>>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Request all the Applications. A token with scope read:clients is needed. If you also need the client_secret and encryption_key attributes the token must have read:client_keys scope.
+     * See https://auth0.com/docs/api/management/v2#!/Clients/get_clients
+     *
+     * @param filter the filter to use. Can be null.
+     * @return a Request to execute.
+     */
+    public Request<ClientsPage> list(ClientFilter filter) {
+        HttpUrl.Builder builder = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/clients");
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+        String url = builder.build().toString();
+        CustomRequest<ClientsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<ClientsPage>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/filter/ClientFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/ClientFilter.java
@@ -1,0 +1,70 @@
+package com.auth0.client.mgmt.filter;
+
+/**
+ * Class used to filter the results received when calling the Clients endpoint. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
+ */
+public class ClientFilter extends FieldsFilter {
+
+    /**
+     * Include the query summary
+     *
+     * @param includeTotals whether to include or not the query summary.
+     * @return this filter instance
+     */
+    public ClientFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+    /**
+     * Filter by page
+     *
+     * @param pageNumber    the page number to retrieve.
+     * @param amountPerPage the amount of items per page to retrieve.
+     * @return this filter instance
+     */
+    public ClientFilter withPage(int pageNumber, int amountPerPage) {
+        parameters.put("page", pageNumber);
+        parameters.put("per_page", amountPerPage);
+        return this;
+    }
+
+    /**
+     * Filter by global clients
+     *
+     * @param isGlobal whether the client should or not be global
+     * @return this filter instance
+     */
+    public ClientFilter withIsGlobal(boolean isGlobal) {
+        parameters.put("is_global", isGlobal);
+        return this;
+    }
+
+    /**
+     * Filter by first party clients
+     *
+     * @param isFirstParty whether the client should or not be first party
+     * @return this filter instance
+     */
+    public ClientFilter withIsFirstParty(boolean isFirstParty) {
+        parameters.put("is_first_party", isFirstParty);
+        return this;
+    }
+
+    /**
+     * Filter by application type
+     *
+     * @param appType A comma separated list of application types used to filter the returned clients (native, spa, regular_web, non_interactive)
+     * @return this filter instance
+     */
+    public ClientFilter withAppType(String appType) {
+        parameters.put("app_type", appType);
+        return this;
+    }
+
+    @Override
+    public ClientFilter withFields(String fields, boolean includeFields) {
+        super.withFields(fields, includeFields);
+        return this;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/client/ClientsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/client/ClientsPage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 /**
- * Class that represents a given Page of Clients. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
+ * Class that represents a given page of Clients. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/auth0/json/mgmt/client/ClientsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/client/ClientsPage.java
@@ -1,4 +1,4 @@
-package com.auth0.json.mgmt.logevents;
+package com.auth0.json.mgmt.client;
 
 import com.auth0.json.mgmt.Page;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -8,19 +8,19 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 /**
- * Class that represents a given Page of Log Events. Related to the {@link com.auth0.client.mgmt.LogEventsEntity} entity.
+ * Class that represents a given Page of Clients. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonDeserialize(using = LogEventsPageDeserializer.class)
-public class LogEventsPage extends Page<LogEvent> {
+@JsonDeserialize(using = ClientsPageDeserializer.class)
+public class ClientsPage extends Page<Client> {
 
-    public LogEventsPage(List<LogEvent> items) {
+    public ClientsPage(List<Client> items) {
         super(items);
     }
 
-    public LogEventsPage(Integer start, Integer length, Integer total, Integer limit, List<LogEvent> items) {
+    public ClientsPage(Integer start, Integer length, Integer total, Integer limit, List<Client> items) {
         super(start, length, total, limit, items);
     }
 

--- a/src/main/java/com/auth0/json/mgmt/client/ClientsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/client/ClientsPageDeserializer.java
@@ -1,0 +1,24 @@
+package com.auth0.json.mgmt.client;
+
+import com.auth0.json.mgmt.PageDeserializer;
+
+import java.util.List;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+class ClientsPageDeserializer extends PageDeserializer<ClientsPage, Client> {
+
+    ClientsPageDeserializer() {
+        super(Client.class, "clients");
+    }
+
+    @Override
+    protected ClientsPage createPage(List<Client> items) {
+        return new ClientsPage(items);
+    }
+
+    @Override
+    protected ClientsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Client> items) {
+        return new ClientsPage(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEventsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEventsPage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 /**
- * Class that represents a given Page of Log Events. Related to the {@link com.auth0.client.mgmt.LogEventsEntity} entity.
+ * Class that represents a given page of Log Events. Related to the {@link com.auth0.client.mgmt.LogEventsEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEventsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEventsPageDeserializer.java
@@ -1,54 +1,23 @@
 package com.auth0.json.mgmt.logevents;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.type.CollectionType;
+import com.auth0.json.mgmt.PageDeserializer;
 
-import java.io.IOException;
 import java.util.List;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-class LogEventsPageDeserializer extends StdDeserializer<LogEventsPage> {
-    LogEventsPageDeserializer(JavaType valueType) {
-        super(valueType);
-    }
+class LogEventsPageDeserializer extends PageDeserializer<LogEventsPage, LogEvent> {
 
-    LogEventsPageDeserializer() {
-        this(null);
+    protected LogEventsPageDeserializer() {
+        super(LogEvent.class, "logs");
     }
 
     @Override
-    public LogEventsPage deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
-        JsonNode node = p.getCodec().readTree(p);
-        ObjectMapper mapper = new ObjectMapper();
-        if (node.isArray()) {
-            return new LogEventsPage(getArrayElements((ArrayNode) node, mapper));
-        }
-
-        Integer start = getIntegerValue(node.get("start"));
-        Integer length = getIntegerValue(node.get("length"));
-        Integer total = getIntegerValue(node.get("total"));
-        Integer limit = getIntegerValue(node.get("limit"));
-        ArrayNode array = (ArrayNode) node.get("logs");
-
-        return new LogEventsPage(start, length, total, limit, getArrayElements(array, mapper));
+    protected LogEventsPage createPage(List<LogEvent> items) {
+        return new LogEventsPage(items);
     }
 
-    private Integer getIntegerValue(JsonNode node) {
-        if (node == null || node.isNull()) {
-            return null;
-        } else {
-            return node.intValue();
-        }
-    }
-
-    private List<LogEvent> getArrayElements(ArrayNode array, ObjectMapper mapper) throws IOException {
-        CollectionType type = mapper.getTypeFactory().constructCollectionType(List.class, LogEvent.class);
-        return mapper.readerFor(type).readValue(array);
+    @Override
+    protected LogEventsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<LogEvent> items) {
+        return new LogEventsPage(start, length, total, limit, items);
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/users/UsersPage.java
+++ b/src/main/java/com/auth0/json/mgmt/users/UsersPage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 /**
- * Class that represents a given Page of Users. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
+ * Class that represents a given Ppge of Users. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/auth0/json/mgmt/users/UsersPage.java
+++ b/src/main/java/com/auth0/json/mgmt/users/UsersPage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 /**
- * Class that represents an Auth0 User object. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
+ * Class that represents a given Page of Users. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/auth0/json/mgmt/users/UsersPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/users/UsersPageDeserializer.java
@@ -1,54 +1,24 @@
 package com.auth0.json.mgmt.users;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.type.CollectionType;
+import com.auth0.json.mgmt.PageDeserializer;
 
-import java.io.IOException;
 import java.util.List;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-class UsersPageDeserializer extends StdDeserializer<UsersPage> {
-    UsersPageDeserializer(JavaType valueType) {
-        super(valueType);
-    }
+class UsersPageDeserializer extends PageDeserializer<UsersPage, User> {
 
     UsersPageDeserializer() {
-        this(null);
+        super(User.class, "users");
     }
 
     @Override
-    public UsersPage deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
-        JsonNode node = p.getCodec().readTree(p);
-        ObjectMapper mapper = new ObjectMapper();
-        if (node.isArray()) {
-            return new UsersPage(getArrayElements((ArrayNode) node, mapper));
-        }
-
-        Integer start = getIntegerValue(node.get("start"));
-        Integer length = getIntegerValue(node.get("length"));
-        Integer total = getIntegerValue(node.get("total"));
-        Integer limit = getIntegerValue(node.get("limit"));
-        ArrayNode array = (ArrayNode) node.get("users");
-
-        return new UsersPage(start, length, total, limit, getArrayElements(array, mapper));
+    protected UsersPage createPage(List<User> items) {
+        return new UsersPage(items);
     }
 
-    private Integer getIntegerValue(JsonNode node) {
-        if (node == null || node.isNull()) {
-            return null;
-        } else {
-            return node.intValue();
-        }
+    @Override
+    protected UsersPage createPage(Integer start, Integer length, Integer total, Integer limit, List<User> items) {
+        return new UsersPage(start, length, total, limit, items);
     }
 
-    private List<User> getArrayElements(ArrayNode array, ObjectMapper mapper) throws IOException {
-        CollectionType type = mapper.getTypeFactory().constructCollectionType(List.class, User.class);
-        return mapper.readerFor(type).readValue(array);
-    }
 }

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -29,6 +29,7 @@ public class MockServer {
     public static final String MGMT_CLIENT_GRANTS_LIST = "src/test/resources/mgmt/client_grants_list.json";
     public static final String MGMT_CLIENT_GRANT = "src/test/resources/mgmt/client_grant.json";
     public static final String MGMT_CLIENTS_LIST = "src/test/resources/mgmt/clients_list.json";
+    public static final String MGMT_CLIENTS_PAGED_LIST = "src/test/resources/mgmt/clients_paged_list.json";
     public static final String MGMT_CLIENT = "src/test/resources/mgmt/client.json";
     public static final String MGMT_CONNECTIONS_LIST = "src/test/resources/mgmt/connections_list.json";
     public static final String MGMT_CONNECTION = "src/test/resources/mgmt/connection.json";

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -1,6 +1,8 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.mgmt.filter.ClientFilter;
 import com.auth0.json.mgmt.client.Client;
+import com.auth0.json.mgmt.client.ClientsPage;
 import com.auth0.net.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
@@ -9,12 +11,115 @@ import java.util.List;
 import java.util.Map;
 
 import static com.auth0.client.MockServer.*;
-import static com.auth0.client.RecordedRequestMatcher.hasHeader;
-import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
+import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class ClientsEntityTest extends BaseMgmtEntityTest {
+
+    @Test
+    public void shouldListClientsWithoutFilter() throws Exception {
+        Request<ClientsPage> request = api.clients().list(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENTS_LIST, 200);
+        ClientsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientsWithPage() throws Exception {
+        ClientFilter filter = new ClientFilter().withPage(23, 5);
+        Request<ClientsPage> request = api.clients().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENTS_LIST, 200);
+        ClientsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "23"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "5"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientsWithTotals() throws Exception {
+        ClientFilter filter = new ClientFilter().withTotals(true);
+        Request<ClientsPage> request = api.clients().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENTS_PAGED_LIST, 200);
+        ClientsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+        assertThat(response.getStart(), is(0));
+        assertThat(response.getLength(), is(14));
+        assertThat(response.getTotal(), is(14));
+        assertThat(response.getLimit(), is(50));
+    }
+
+    @Test
+    public void shouldListClientsWithFields() throws Exception {
+        ClientFilter filter = new ClientFilter().withFields("some,random,fields", true);
+        Request<ClientsPage> request = api.clients().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENTS_PAGED_LIST, 200);
+        ClientsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("fields", "some,random,fields"));
+        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientsWithAdditionalProperties() throws Exception {
+        ClientFilter filter = new ClientFilter()
+                .withAppType("regular_web,native")
+                .withIsFirstParty(true)
+                .withIsGlobal(true);
+        Request<ClientsPage> request = api.clients().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENTS_LIST, 200);
+        ClientsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("app_type", "regular_web,native"));
+        assertThat(recordedRequest, hasQueryParameter("is_first_party", "true"));
+        assertThat(recordedRequest, hasQueryParameter("is_global", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
 
     @Test
     public void shouldListClients() throws Exception {

--- a/src/test/resources/mgmt/clients_paged_list.json
+++ b/src/test/resources/mgmt/clients_paged_list.json
@@ -1,0 +1,148 @@
+{
+  "start": 0,
+  "length": 14,
+  "total": 14,
+  "limit": 50,
+  "clients": [
+    {
+      "name": "My 1 application",
+      "client_id": "AaiyAPdpYdesoKnqjj8HJqRn4T5titww",
+      "client_secret": "MG_TNT2ver-SylNat-_VeMmd-4m0Waba0jr1troztBniSChEw0glxEmgEi2Kw40H",
+      "logo_uri": "https://my.logo.com/uri",
+      "callbacks": [
+        "https://domain.auth0.com/callback"
+      ],
+      "allowed_origins": [
+        "https://domain.auth0.com"
+      ],
+      "client_aliases": [
+        "https://domain.auth0.com"
+      ],
+      "allowed_clients": [
+        "clientId1"
+      ],
+      "allowed_logout_urls": [
+        "https://domain.auth0.com/logout"
+      ],
+      "token_endpoint_auth_method": "code",
+      "app_type": "native",
+      "oidc_conformant": false,
+      "jwt_configuration": {
+        "lifetime_in_seconds": 100,
+        "secret_encoded": true,
+        "scopes": {},
+        "alg": "HS256"
+      },
+      "encryption_key": {
+        "pub": "",
+        "cert": ""
+      },
+      "sso": false,
+      "sso_disabled": false,
+      "custom_login_page_on": false,
+      "custom_login_page": "",
+      "custom_login_page_preview": "",
+      "form_template": "",
+      "is_heroku_app": false,
+      "addons": {
+        "rms": {},
+        "slack": {
+          "team": "Auth0"
+        },
+        "mscrm": {},
+        "layer": {},
+        "zoom": {}
+      },
+      "resource_servers": [
+        {
+          "identifier": "api.tenant.com",
+          "scopes": [
+            "read:something"
+          ]
+        }
+      ],
+      "client_metadata": {},
+      "mobile": {
+        "android": {
+          "app_package_name": "com.example",
+          "sha256_cert_fingerprints": [
+            "D8:A0:83:..."
+          ]
+        },
+        "ios": {
+          "team_id": "9JA89QQLNQ",
+          "app_bundle_identifier": "com.my.bundle.id"
+        }
+      }
+    },
+    {
+      "name": "My 2 application",
+      "client_id": "BbiyAPdpYdesoKnqjj8HJqRn4T5titww",
+      "client_secret": "MG_TNT2ver-SylNat-_VeMmd-4m0Waba0jr1troztBniSChEw0glxEmgEi2Kw40H",
+      "logo_uri": "https://my.logo.com/uri",
+      "callbacks": [
+        "https://domain.auth0.com/callback"
+      ],
+      "allowed_origins": [
+        "https://domain.auth0.com"
+      ],
+      "client_aliases": [
+        "https://domain.auth0.com"
+      ],
+      "allowed_clients": [
+        "clientId1"
+      ],
+      "allowed_logout_urls": [
+        "https://domain.auth0.com/logout"
+      ],
+      "token_endpoint_auth_method": "code",
+      "app_type": "native",
+      "oidc_conformant": false,
+      "jwt_configuration": {
+        "lifetime_in_seconds": 100,
+        "secret_encoded": true,
+        "scopes": {},
+        "alg": "HS256"
+      },
+      "encryption_key": {
+        "pub": "",
+        "cert": ""
+      },
+      "sso": false,
+      "sso_disabled": false,
+      "custom_login_page_on": false,
+      "custom_login_page": "",
+      "custom_login_page_preview": "",
+      "form_template": "",
+      "is_heroku_app": false,
+      "addons": {
+        "rms": {},
+        "slack": {},
+        "mscrm": {},
+        "layer": {},
+        "zoom": {}
+      },
+      "resource_servers": [
+        {
+          "identifier": "api.tenant.com",
+          "scopes": [
+            "read:something"
+          ]
+        }
+      ],
+      "client_metadata": {},
+      "mobile": {
+        "android": {
+          "app_package_name": "com.example",
+          "sha256_cert_fingerprints": [
+            "D8:A0:83:..."
+          ]
+        },
+        "ios": {
+          "team_id": "9JA89QQLNQ",
+          "app_bundle_identifier": "com.my.bundle.id"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR refactors the way "Page Deserializers" work to prepare them for a generic approach. It also adds a ClientFilter and a new `list(filter)` under the clients entity to send pagination parameters, among others. 

A separate PR will deprecate the existing `list()` method, once this one is merged so it can reference the new one.