### PR TITLE
Add web_origins attribute to the Client class

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -268,7 +268,7 @@ public class Client {
      *
      * @param webOrigins the web origins to set.
      */
-    @JsonProperty("allowed_origins")
+    @JsonProperty("web_origins")
     public void setWebOrigins(List<String> webOrigins) {
         this.webOrigins = webOrigins;
     }
@@ -278,7 +278,7 @@ public class Client {
      *
      * @return the list of web origins.
      */
-    @JsonProperty("allowed_origins")
+    @JsonProperty("web_origins")
     public List<String> getWebOrigins() {
         return webOrigins;
     }

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -36,6 +36,8 @@ public class Client {
     private List<String> callbacks;
     @JsonProperty("allowed_origins")
     private List<String> allowedOrigins;
+    @JsonProperty("web_origins")
+    private List<String> webOrigins;
     @JsonProperty("client_aliases")
     private List<String> clientAliases;
     @JsonProperty("allowed_clients")
@@ -260,6 +262,27 @@ public class Client {
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
     }
+
+    /**
+     * Setter for the list of web origins for the application.
+     *
+     * @param webOrigins the web origins to set.
+     */
+    @JsonProperty("allowed_origins")
+    public void setWebOrigins(List<String> webOrigins) {
+        this.webOrigins = webOrigins;
+    }
+
+    /**
+     * Getter for the list of web origins for the application.
+     *
+     * @return the list of web origins.
+     */
+    @JsonProperty("allowed_origins")
+    public List<String> getWebOrigins() {
+        return webOrigins;
+    }
+
 
     /**
      * Getter for the list of application aliases.

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.*;
 
 public class ClientTest extends JsonTest<Client> {
 
-    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
     private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_first_party\":true,\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
+    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -30,6 +30,7 @@ public class ClientTest extends JsonTest<Client> {
         List<String> stringList = Collections.singletonList("value");
         client.setCallbacks(stringList);
         client.setAllowedOrigins(stringList);
+        client.setWebOrigins(stringList);
         client.setClientAliases(stringList);
         client.setAllowedClients(stringList);
         client.setAllowedLogoutUrls(stringList);
@@ -93,6 +94,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.isOIDCConformant(), is(true));
 
         assertThat(client.getCallbacks(), contains("value"));
+        assertThat(client.getWebOrigins(), contains("value"));
         assertThat(client.getAllowedOrigins(), contains("value"));
         assertThat(client.getClientAliases(), contains("value"));
         assertThat(client.getAllowedClients(), contains("value"));


### PR DESCRIPTION
This attribute was missing from the SDK. Added to the Auth0 MGMT API on the CORS auth update.