### PR TITLE
Security fix and dependencies update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,12 @@ compileJava {
 buildscript {
     repositories {
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url 'https://plugins.gradle.org/m2/'
         }
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
-        classpath "gradle.plugin.com.auth0.gradle:oss-library:0.6.0"
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
+        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.6.0'
     }
 }
 
@@ -59,13 +59,13 @@ test {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp3:okhttp:3.7.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.7.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.2'
-    compile 'commons-codec:commons-codec:1.10'
+    compile 'com.squareup.okhttp3:okhttp:3.10.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.10.0'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
+    compile 'commons-codec:commons-codec:1.11'
 
-    testCompile 'org.mockito:mockito-core:2.5.4'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.7.0'
+    testCompile 'org.mockito:mockito-core:2.18.3'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.10.0'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'junit:junit:4.11'

--- a/build.gradle
+++ b/build.gradle
@@ -59,13 +59,13 @@ test {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.10.0'
+    compile 'com.squareup.okhttp3:okhttp:3.9.1'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.9.1'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
     compile 'commons-codec:commons-codec:1.11'
 
     testCompile 'org.mockito:mockito-core:2.18.3'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.10.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.1'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
Bump libraries and plugins dependencies to latest versions. This also fixes a security issue found on jackson databind.