### PR TITLE
Add pagination support to Client Grants, Grants, Resource Servers and Rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ buildscript {
 }
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 test {

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -1,6 +1,8 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.mgmt.filter.ClientGrantsFilter;
 import com.auth0.json.mgmt.ClientGrant;
+import com.auth0.json.mgmt.ClientGrantsPage;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
@@ -10,6 +12,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Class that provides an implementation of the Client Grants methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Client_Grants
@@ -25,9 +28,34 @@ public class ClientGrantsEntity extends BaseManagementEntity {
      * Request all the Client Grants. A token with scope read:client_grants is needed.
      * See https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
      *
+     * @param filter the filter to use. Can be null
+     * @return a Request to execute.
+     */
+    public Request<ClientGrantsPage> list(ClientGrantsFilter filter) {
+        HttpUrl.Builder builder = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/client-grants");
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+
+        String url = builder.build().toString();
+        CustomRequest<ClientGrantsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<ClientGrantsPage>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Request all the Client Grants. A token with scope read:client_grants is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
+     *
      * @return a Request to execute.
      */
     public Request<List<ClientGrant>> list() {
+        //TODO Deprecate
         String url = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/client-grants")

--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -1,17 +1,18 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.mgmt.filter.GrantsFilter;
+import com.auth0.json.mgmt.Grant;
+import com.auth0.json.mgmt.GrantsPage;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
 import com.auth0.utils.Asserts;
 import com.fasterxml.jackson.core.type.TypeReference;
-
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
 import java.util.List;
-
-import com.auth0.json.mgmt.Grant;
+import java.util.Map;
 
 /**
  * Class that provides an implementation of the Grants methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Grants/
@@ -27,12 +28,40 @@ public class GrantsEntity extends BaseManagementEntity {
      * Request all Grants. A token with scope read:grants is needed
      * See https://auth0.com/docs/api/management/v2#!/Grants/get_grants
      *
-     * @param userId The user id of the grants to retrieve 
+     * @param userId The user id of the grants to retrieve
+     * @return a Request to execute.
+     */
+    public Request<GrantsPage> list(String userId, GrantsFilter filter) {
+        Asserts.assertNotNull(userId, "user id");
+
+        HttpUrl.Builder builder = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/grants")
+                .addQueryParameter("user_id", userId);
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+
+        String url = builder.build().toString();
+        CustomRequest<GrantsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<GrantsPage>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Request all Grants. A token with scope read:grants is needed
+     * See https://auth0.com/docs/api/management/v2#!/Grants/get_grants
+     *
+     * @param userId The user id of the grants to retrieve
      * @return a Request to execute.
      */
     public Request<List<Grant>> list(String userId) {
+        //TODO: Deprecate
         Asserts.assertNotNull(userId, "user id");
-        
+
         String url = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/grants")
@@ -54,7 +83,7 @@ public class GrantsEntity extends BaseManagementEntity {
      */
     public Request delete(String grantId) {
         Asserts.assertNotNull(grantId, "grant id");
-        
+
         final String url = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/grants")
@@ -65,7 +94,7 @@ public class GrantsEntity extends BaseManagementEntity {
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
-    
+
     /**
      * Deletes all Grants of a given user. A token with scope delete:grants is needed.
      * See https://auth0.com/docs/api/management/v2#!/Grants/delete_grants_by_id<br>
@@ -75,7 +104,7 @@ public class GrantsEntity extends BaseManagementEntity {
      */
     public Request deleteAll(String userId) {
         Asserts.assertNotNull(userId, "user id");
-        
+
         final String url = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/grants")

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -1,8 +1,8 @@
 package com.auth0.client.mgmt;
 
-import java.util.List;
-
+import com.auth0.client.mgmt.filter.ResourceServersFilter;
 import com.auth0.json.mgmt.ResourceServer;
+import com.auth0.json.mgmt.ResourceServersPage;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
@@ -11,10 +11,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Class that provides an implementation of the Resource Server methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Resource_Servers
  */
-public class ResourceServerEntity  {
+public class ResourceServerEntity {
     private OkHttpClient client;
     private HttpUrl baseUrl;
     private String apiToken;
@@ -31,16 +34,40 @@ public class ResourceServerEntity  {
      *
      * @return request to execute
      */
-    public Request<List<ResourceServer>> list() {
+    public Request<ResourceServersPage> list(ResourceServersFilter filter) {
+        HttpUrl.Builder builder = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/resource-servers");
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
 
+        String url = builder.build().toString();
+        CustomRequest<ResourceServersPage> request = new CustomRequest<>(client, url, "GET",
+                new TypeReference<ResourceServersPage>() {
+                });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Creates request to fetch all resource servers.
+     * See <a href=https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers>API documentation</a>
+     *
+     * @return request to execute
+     */
+    public Request<List<ResourceServer>> list() {
+        //TODO: Deprecate
         HttpUrl.Builder builder = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
         CustomRequest<List<ResourceServer>> request = new CustomRequest<>(client, url, "GET",
-                                                                          new TypeReference<List<ResourceServer>>() {
-                                                                          });
+                new TypeReference<List<ResourceServer>>() {
+                });
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
@@ -62,8 +89,8 @@ public class ResourceServerEntity  {
 
         String url = builder.build().toString();
         CustomRequest<ResourceServer> request = new CustomRequest<>(client, url, "GET",
-                                                                    new TypeReference<ResourceServer>() {
-                                                                    });
+                new TypeReference<ResourceServer>() {
+                });
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
@@ -84,8 +111,8 @@ public class ResourceServerEntity  {
 
         String url = builder.build().toString();
         CustomRequest<ResourceServer> request = new CustomRequest<>(client, url, "POST",
-                                                                    new TypeReference<ResourceServer>() {
-                                                                    });
+                new TypeReference<ResourceServer>() {
+                });
         request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(resourceServer);
         return request;
@@ -131,8 +158,8 @@ public class ResourceServerEntity  {
 
         String url = builder.build().toString();
         CustomRequest<ResourceServer> request = new CustomRequest<ResourceServer>(client, url, "PATCH",
-                                                                                  new TypeReference<ResourceServer>() {
-                                                                                  });
+                new TypeReference<ResourceServer>() {
+                });
         request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(resourceServer);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/RulesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesEntity.java
@@ -2,6 +2,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.filter.RulesFilter;
 import com.auth0.json.mgmt.Rule;
+import com.auth0.json.mgmt.RulesPage;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
@@ -30,7 +31,31 @@ public class RulesEntity extends BaseManagementEntity {
      * @param filter the filter to use. Can be null.
      * @return a Request to execute.
      */
+    public Request<RulesPage> listAll(RulesFilter filter) {
+        HttpUrl.Builder builder = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/rules");
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+        String url = builder.build().toString();
+        CustomRequest<RulesPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<RulesPage>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Request all the Rules. A token with scope read:rules is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Rules/get_rules
+     *
+     * @param filter the filter to use. Can be null.
+     * @return a Request to execute.
+     */
     public Request<List<Rule>> list(RulesFilter filter) {
+        //TODO: Deprecate. Warn page params are not going to work on this method
         HttpUrl.Builder builder = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/rules");

--- a/src/main/java/com/auth0/client/mgmt/filter/ClientGrantsFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/ClientGrantsFilter.java
@@ -1,0 +1,54 @@
+package com.auth0.client.mgmt.filter;
+
+/**
+ * Class used to filter the results received when calling the Client Grants endpoint. Related to the {@link com.auth0.client.mgmt.ClientGrantsEntity} entity.
+ */
+public class ClientGrantsFilter extends BaseFilter {
+
+    /**
+     * Filter by client id
+     *
+     * @param clientId only retrieve items with this client id.
+     * @return this filter instance
+     */
+    public ClientGrantsFilter withClientId(String clientId) {
+        parameters.put("client_id", clientId);
+        return this;
+    }
+
+    /**
+     * Filter by audience
+     *
+     * @param audience only retrieve the item with this audience.
+     * @return this filter instance
+     */
+    public ClientGrantsFilter withAudience(String audience) {
+        parameters.put("audience", audience);
+        return this;
+    }
+
+    /**
+     * Filter by page
+     *
+     * @param pageNumber    the page number to retrieve.
+     * @param amountPerPage the amount of items per page to retrieve.
+     * @return this filter instance
+     */
+    public ClientGrantsFilter withPage(int pageNumber, int amountPerPage) {
+        parameters.put("page", pageNumber);
+        parameters.put("per_page", amountPerPage);
+        return this;
+    }
+
+    /**
+     * Include the query summary
+     *
+     * @param includeTotals whether to include or not the query summary.
+     * @return this filter instance
+     */
+    public ClientGrantsFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+}

--- a/src/main/java/com/auth0/client/mgmt/filter/GrantsFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/GrantsFilter.java
@@ -1,0 +1,54 @@
+package com.auth0.client.mgmt.filter;
+
+/**
+ * Class used to filter the results received when calling the Grants endpoint. Related to the {@link com.auth0.client.mgmt.GrantsEntity} entity.
+ */
+public class GrantsFilter extends BaseFilter {
+
+    /**
+     * Filter by client id
+     *
+     * @param clientId only retrieve items with this client id.
+     * @return this filter instance
+     */
+    public GrantsFilter withClientId(String clientId) {
+        parameters.put("client_id", clientId);
+        return this;
+    }
+
+    /**
+     * Filter by audience
+     *
+     * @param audience only retrieve the item with this audience.
+     * @return this filter instance
+     */
+    public GrantsFilter withAudience(String audience) {
+        parameters.put("audience", audience);
+        return this;
+    }
+
+    /**
+     * Filter by page
+     *
+     * @param pageNumber    the page number to retrieve.
+     * @param amountPerPage the amount of items per page to retrieve.
+     * @return this filter instance
+     */
+    public GrantsFilter withPage(int pageNumber, int amountPerPage) {
+        parameters.put("page", pageNumber);
+        parameters.put("per_page", amountPerPage);
+        return this;
+    }
+
+    /**
+     * Include the query summary
+     *
+     * @param includeTotals whether to include or not the query summary.
+     * @return this filter instance
+     */
+    public GrantsFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+}

--- a/src/main/java/com/auth0/client/mgmt/filter/ResourceServersFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/ResourceServersFilter.java
@@ -1,0 +1,32 @@
+package com.auth0.client.mgmt.filter;
+
+/**
+ * Class used to filter the results received when calling the Resource Servers endpoint. Related to the {@link com.auth0.client.mgmt.ResourceServerEntity} entity.
+ */
+public class ResourceServersFilter extends BaseFilter {
+
+    /**
+     * Filter by page
+     *
+     * @param pageNumber    the page number to retrieve.
+     * @param amountPerPage the amount of items per page to retrieve.
+     * @return this filter instance
+     */
+    public ResourceServersFilter withPage(int pageNumber, int amountPerPage) {
+        parameters.put("page", pageNumber);
+        parameters.put("per_page", amountPerPage);
+        return this;
+    }
+
+    /**
+     * Include the query summary
+     *
+     * @param includeTotals whether to include or not the query summary.
+     * @return this filter instance
+     */
+    public ResourceServersFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+}

--- a/src/main/java/com/auth0/client/mgmt/filter/RulesFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/RulesFilter.java
@@ -21,4 +21,29 @@ public class RulesFilter extends FieldsFilter {
         super.withFields(fields, includeFields);
         return this;
     }
+
+    /**
+     * Include the query summary
+     *
+     * @param includeTotals whether to include or not the query summary.
+     * @return this filter instance
+     */
+    public RulesFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+    /**
+     * Filter by page
+     *
+     * @param pageNumber    the page number to retrieve.
+     * @param amountPerPage the amount of items per page to retrieve.
+     * @return this filter instance
+     */
+    public RulesFilter withPage(int pageNumber, int amountPerPage) {
+        parameters.put("page", pageNumber);
+        parameters.put("per_page", amountPerPage);
+        return this;
+    }
+
 }

--- a/src/main/java/com/auth0/json/mgmt/ClientGrantsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/ClientGrantsPage.java
@@ -1,0 +1,26 @@
+package com.auth0.json.mgmt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Class that represents a given page of Clients. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = ClientGrantsPageDeserializer.class)
+public class ClientGrantsPage extends Page<ClientGrant> {
+
+    public ClientGrantsPage(List<ClientGrant> items) {
+        super(items);
+    }
+
+    public ClientGrantsPage(Integer start, Integer length, Integer total, Integer limit, List<ClientGrant> items) {
+        super(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/ClientGrantsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/ClientGrantsPageDeserializer.java
@@ -1,0 +1,22 @@
+package com.auth0.json.mgmt;
+
+import java.util.List;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+class ClientGrantsPageDeserializer extends PageDeserializer<ClientGrantsPage, ClientGrant> {
+
+    ClientGrantsPageDeserializer() {
+        super(ClientGrant.class, "client_grants");
+    }
+
+    @Override
+    protected ClientGrantsPage createPage(List<ClientGrant> items) {
+        return new ClientGrantsPage(items);
+    }
+
+    @Override
+    protected ClientGrantsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<ClientGrant> items) {
+        return new ClientGrantsPage(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/GrantsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/GrantsPage.java
@@ -7,19 +7,19 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 /**
- * Class that represents a given page of Client Grants. Related to the {@link com.auth0.client.mgmt.ClientGrantsEntity} entity.
+ * Class that represents a given page of Grants. Related to the {@link com.auth0.client.mgmt.GrantsEntity} entity.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonDeserialize(using = ClientGrantsPageDeserializer.class)
-public class ClientGrantsPage extends Page<ClientGrant> {
+@JsonDeserialize(using = GrantsPageDeserializer.class)
+public class GrantsPage extends Page<Grant> {
 
-    public ClientGrantsPage(List<ClientGrant> items) {
+    public GrantsPage(List<Grant> items) {
         super(items);
     }
 
-    public ClientGrantsPage(Integer start, Integer length, Integer total, Integer limit, List<ClientGrant> items) {
+    public GrantsPage(Integer start, Integer length, Integer total, Integer limit, List<Grant> items) {
         super(start, length, total, limit, items);
     }
 

--- a/src/main/java/com/auth0/json/mgmt/GrantsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/GrantsPageDeserializer.java
@@ -1,0 +1,22 @@
+package com.auth0.json.mgmt;
+
+import java.util.List;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+class GrantsPageDeserializer extends PageDeserializer<GrantsPage, Grant> {
+
+    GrantsPageDeserializer() {
+        super(Grant.class, "grants");
+    }
+
+    @Override
+    protected GrantsPage createPage(List<Grant> items) {
+        return new GrantsPage(items);
+    }
+
+    @Override
+    protected GrantsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Grant> items) {
+        return new GrantsPage(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/ResourceServersPage.java
+++ b/src/main/java/com/auth0/json/mgmt/ResourceServersPage.java
@@ -1,0 +1,26 @@
+package com.auth0.json.mgmt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Class that represents a given page of Resource Servers. Related to the {@link com.auth0.client.mgmt.ResourceServerEntity} entity.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = ResourceServersPageDeserializer.class)
+public class ResourceServersPage extends Page<ResourceServer> {
+
+    public ResourceServersPage(List<ResourceServer> items) {
+        super(items);
+    }
+
+    public ResourceServersPage(Integer start, Integer length, Integer total, Integer limit, List<ResourceServer> items) {
+        super(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/ResourceServersPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/ResourceServersPageDeserializer.java
@@ -1,0 +1,22 @@
+package com.auth0.json.mgmt;
+
+import java.util.List;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+class ResourceServersPageDeserializer extends PageDeserializer<ResourceServersPage, ResourceServer> {
+
+    ResourceServersPageDeserializer() {
+        super(ResourceServer.class, "resource_servers");
+    }
+
+    @Override
+    protected ResourceServersPage createPage(List<ResourceServer> items) {
+        return new ResourceServersPage(items);
+    }
+
+    @Override
+    protected ResourceServersPage createPage(Integer start, Integer length, Integer total, Integer limit, List<ResourceServer> items) {
+        return new ResourceServersPage(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/RulesPage.java
+++ b/src/main/java/com/auth0/json/mgmt/RulesPage.java
@@ -1,0 +1,26 @@
+package com.auth0.json.mgmt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Class that represents a given page of Rules. Related to the {@link com.auth0.client.mgmt.RulesEntity} entity.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = RulesPageDeserializer.class)
+public class RulesPage extends Page<Rule> {
+
+    public RulesPage(List<Rule> items) {
+        super(items);
+    }
+
+    public RulesPage(Integer start, Integer length, Integer total, Integer limit, List<Rule> items) {
+        super(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/RulesPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/RulesPageDeserializer.java
@@ -1,0 +1,22 @@
+package com.auth0.json.mgmt;
+
+import java.util.List;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+class RulesPageDeserializer extends PageDeserializer<RulesPage, Rule> {
+
+    RulesPageDeserializer() {
+        super(Rule.class, "rules");
+    }
+
+    @Override
+    protected RulesPage createPage(List<Rule> items) {
+        return new RulesPage(items);
+    }
+
+    @Override
+    protected RulesPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Rule> items) {
+        return new RulesPage(start, length, total, limit, items);
+    }
+
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -42,6 +42,7 @@ public class MockServer {
     public static final String MGMT_LOG_EVENTS_PAGED_LIST = "src/test/resources/mgmt/event_logs_paged_list.json";
     public static final String MGMT_LOG_EVENT = "src/test/resources/mgmt/event_log.json";
     public static final String MGMT_RESOURCE_SERVERS_LIST = "src/test/resources/mgmt/resource_servers_list.json";
+    public static final String MGMT_RESOURCE_SERVERS_PAGED_LIST = "src/test/resources/mgmt/resource_servers_paged_list.json";
     public static final String MGMT_RESOURCE_SERVER = "src/test/resources/mgmt/resource_server.json";
     public static final String MGMT_RULES_LIST = "src/test/resources/mgmt/rules_list.json";
     public static final String MGMT_RULE = "src/test/resources/mgmt/rule.json";

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -27,6 +27,7 @@ public class MockServer {
     public static final String AUTH_ERROR_PLAINTEXT = "src/test/resources/auth/error_plaintext.json";
     public static final String MGMT_ERROR_WITH_MESSAGE = "src/test/resources/mgmt/error_with_message.json";
     public static final String MGMT_CLIENT_GRANTS_LIST = "src/test/resources/mgmt/client_grants_list.json";
+    public static final String MGMT_CLIENT_GRANTS_PAGED_LIST = "src/test/resources/mgmt/client_grants_paged_list.json";
     public static final String MGMT_CLIENT_GRANT = "src/test/resources/mgmt/client_grant.json";
     public static final String MGMT_CLIENTS_LIST = "src/test/resources/mgmt/clients_list.json";
     public static final String MGMT_CLIENTS_PAGED_LIST = "src/test/resources/mgmt/clients_paged_list.json";

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -37,6 +37,7 @@ public class MockServer {
     public static final String MGMT_DEVICE_CREDENTIALS_LIST = "src/test/resources/mgmt/device_credentials_list.json";
     public static final String MGMT_DEVICE_CREDENTIALS = "src/test/resources/mgmt/device_credentials.json";
     public static final String MGMT_GRANTS_LIST = "src/test/resources/mgmt/grants_list.json";
+    public static final String MGMT_GRANTS_PAGED_LIST = "src/test/resources/mgmt/grants_paged_list.json";
     public static final String MGMT_LOG_EVENTS_LIST = "src/test/resources/mgmt/event_logs_list.json";
     public static final String MGMT_LOG_EVENTS_PAGED_LIST = "src/test/resources/mgmt/event_logs_paged_list.json";
     public static final String MGMT_LOG_EVENT = "src/test/resources/mgmt/event_log.json";

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -45,6 +45,7 @@ public class MockServer {
     public static final String MGMT_RESOURCE_SERVERS_PAGED_LIST = "src/test/resources/mgmt/resource_servers_paged_list.json";
     public static final String MGMT_RESOURCE_SERVER = "src/test/resources/mgmt/resource_server.json";
     public static final String MGMT_RULES_LIST = "src/test/resources/mgmt/rules_list.json";
+    public static final String MGMT_RULES_PAGED_LIST = "src/test/resources/mgmt/rules_paged_list.json";
     public static final String MGMT_RULE = "src/test/resources/mgmt/rule.json";
     public static final String MGMT_USER_BLOCKS = "src/test/resources/mgmt/user_blocks.json";
     public static final String MGMT_BLACKLISTED_TOKENS_LIST = "src/test/resources/mgmt/blacklisted_tokens_list.json";

--- a/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
@@ -1,6 +1,8 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.mgmt.filter.ClientGrantsFilter;
 import com.auth0.json.mgmt.ClientGrant;
+import com.auth0.json.mgmt.ClientGrantsPage;
 import com.auth0.net.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
@@ -10,12 +12,94 @@ import java.util.List;
 import java.util.Map;
 
 import static com.auth0.client.MockServer.*;
-import static com.auth0.client.RecordedRequestMatcher.hasHeader;
-import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
+import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
+
+    @Test
+    public void shouldListClientGrantsWithoutFilter() throws Exception {
+        Request<ClientGrantsPage> request = api.clientGrants().list(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
+        ClientGrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientGrantsWithPage() throws Exception {
+        ClientGrantsFilter filter = new ClientGrantsFilter().withPage(23, 5);
+        Request<ClientGrantsPage> request = api.clientGrants().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
+        ClientGrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "23"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "5"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientGrantsWithTotals() throws Exception {
+        ClientGrantsFilter filter = new ClientGrantsFilter().withTotals(true);
+        Request<ClientGrantsPage> request = api.clientGrants().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT_GRANTS_PAGED_LIST, 200);
+        ClientGrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+        assertThat(response.getStart(), is(0));
+        assertThat(response.getLength(), is(14));
+        assertThat(response.getTotal(), is(14));
+        assertThat(response.getLimit(), is(50));
+    }
+
+    @Test
+    public void shouldListClientGrantsWithAdditionalProperties() throws Exception {
+        ClientGrantsFilter filter = new ClientGrantsFilter()
+                .withAudience("https://myapi.auth0.com")
+                .withClientId("u9e3hh3e9j2fj9092ked");
+        Request<ClientGrantsPage> request = api.clientGrants().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
+        ClientGrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("audience", "https://myapi.auth0.com"));
+        assertThat(recordedRequest, hasQueryParameter("client_id", "u9e3hh3e9j2fj9092ked"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
 
     @Test
     public void shouldListClientGrants() throws Exception {

--- a/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
@@ -1,22 +1,114 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.mgmt.filter.GrantsFilter;
 import com.auth0.json.mgmt.Grant;
+import com.auth0.json.mgmt.GrantsPage;
 import com.auth0.net.Request;
-
 import okhttp3.mockwebserver.RecordedRequest;
-
 import org.junit.Test;
 
 import java.util.List;
 
 import static com.auth0.client.MockServer.*;
-import static com.auth0.client.RecordedRequestMatcher.hasHeader;
-import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
-import static com.auth0.client.RecordedRequestMatcher.hasQueryParameter;
+import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class GrantsEntityTest extends BaseMgmtEntityTest {
+
+    @Test
+    public void shouldListGrantsWithoutFilter() throws Exception {
+        Request<GrantsPage> request = api.grants().list("userId", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_GRANTS_LIST, 200);
+        GrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("user_id", "userId"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldThrowOnListGrantsWithoutFilterWithNullUserId() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'user id' cannot be null!");
+        api.grants().list(null, null);
+    }
+
+    @Test
+    public void shouldListGrantsWithPage() throws Exception {
+        GrantsFilter filter = new GrantsFilter().withPage(23, 5);
+        Request<GrantsPage> request = api.grants().list("userId", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_GRANTS_LIST, 200);
+        GrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("user_id", "userId"));
+        assertThat(recordedRequest, hasQueryParameter("page", "23"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "5"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListGrantsWithTotals() throws Exception {
+        GrantsFilter filter = new GrantsFilter().withTotals(true);
+        Request<GrantsPage> request = api.grants().list("userId", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_GRANTS_PAGED_LIST, 200);
+        GrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("user_id", "userId"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+        assertThat(response.getStart(), is(0));
+        assertThat(response.getLength(), is(14));
+        assertThat(response.getTotal(), is(14));
+        assertThat(response.getLimit(), is(50));
+    }
+
+    @Test
+    public void shouldListGrantsWithAdditionalProperties() throws Exception {
+        GrantsFilter filter = new GrantsFilter()
+                .withAudience("https://myapi.auth0.com")
+                .withClientId("u9e3hh3e9j2fj9092ked");
+        Request<GrantsPage> request = api.grants().list("userId", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_GRANTS_LIST, 200);
+        GrantsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("user_id", "userId"));
+        assertThat(recordedRequest, hasQueryParameter("audience", "https://myapi.auth0.com"));
+        assertThat(recordedRequest, hasQueryParameter("client_id", "u9e3hh3e9j2fj9092ked"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
 
     @Test
     public void shouldListGrants() throws Exception {
@@ -42,7 +134,13 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
             assertThat(grant.getScope(), hasSize(2));
             assertThat(grant.getUserId(), equalTo("userId"));
         }
-        
+    }
+
+    @Test
+    public void shouldThrowOnListGrantsWithNullUserId() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'user id' cannot be null!");
+        api.grants().list(null);
     }
 
     @Test
@@ -63,7 +161,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         exception.expectMessage("'grant id' cannot be null!");
         api.grants().delete(null);
     }
-    
+
     @Test
     public void shouldDeleteGrantById() throws Exception {
         Request request = api.grants().delete("1");
@@ -77,14 +175,14 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
     }
-    
+
     @Test
     public void shouldThrowOnDeleteAllGrantsWithNullUserId() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'user id' cannot be null!");
         api.grants().deleteAll(null);
     }
-    
+
     @Test
     public void shouldDeleteAllGrantsByUserId() throws Exception {
         Request request = api.grants().deleteAll("userId");
@@ -99,5 +197,5 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
     }
-    
+
 }

--- a/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
@@ -1,27 +1,85 @@
 package com.auth0.client.mgmt;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
+import com.auth0.client.mgmt.filter.ResourceServersFilter;
 import com.auth0.json.mgmt.ResourceServer;
+import com.auth0.json.mgmt.ResourceServersPage;
 import com.auth0.json.mgmt.Scope;
 import com.auth0.net.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 
-import static com.auth0.client.MockServer.MGMT_RESOURCE_SERVER;
-import static com.auth0.client.MockServer.MGMT_RESOURCE_SERVERS_LIST;
-import static com.auth0.client.MockServer.bodyFromRequest;
-import static com.auth0.client.RecordedRequestMatcher.hasHeader;
-import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.auth0.client.MockServer.*;
+import static com.auth0.client.RecordedRequestMatcher.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class ResourceServerEntityTest extends BaseMgmtEntityTest {
+
+
+    @Test
+    public void shouldListResourceServerWithoutFilter() throws Exception {
+        Request<ResourceServersPage> request = api.resourceServers().list(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_RESOURCE_SERVERS_LIST, 200);
+        ResourceServersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListResourceServerWithPage() throws Exception {
+        ResourceServersFilter filter = new ResourceServersFilter().withPage(23, 5);
+        Request<ResourceServersPage> request = api.resourceServers().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_RESOURCE_SERVERS_LIST, 200);
+        ResourceServersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "23"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "5"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListResourceServerWithTotals() throws Exception {
+        ResourceServersFilter filter = new ResourceServersFilter().withTotals(true);
+        Request<ResourceServersPage> request = api.resourceServers().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_RESOURCE_SERVERS_PAGED_LIST, 200);
+        ResourceServersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+        assertThat(response.getStart(), is(0));
+        assertThat(response.getLength(), is(14));
+        assertThat(response.getTotal(), is(14));
+        assertThat(response.getLimit(), is(50));
+    }
+
     @Test
     public void shouldListResourceServers() throws Exception {
         Request<List<ResourceServer>> request = api.resourceServers().list();
@@ -53,7 +111,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         resourceServer.setTokenLifetime(0);
         resourceServer.setVerificationLocation("verification_location");
         Request<ResourceServer> request = api.resourceServers()
-                                             .update("23445566abab", resourceServer);
+                .update("23445566abab", resourceServer);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVER, 200);
@@ -74,7 +132,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldGetResourceServerById() throws Exception {
         Request<ResourceServer> request = api.resourceServers()
-                                             .get("23445566abab");
+                .get("23445566abab");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVER, 200);
@@ -91,7 +149,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldCreateResourceServer() throws Exception {
         Request<ResourceServer> request = api.resourceServers()
-                                             .create(new ResourceServer("https://api.my-company.com/api/v2/"));
+                .create(new ResourceServer("https://api.my-company.com/api/v2/"));
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVER, 200);
@@ -112,7 +170,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldDeleteResourceServer() throws Exception {
         Request<Void> request = api.resourceServers()
-                                   .delete("23445566abab");
+                .delete("23445566abab");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);

--- a/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
@@ -2,6 +2,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.filter.RulesFilter;
 import com.auth0.json.mgmt.Rule;
+import com.auth0.json.mgmt.RulesPage;
 import com.auth0.net.Request;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
@@ -31,6 +32,23 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
 
         assertThat(response, is(notNullValue()));
         assertThat(response, hasSize(2));
+    }
+
+    @Test
+    public void shouldListRulesWithoutFilter() throws Exception {
+        Request<RulesPage> request = api.rules().listAll(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_RULES_LIST, 200);
+        RulesPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
     }
 
     @Test
@@ -70,6 +88,49 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
 
         assertThat(response, is(notNullValue()));
         assertThat(response, hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientsWithPage() throws Exception {
+        RulesFilter filter = new RulesFilter().withPage(23, 5);
+        Request<RulesPage> request = api.rules().listAll(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_RULES_LIST, 200);
+        RulesPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "23"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "5"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListClientsWithTotals() throws Exception {
+        RulesFilter filter = new RulesFilter().withTotals(true);
+        Request<RulesPage> request = api.rules().listAll(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_RULES_PAGED_LIST, 200);
+        RulesPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+        assertThat(response.getStart(), is(0));
+        assertThat(response.getLength(), is(14));
+        assertThat(response.getTotal(), is(14));
+        assertThat(response.getLimit(), is(50));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/filter/ClientGrantsFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/ClientGrantsFilterTest.java
@@ -1,0 +1,57 @@
+package com.auth0.client.mgmt.filter;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ClientGrantsFilterTest {
+
+    private ClientGrantsFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        filter = new ClientGrantsFilter();
+    }
+
+    @Test
+    public void shouldFilterByAudience() throws Exception {
+        ClientGrantsFilter instance = filter.withAudience("https://myapi.auth0.com");
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("audience", (Object) "https://myapi.auth0.com"));
+    }
+
+    @Test
+    public void shouldFilterByClientId() throws Exception {
+        ClientGrantsFilter instance = filter.withClientId("n3roinr32i23iron23nr");
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("client_id", (Object) "n3roinr32i23iron23nr"));
+    }
+
+    @Test
+    public void shouldFilterByPage() throws Exception {
+        ClientGrantsFilter instance = filter.withPage(5, 10);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("per_page", (Object) 10));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("page", (Object) 5));
+    }
+
+    @Test
+    public void shouldIncludeTotals() throws Exception {
+        ClientGrantsFilter instance = filter.withTotals(true);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("include_totals", (Object) true));
+    }
+
+}

--- a/src/test/java/com/auth0/client/mgmt/filter/ConnectionFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/ConnectionFilterTest.java
@@ -1,6 +1,5 @@
 package com.auth0.client.mgmt.filter;
 
-import com.auth0.client.mgmt.filter.ConnectionFilter;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/auth0/client/mgmt/filter/GrantsFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/GrantsFilterTest.java
@@ -1,0 +1,57 @@
+package com.auth0.client.mgmt.filter;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class GrantsFilterTest {
+
+    private GrantsFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        filter = new GrantsFilter();
+    }
+
+    @Test
+    public void shouldFilterByAudience() throws Exception {
+        GrantsFilter instance = filter.withAudience("https://myapi.auth0.com");
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("audience", (Object) "https://myapi.auth0.com"));
+    }
+
+    @Test
+    public void shouldFilterByClientId() throws Exception {
+        GrantsFilter instance = filter.withClientId("n3roinr32i23iron23nr");
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("client_id", (Object) "n3roinr32i23iron23nr"));
+    }
+
+    @Test
+    public void shouldFilterByPage() throws Exception {
+        GrantsFilter instance = filter.withPage(5, 10);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("per_page", (Object) 10));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("page", (Object) 5));
+    }
+
+    @Test
+    public void shouldIncludeTotals() throws Exception {
+        GrantsFilter instance = filter.withTotals(true);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("include_totals", (Object) true));
+    }
+
+}

--- a/src/test/java/com/auth0/client/mgmt/filter/ResourceServersFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/ResourceServersFilterTest.java
@@ -1,0 +1,38 @@
+package com.auth0.client.mgmt.filter;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ResourceServersFilterTest {
+
+    private ResourceServersFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        filter = new ResourceServersFilter();
+    }
+
+    @Test
+    public void shouldFilterByPage() throws Exception {
+        ResourceServersFilter instance = filter.withPage(5, 10);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("per_page", (Object) 10));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("page", (Object) 5));
+    }
+
+    @Test
+    public void shouldIncludeTotals() throws Exception {
+        ResourceServersFilter instance = filter.withTotals(true);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("include_totals", (Object) true));
+    }
+}

--- a/src/test/java/com/auth0/client/mgmt/filter/RulesFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/RulesFilterTest.java
@@ -45,4 +45,23 @@ public class RulesFilterTest {
         assertThat(filter.getAsMap(), Matchers.hasEntry("fields", (Object) "a,b,c"));
         assertThat(filter.getAsMap(), Matchers.hasEntry("include_fields", (Object) false));
     }
+
+    @Test
+    public void shouldIncludeTotals() throws Exception {
+        RulesFilter instance = filter.withTotals(true);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("include_totals", (Object) true));
+    }
+
+    @Test
+    public void shouldFilterByPage() throws Exception {
+        RulesFilter instance = filter.withPage(15, 50);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("page", (Object) 15));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("per_page", (Object) 50));
+    }
 }

--- a/src/test/resources/mgmt/client_grants_paged_list.json
+++ b/src/test/resources/mgmt/client_grants_paged_list.json
@@ -1,0 +1,26 @@
+{
+  "start": 0,
+  "length": 14,
+  "total": 14,
+  "limit": 50,
+  "client_grants": [
+    {
+      "id": "1",
+      "client_id": "clientId1",
+      "audience": "audience1",
+      "scope": [
+        "openid",
+        "profile"
+      ]
+    },
+    {
+      "id": "2",
+      "client_id": "clientId2",
+      "audience": "audience2",
+      "scope": [
+        "openid",
+        "profile"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mgmt/grants_paged_list.json
+++ b/src/test/resources/mgmt/grants_paged_list.json
@@ -1,0 +1,28 @@
+{
+  "start": 0,
+  "length": 14,
+  "total": 14,
+  "limit": 50,
+  "grants": [
+    {
+      "id": "1",
+      "clientID": "clientId1",
+      "audience": "audience1",
+      "user_id": "userId",
+      "scope": [
+        "openid",
+        "profile"
+      ]
+    },
+    {
+      "id": "2",
+      "clientID": "clientId2",
+      "user_id": "userId",
+      "audience": "audience2",
+      "scope": [
+        "openid",
+        "profile"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mgmt/resource_servers_paged_list.json
+++ b/src/test/resources/mgmt/resource_servers_paged_list.json
@@ -1,0 +1,50 @@
+{
+  "start": 0,
+  "length": 14,
+  "total": 14,
+  "limit": 50,
+  "resource_servers": [
+    {
+      "id": "23445566abab",
+      "name": "Some API",
+      "identifier": "https://api.my-company.com/api/v2/",
+      "signing_alg": "RS256",
+      "token_lifetime": 86400,
+      "token_lifetime_for_web": 7200,
+      "allow_offline_access": false,
+      "skip_consent_for_verifiable_first_party_clients": false,
+      "scopes": [
+        {
+          "description": "Read Client Grants",
+          "value": "read:client_grants"
+        },
+        {
+          "description": "Create Client Grants",
+          "value": "create:client_grants"
+        }
+      ],
+      "is_system": true
+    },
+    {
+      "id": "3223232da",
+      "name": "Another API",
+      "identifier": "https://another-api.my-company.com/api/v2/",
+      "signing_alg": "RS256",
+      "token_lifetime": 86400,
+      "token_lifetime_for_web": 7200,
+      "allow_offline_access": false,
+      "skip_consent_for_verifiable_first_party_clients": false,
+      "scopes": [
+        {
+          "description": "Read Client Grants",
+          "value": "read:client_grants"
+        },
+        {
+          "description": "Create Client Grants",
+          "value": "create:client_grants"
+        }
+      ],
+      "is_system": true
+    }
+  ]
+}

--- a/src/test/resources/mgmt/rules_paged_list.json
+++ b/src/test/resources/mgmt/rules_paged_list.json
@@ -1,0 +1,24 @@
+{
+  "start": 0,
+  "length": 14,
+  "total": 14,
+  "limit": 50,
+  "rules": [
+    {
+      "name": "rule_1",
+      "id": "con_0000000000000001",
+      "enabled": true,
+      "script": "function (user, context, callback) {\n  callback(null, user, context);\n}",
+      "order": 1,
+      "stage": "login_success"
+    },
+    {
+      "name": "rule_2",
+      "id": "con_0000000000000002",
+      "enabled": true,
+      "script": "function (user, context, callback) {\n  callback(null, user, context);\n}",
+      "order": 1,
+      "stage": "login_success"
+    }
+  ]
+}


### PR DESCRIPTION
### What
This PR adds pagination support on MGMT API entities that were missing.

### Scope
- [x] Client Grants 
- [x] Grants
- [x] Resource Servers 
- [x] Rules


#### Discussion

Since the Rules entity already was accepting a Filter as part of the call params, and no other param is required I am forced to create a new method (because the returned type change). This looks odd since the accepted call params are equally the same to the existing `list` method. If you look carefully, what changes between this one and the rest of the entities is that now I added a `listAll` method to handle pagination on Rules


### Pending items
Deprecate the old `list` methods without pagination.

### Closed Issues
Closes #126 

### Related Issues
Related #134