### PR TITLE
Support HTTP Proxy : fixes #91

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -47,6 +47,18 @@ public class AuthAPI {
      * @param clientSecret the application's client secret.
      */
     public AuthAPI(String domain, String clientId, String clientSecret) {
+        this(domain, clientId, clientSecret, new OkHttpClient.Builder());
+    }
+
+    /**
+     * Create a new instance with the given tenant's domain, application's client id and client secret. These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
+     *
+     * @param domain       tenant's domain.
+     * @param clientId     the application's client id.
+     * @param clientSecret the application's client secret.
+     * @param okhttpBuilder the {@link OkHttpClient.Builder} used to construct an {@link OkHttpClient} instance.
+     */
+    public AuthAPI(String domain, String clientId, String clientSecret, OkHttpClient.Builder okhttpBuilder) {
         Asserts.assertNotNull(domain, "domain");
         Asserts.assertNotNull(clientId, "client id");
         Asserts.assertNotNull(clientSecret, "client secret");
@@ -61,7 +73,7 @@ public class AuthAPI {
         telemetry = new TelemetryInterceptor();
         logging = new HttpLoggingInterceptor();
         logging.setLevel(Level.NONE);
-        client = new OkHttpClient.Builder()
+        this.client = okhttpBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
                 .build();

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -28,6 +28,18 @@ public class ManagementAPI {
      * @param apiToken the token to authenticate the calls with.
      */
     public ManagementAPI(String domain, String apiToken) {
+        this(domain, apiToken, new OkHttpClient.Builder());
+    }
+
+    /**
+     * Create an instance with the given tenant's domain and API token.
+     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens to learn how to obtain a token.
+     *
+     * @param domain   the tenant's domain.
+     * @param apiToken the token to authenticate the calls with.
+     * @param okhttpBuilder the {@link OkHttpClient.Builder} used to construct an {@link OkHttpClient} instance.
+     */
+    public ManagementAPI(String domain, String apiToken, OkHttpClient.Builder okhttpBuilder) {
         Asserts.assertNotNull(domain, "domain");
         Asserts.assertNotNull(apiToken, "api token");
 
@@ -40,7 +52,7 @@ public class ManagementAPI {
         telemetry = new TelemetryInterceptor();
         logging = new HttpLoggingInterceptor();
         logging.setLevel(Level.NONE);
-        client = new OkHttpClient.Builder()
+        this.client = okhttpBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
                 .build();


### PR DESCRIPTION
Adds constructors to pass instances of java.net.Proxy and java.net.PasswordAuthentication to ManagementAPI and AuthAPI.