### PR TITLE
Allow to update the Management API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ ManagementAPI mgmt = new ManagementAPI("{YOUR_DOMAIN}", holder.getAccessToken())
 
 Click [here](https://auth0.com/docs/api/management/v2/tokens) for more information on how to obtain API Tokens.
 
+In the event of token expiration a new one can be set to an existing `ManagementAPI` instance by calling the `setApiToken` method with the new token.
+
+
 The Management API is divided into different entities. Each of them have the list, create, update, delete and update methods plus a few more if corresponds. The calls are authenticated using the API Token given in the `ManagementAPI` instance creation and must contain the `scope` required by each entity. See the javadoc for details on which `scope` is expected for each call.
 
 * **Blacklists:** See [Docs](https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens). Access the methods by calling `mgmt.blacklists()`.

--- a/README.md
+++ b/README.md
@@ -264,11 +264,11 @@ TokenHolder holder = authRequest.execute();
 ManagementAPI mgmt = new ManagementAPI("{YOUR_DOMAIN}", holder.getAccessToken());
 ```
 
-(Note that the simplified should have error handling, and ideally cache the obtained token until it expires instead of requesting one access token for each Management API v2 invocation).
+(Note that the snippet above should have error handling, and ideally cache the obtained token until it expires instead of requesting one access token for each Management API v2 invocation). 
+
+An expired token for an existing `ManagementAPI` instance can be replaced by calling the `setApiToken` method with the new token.
 
 Click [here](https://auth0.com/docs/api/management/v2/tokens) for more information on how to obtain API Tokens.
-
-In the event of token expiration a new one can be set to an existing `ManagementAPI` instance by calling the `setApiToken` method with the new token.
 
 
 The Management API is divided into different entities. Each of them have the list, create, update, delete and update methods plus a few more if corresponds. The calls are authenticated using the API Token given in the `ManagementAPI` instance creation and must contain the `scope` required by each entity. See the javadoc for details on which `scope` is expected for each call.

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -15,16 +15,17 @@ import okhttp3.logging.HttpLoggingInterceptor.Level;
 public class ManagementAPI {
 
     private final HttpUrl baseUrl;
-    private final String apiToken;
+    private String apiToken;
     private final OkHttpClient client;
     private final TelemetryInterceptor telemetry;
     private final HttpLoggingInterceptor logging;
 
     /**
      * Create an instance with the given tenant's domain and API token.
+     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens to learn how to obtain a token.
      *
      * @param domain   the tenant's domain.
-     * @param apiToken the token to authenticate the calls with. See the "Getting an API token" section to learn how to obtain a token.
+     * @param apiToken the token to authenticate the calls with.
      */
     public ManagementAPI(String domain, String apiToken) {
         Asserts.assertNotNull(domain, "domain");
@@ -43,6 +44,18 @@ public class ManagementAPI {
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
                 .build();
+    }
+
+    /**
+     * Update the API token to use on new calls. This is useful when the token is about to expire or it already has.
+     * Please note you'll need to obtain the correspondent entity again for this to apply. e.g. call {@link #clients()} again.
+     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens to learn how to obtain a token.
+     *
+     * @param apiToken the token to authenticate the calls with.
+     */
+    public void setApiToken(String apiToken) {
+        Asserts.assertNotNull(apiToken, "api token");
+        this.apiToken = apiToken;
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -47,8 +47,8 @@ public class ManagementAPI {
     }
 
     /**
-     * Update the API token to use on new calls. This is useful when the token is about to expire or it already has.
-     * Please note you'll need to obtain the correspondent entity again for this to apply. e.g. call {@link #clients()} again.
+     * Update the API token to use on new calls. This is useful when the token is about to expire or already has.
+     * Please note you'll need to obtain the corresponding entity again for this to apply. e.g. call {@link #clients()} again.
      * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens to learn how to obtain a token.
      *
      * @param apiToken the token to authenticate the calls with.

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -17,15 +17,10 @@ import java.util.Map;
 /**
  * Class that provides an implementation of the Resource Server methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Resource_Servers
  */
-public class ResourceServerEntity {
-    private OkHttpClient client;
-    private HttpUrl baseUrl;
-    private String apiToken;
+public class ResourceServerEntity extends BaseManagementEntity {
 
     ResourceServerEntity(OkHttpClient client, HttpUrl baseUrl, String apiToken) {
-        this.client = client;
-        this.baseUrl = baseUrl;
-        this.apiToken = apiToken;
+        super(client, baseUrl, apiToken);
     }
 
     /**

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -76,6 +76,60 @@ public class ManagementAPITest {
     }
 
     @Test
+    public void shouldThrowOnUpdateWhenApiTokenIsNull() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'api token' cannot be null!");
+        new ManagementAPI(DOMAIN, null);
+    }
+
+    @Test
+    public void shouldUpdateApiToken() throws Exception {
+        //Initialize with a token
+        ManagementAPI api = new ManagementAPI(DOMAIN, "first token");
+
+        assertThat(api.blacklists().apiToken, is("first token"));
+        assertThat(api.clientGrants().apiToken, is("first token"));
+        assertThat(api.clients().apiToken, is("first token"));
+        assertThat(api.connections().apiToken, is("first token"));
+        assertThat(api.deviceCredentials().apiToken, is("first token"));
+        assertThat(api.emailProvider().apiToken, is("first token"));
+        assertThat(api.emailTemplates().apiToken, is("first token"));
+        assertThat(api.grants().apiToken, is("first token"));
+        assertThat(api.guardian().apiToken, is("first token"));
+        assertThat(api.jobs().apiToken, is("first token"));
+        assertThat(api.logEvents().apiToken, is("first token"));
+        assertThat(api.resourceServers().apiToken, is("first token"));
+        assertThat(api.rules().apiToken, is("first token"));
+        assertThat(api.stats().apiToken, is("first token"));
+        assertThat(api.tenants().apiToken, is("first token"));
+        assertThat(api.tickets().apiToken, is("first token"));
+        assertThat(api.userBlocks().apiToken, is("first token"));
+        assertThat(api.users().apiToken, is("first token"));
+
+        //Update the token
+        api.setApiToken("new token");
+
+        assertThat(api.blacklists().apiToken, is("new token"));
+        assertThat(api.clientGrants().apiToken, is("new token"));
+        assertThat(api.clients().apiToken, is("new token"));
+        assertThat(api.connections().apiToken, is("new token"));
+        assertThat(api.deviceCredentials().apiToken, is("new token"));
+        assertThat(api.emailProvider().apiToken, is("new token"));
+        assertThat(api.emailTemplates().apiToken, is("new token"));
+        assertThat(api.grants().apiToken, is("new token"));
+        assertThat(api.guardian().apiToken, is("new token"));
+        assertThat(api.jobs().apiToken, is("new token"));
+        assertThat(api.logEvents().apiToken, is("new token"));
+        assertThat(api.resourceServers().apiToken, is("new token"));
+        assertThat(api.rules().apiToken, is("new token"));
+        assertThat(api.stats().apiToken, is("new token"));
+        assertThat(api.tenants().apiToken, is("new token"));
+        assertThat(api.tickets().apiToken, is("new token"));
+        assertThat(api.userBlocks().apiToken, is("new token"));
+        assertThat(api.users().apiToken, is("new token"));
+    }
+
+    @Test
     public void shouldAddAndEnableTelemetryInterceptor() throws Exception {
         ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
         assertThat(api.getClient().interceptors(), hasItem(isA(TelemetryInterceptor.class)));

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -77,9 +77,11 @@ public class ManagementAPITest {
 
     @Test
     public void shouldThrowOnUpdateWhenApiTokenIsNull() throws Exception {
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
+
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'api token' cannot be null!");
-        new ManagementAPI(DOMAIN, null);
+        api.setApiToken(null);
     }
 
     @Test


### PR DESCRIPTION
As I wrote this I thought that good alternative would be to have a function with a callback the user can implement their own logic in. So they can code a token refresher and feed that instead. 

Fixes: https://github.com/auth0/auth0-java/issues/131