### PR TITLE
Allow to set search_engine version

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/QueryFilter.java
@@ -10,7 +10,7 @@ public class QueryFilter extends FieldsFilter {
     /**
      * Filter by a query
      *
-     * @param query the query expression using the following syntax https://auth0.com/docs/api/management/v2/query-string-syntax.
+     * @param query the query expression to use
      * @return this filter instance
      */
     public QueryFilter withQuery(String query) {
@@ -65,7 +65,7 @@ public class QueryFilter extends FieldsFilter {
         super.withFields(fields, includeFields);
         return this;
     }
-    
+
     //Visible for testing
     String urlEncode(String query) throws UnsupportedEncodingException {
         return URLEncoder.encode(query, "UTF-8");

--- a/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
@@ -7,9 +7,13 @@ public class UserFilter extends QueryFilter {
 
     /**
      * Creates a new instance using the search engine 'v2'.
+     * <p>
+     * This version of the search engine is now deprecated and will stop working on November 13th 2018.
+     * Please, migrate as soon as possible and use the {@link #withSearchEngine(String)} method to specify version 'v3'.
+     * See the migration guide at https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3
      */
     public UserFilter() {
-        parameters.put("search_engine", "v2");
+        withSearchEngine("v2");
     }
 
     @Override
@@ -18,6 +22,26 @@ public class UserFilter extends QueryFilter {
         return this;
     }
 
+    /**
+     * Selects which Search Engine version to use.
+     * <p>
+     * Version 2 is now deprecated and will stop working on November 13th 2018. Please, migrate as soon as possible to 'v3'.
+     * See the migration guide at https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3
+     *
+     * @param searchEngineVersion the search engine version to use on queries.
+     * @return this filter instance
+     */
+    public UserFilter withSearchEngine(String searchEngineVersion) {
+        parameters.put("search_engine", searchEngineVersion);
+        return this;
+    }
+
+    /**
+     * Filter by a query
+     *
+     * @param query the query expression to use following the syntax defined at https://auth0.com/docs/users/search/v3/query-syntax
+     * @return this filter instance
+     */
     @Override
     public UserFilter withQuery(String query) {
         super.withQuery(query);

--- a/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
@@ -18,9 +18,18 @@ public class UserFilterTest {
     }
 
     @Test
-    public void shouldUseSearchEngineV2() throws Exception {
+    public void shouldUseSearchEngineV2ByDefault() throws Exception {
         assertThat(filter.getAsMap(), is(notNullValue()));
         assertThat(filter.getAsMap(), Matchers.hasEntry("search_engine", (Object) "v2"));
+    }
+
+    @Test
+    public void shouldSetSearchEngine() throws Exception {
+        UserFilter instance = filter.withSearchEngine("v3");
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("search_engine", (Object) "v3"));
     }
 
     @Test


### PR DESCRIPTION
Since the search_engine v2 is no longer allowed for new tenants and it's going to be shut down on November 13th this year, this PR adds a setter to specify a different value than the default one.

Fixes https://github.com/auth0/auth0-java/issues/133