### PR TITLE
Add support for bulk user exports

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -1,14 +1,17 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.json.mgmt.jobs.Job;
+import com.auth0.json.mgmt.jobs.UsersExport;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
+import com.auth0.net.StatusCodeRequest;
 import com.auth0.utils.Asserts;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -23,7 +26,7 @@ public class JobsEntity extends BaseManagementEntity {
 
     /**
      * Sends an Email Verification. A token with scope update:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email
+     * See <a href=https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email>Post Verification Email</a>
      *
      * @param userId The user_id of the user to whom the email will be sent.
      * @param clientId The id of the client, if not provided the global one will be used.
@@ -32,22 +35,116 @@ public class JobsEntity extends BaseManagementEntity {
     public Request<Job> sendVerificationEmail(String userId, String clientId) {
         Asserts.assertNotNull(userId, "user id");
 
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/jobs/verification-email")
-                .build()
-                .toString();
+        final String url = this.generateUrl("api/v2/jobs/verification-email");
 
-        Map<String, String> requestBody = new HashMap<>();
+        final Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("user_id", userId);
-        if (clientId != null && !clientId.isEmpty()) {
+        if (this.isValued(clientId)) {
             requestBody.put("client_id", clientId);
         }
 
-        CustomRequest<Job> request = new CustomRequest<>(client, url, "POST", new TypeReference<Job>() {
-        });
+        return this.generatePostRequest(url, requestBody);
+    }
+
+    /**
+     * Generates a job request to produce a long-running user export job.
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports">Post Users Exports</a>
+     *
+     * @return A request to execute the job.
+     */
+    public Request<Job> exportUsers() { return this.exportUsers(new UsersExport()); }
+
+    /**
+     * Generates a job request to produce a long-running user export job.
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports">Post Users Exports</a>
+     *
+     * @param usersExport Object containing the parameters by which the user export job will be run.
+     * @return A request to execute the job.
+     */
+    public Request<Job> exportUsers(final UsersExport usersExport) {
+        Asserts.assertNotNull(usersExport, "usersExport");
+
+        final String url = this.generateUrl("api/v2/jobs/users-exports");
+
+        final Map<String, Object> requestBody = new HashMap<>();
+        final String connectionId = usersExport.getConnectionId();
+        final String format = usersExport.getFormat();
+        final int limit = usersExport.getLimit();
+        final List<List<Map<String, String>>> fields = usersExport.getFields();
+
+        if (this.isValued(connectionId)) {
+            requestBody.put("connection_id", connectionId);
+        }
+
+        if (this.isValued(format)) {
+            requestBody.put("format", format);
+        }
+
+        if (limit != 0) {
+            requestBody.put("limit", Integer.toString(limit));
+        }
+
+        if ((fields != null) && (fields.size() > 0)) {
+            requestBody.put("fields", fields);
+        }
+
+        return this.generatePostRequest(url, requestBody);
+    }
+
+    /**
+     * Generates a request to get a job.  Useful to check its status.
+     * @see <a href="https://auth0.com/docs/api/management/v2/#!/Jobs/get_results">Get a Job</a>
+     *
+     * @param jobId Id of the job to be retrieved
+     * @return A request to execute the job details retrieval.
+     */
+    public Request<Job> getJob(final String jobId) {
+        Asserts.assertNotNull(jobId, "jobId");
+        final String url = this.generateUrl(String.format("api/v2/jobs/%s", jobId));
+        return this.generateJobRequest(url);
+    }
+
+    /**
+     * Generates a request to get the details of failed a job.
+     * @see <a href="https://auth0.com/docs/api/management/v2/#!/Jobs/get_errors">Get Job Error Details</a>
+     *
+     * @param jobId Id of the job error details to be retrieved
+     * @return A request to execute the job error details retrieval.
+     */
+    public StatusCodeRequest getJobError(final String jobId) {
+        Asserts.assertNotNull(jobId, "jobId");
+        final String url = this.generateUrl(String.format("api/v2/jobs/%s/errors", jobId));
+        return this.generateJobErrorRequest(url);
+    }
+
+    private String generateUrl(final String restEndpoint) {
+        return baseUrl
+                .newBuilder()
+                .addPathSegments(restEndpoint)
+                .build()
+                .toString();
+    }
+
+    private boolean isValued(final String string) {
+        return (string != null) && (!string.isEmpty());
+    }
+
+    private CustomRequest<Job> generatePostRequest(final String url, final Map<String, Object> requestBody) {
+        final CustomRequest<Job> request = new CustomRequest<>(client, url, "POST", new TypeReference<Job>() {});
         request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(requestBody);
+        return request;
+    }
+
+    private CustomRequest<Job> generateJobRequest(final String url) {
+        final CustomRequest<Job> request = new CustomRequest<>(client, url, "GET", new TypeReference<Job>() {});
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    private StatusCodeRequest generateJobErrorRequest(final String url) {
+        final StatusCodeRequest request = new StatusCodeRequest(client, url);
+        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/jobs/Job.java
+++ b/src/main/java/com/auth0/json/mgmt/jobs/Job.java
@@ -1,6 +1,10 @@
 package com.auth0.json.mgmt.jobs;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
 
@@ -21,6 +25,14 @@ public class Job {
     private Date createdAt;
     @JsonProperty("id")
     private String id;
+    @JsonProperty("connection_id")
+    private String connectionId;
+    @JsonProperty("location")
+    private String location;
+    @JsonProperty("percentage_done")
+    private Integer percentageDone;
+    @JsonProperty("time_left_seconds")
+    private Integer timeLeftSeconds;
 
     @JsonCreator
     private Job(@JsonProperty("status") String status, @JsonProperty("type") String type, @JsonProperty("id") String id) {
@@ -48,5 +60,40 @@ public class Job {
     @JsonProperty("id")
     public String getId() {
         return id;
+    }
+
+    @JsonProperty("connection_id")
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    @JsonProperty("location")
+    public String getLocation() {
+        return location;
+    }
+
+    @JsonProperty("location")
+    public void setLocation(final String location) {
+        this.location = location;
+    }
+
+    @JsonProperty("percentage_done")
+    public Integer getPercentageDone() {
+        return percentageDone;
+    }
+
+    @JsonProperty("percentage_done")
+    public void setPercentageDone(final Integer percentageDone) {
+        this.percentageDone = percentageDone;
+    }
+
+    @JsonProperty("time_left_seconds")
+    public Integer getTimeLeftSeconds() {
+        return timeLeftSeconds;
+    }
+
+    @JsonProperty("time_left_seconds")
+    public void setTimeLeftSeconds(final Integer timeLeftSeconds) {
+        this.timeLeftSeconds = timeLeftSeconds;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/jobs/JobError.java
+++ b/src/main/java/com/auth0/json/mgmt/jobs/JobError.java
@@ -1,0 +1,36 @@
+package com.auth0.json.mgmt.jobs;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents an Auth0 Job Error object. Related to the {@link com.auth0.client.mgmt.JobsEntity} entity.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JobError {
+
+    @JsonProperty("statusCode")
+    private Integer statusCode;
+    @JsonProperty("message")
+    private String message;
+
+    @JsonCreator
+    public JobError(@JsonProperty("statusCode") Integer statusCode, @JsonProperty("message") String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    @JsonProperty("statusCode")
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/jobs/UsersExport.java
+++ b/src/main/java/com/auth0/json/mgmt/jobs/UsersExport.java
@@ -1,0 +1,74 @@
+package com.auth0.json.mgmt.jobs;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class that represents an Auth0 Users Export object. Related to the {@link com.auth0.client.mgmt.JobsEntity} entity.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UsersExport {
+
+    @JsonProperty("connection_id")
+    private String connectionId;
+    @JsonProperty("format")
+    private String format;
+    @JsonProperty("limit")
+    private int limit;
+    @JsonProperty("fields")
+    private List<List<Map<String, String>>> fields = null;
+
+    @JsonCreator
+    public UsersExport() {}
+
+    @JsonCreator
+    public UsersExport(
+            @JsonProperty("connection_id") String connectionId,
+            @JsonProperty("format") String format,
+            @JsonProperty("limit") int limit,
+            @JsonProperty("fields") List<List<Map<String, String>>> fields) {
+        this.connectionId = connectionId;
+        this.format = format;
+        this.limit = limit;
+        this.fields = fields;
+    }
+
+    @JsonProperty("connection_id")
+    public String getConnectionId() { return connectionId; }
+
+    @JsonProperty("connection_id")
+    public void setConnectionId(final String connectionId) {
+        this.connectionId = connectionId;
+    }
+
+    @JsonProperty("format")
+    public String getFormat() { return format; }
+
+    @JsonProperty("format")
+    public void setFormat(final String format) {
+        this.format = format;
+    }
+
+    @JsonProperty("limit")
+    public int getLimit() { return limit; }
+
+    @JsonProperty("limit")
+    public void setFields(final List<List<Map<String, String>>> fields) {
+        this.fields = fields;
+    }
+
+    @JsonProperty("fields")
+    public List<List<Map<String, String>>> getFields() { return fields; }
+
+    @JsonProperty("fields")
+    public void setLimit(final int limit) {
+        this.limit = limit;
+    }
+}

--- a/src/main/java/com/auth0/net/StatusCodeRequest.java
+++ b/src/main/java/com/auth0/net/StatusCodeRequest.java
@@ -1,0 +1,38 @@
+package com.auth0.net;
+
+import com.auth0.exception.APIException;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.json.mgmt.jobs.JobError;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+
+public class StatusCodeRequest extends EmptyBodyRequest<JobError> {
+
+    public StatusCodeRequest(final OkHttpClient client, final String url) {
+        super(client, url, "GET", new TypeReference<JobError>() {});
+    }
+
+    @Override
+    protected RequestBody createBody() {
+        return null;
+    }
+
+    @Override
+    protected JobError parseResponse(final Response response) throws Auth0Exception {
+        if (!response.isSuccessful()) {
+            throw createResponseException(response);
+        }
+
+        try (final ResponseBody body = response.body()) {
+            final String payload = body.string();
+            return new JobError(response.code(), payload);
+        } catch (final IOException e) {
+            throw new APIException("Failed to parse response", response.code(), e);
+        }
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -75,6 +75,9 @@ public class MockServer {
     public static final String MGMT_EMAIL_VERIFICATION_TICKET = "src/test/resources/mgmt/email_verification_ticket.json";
     public static final String MGMT_EMPTY_LIST = "src/test/resources/mgmt/empty_list.json";
     public static final String MGMT_JOB_POST_VERIFICATION_EMAIL = "src/test/resources/mgmt/post_verification_email.json";
+    public static final String MGMT_JOB_POST_USERS_EXPORT = "src/test/resources/mgmt/post_users_export.json";
+    public static final String MGMT_JOB_GET = "src/test/resources/mgmt/get_job.json";
+    public static final String MGMT_JOB_ERROR_GET = "src/test/resources/mgmt/get_job_error.json";
 
     private final MockWebServer server;
 

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -1,13 +1,22 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.json.mgmt.jobs.Job;
+import com.auth0.json.mgmt.jobs.JobError;
+import com.auth0.json.mgmt.jobs.UsersExport;
 import com.auth0.net.Request;
+import com.auth0.net.StatusCodeRequest;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
-import static com.auth0.client.MockServer.*;
+import static com.auth0.client.MockServer.MGMT_JOB_GET;
+import static com.auth0.client.MockServer.MGMT_JOB_POST_USERS_EXPORT;
+import static com.auth0.client.MockServer.MGMT_JOB_POST_VERIFICATION_EMAIL;
+import static com.auth0.client.MockServer.bodyFromRequest;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static org.hamcrest.Matchers.hasEntry;
@@ -16,6 +25,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 
 public class JobsEntityTest extends BaseMgmtEntityTest {
+
+    private static final String CONNECTION_ID = "con_0000000000000001";
+    private static final String CSV = "csv";
+    private static final String JOB_ID = "job_0000000000000001";
 
     @Test
     public void shouldSendAUserAVerificationEmail() throws Exception {
@@ -32,7 +45,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
         assertThat(body.size(), is(1));
-        assertThat(body, hasEntry("user_id", (Object) "google-oauth2|1234"));
+        assertThat(body, hasEntry("user_id", "google-oauth2|1234"));
 
         assertThat(response, is(notNullValue()));
     }
@@ -63,5 +76,157 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'user id' cannot be null!");
         api.jobs().sendVerificationEmail(null, null);
+    }
+
+    @Test
+    public void shouldRequestUsersExport() throws Exception {
+        final List<List<Map<String, String>>> fields = Collections.singletonList(new ArrayList<Map<String, String>>() {{
+            add(Collections.singletonMap("name", "user_id"));
+        }});
+
+        final UsersExport usersExport = new UsersExport(
+                CONNECTION_ID,
+                CSV,
+                5,
+                fields
+        );
+
+        final Request<Job> request = api.jobs().exportUsers(usersExport);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORT, 200);
+        final Job response = request.execute();
+        final RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        final Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(4));
+        assertThat(body, hasEntry("connection_id", CONNECTION_ID));
+        assertThat(body, hasEntry("format", CSV));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldRequestUsersExportWithEmptyFields() throws Exception {
+        final List<List<Map<String, String>>> fields = Collections.singletonList(new ArrayList<>());
+        final UsersExport usersExport = new UsersExport(
+                CONNECTION_ID,
+                "",
+                5,
+                fields
+        );
+
+        final Request<Job> request = api.jobs().exportUsers(usersExport);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORT, 200);
+        final Job response = request.execute();
+        final RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        final Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(3));
+        assertThat(body, hasEntry("connection_id", CONNECTION_ID));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldRequestUsersExportWithNullFields() throws Exception {
+        final UsersExport usersExport = new UsersExport(
+                CONNECTION_ID,
+                CSV,
+                5,
+                null
+        );
+
+        final Request<Job> request = api.jobs().exportUsers(usersExport);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORT, 200);
+        final Job response = request.execute();
+        final RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        final Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(3));
+        assertThat(body, hasEntry("connection_id", CONNECTION_ID));
+        assertThat(body, hasEntry("format", CSV));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldRequestUsersExportWithoutUsersExportObject() throws Exception {
+        final Request<Job> request = api.jobs().exportUsers();
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORT, 200);
+        final Job response = request.execute();
+        final RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        final Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(0));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnNullUsersExport() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'usersExport' cannot be null!");
+        api.jobs().exportUsers(null);
+    }
+
+    @Test
+    public void shouldGetJob() throws Exception {
+        final Request<Job> request = api.jobs().getJob(JOB_ID);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_GET, 200);
+        final Job response = request.execute();
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getStatus(), is("pending"));
+    }
+
+    @Test
+    public void getJobShouldThrowOnNullJobId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'jobId' cannot be null!");
+        api.jobs().getJob(null);
+    }
+
+    @Test
+    public void shouldGetJobError() throws Exception {
+        final StatusCodeRequest request = api.jobs().getJobError(JOB_ID);
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+
+        final JobError jobError = request.execute();
+        assertThat(jobError.getStatusCode(), is(204));
+
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest, hasMethodAndPath("GET", String.format("/api/v2/jobs/%s/errors", JOB_ID)));
+    }
+
+    @Test
+    public void getJobErrorShouldThrowOnNullJobId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'jobId' cannot be null!");
+        api.jobs().getJobError(null);
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/jobs/JobErrorTest.java
+++ b/src/test/java/com/auth0/json/mgmt/jobs/JobErrorTest.java
@@ -1,0 +1,22 @@
+package com.auth0.json.mgmt.jobs;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class JobErrorTest extends JsonTest<JobError> {
+
+    private static final String json = "{\"statusCode\": 401, \"message\": \"Missing authentication\"}";
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        JobError job = fromJSON(json, JobError.class);
+
+        assertThat(job, is(notNullValue()));
+        assertThat(job.getStatusCode(), is(401));
+        assertThat(job.getMessage(), is("Missing authentication"));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/jobs/JobTest.java
+++ b/src/test/java/com/auth0/json/mgmt/jobs/JobTest.java
@@ -21,4 +21,21 @@ public class JobTest extends JsonTest<Job> {
         assertThat(job.getType(), is("verification_email"));
         assertThat(job.getCreatedAt(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
     }
+
+    @Test
+    public void shouldSetValues() throws Exception {
+        Job job = fromJSON(json, Job.class);
+        job.setLocation("https://test.auth0.com/mock_endpoint.gz");
+        job.setPercentageDone(100);
+        job.setTimeLeftSeconds(0);
+
+        assertThat(job, is(notNullValue()));
+        assertThat(job.getId(), is("job_0000000000000001"));
+        assertThat(job.getStatus(), is("completed"));
+        assertThat(job.getType(), is("verification_email"));
+        assertThat(job.getCreatedAt(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
+        assertThat(job.getLocation(), is("https://test.auth0.com/mock_endpoint.gz"));
+        assertThat(job.getPercentageDone(), is(100));
+        assertThat(job.getTimeLeftSeconds(), is(0));
+    }
 }

--- a/src/test/java/com/auth0/json/mgmt/jobs/UsersExportTest.java
+++ b/src/test/java/com/auth0/json/mgmt/jobs/UsersExportTest.java
@@ -1,0 +1,79 @@
+package com.auth0.json.mgmt.jobs;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class UsersExportTest extends JsonTest<UsersExport> {
+
+    private static final String json = "{\n" +
+            "  \"status\": \"pending\",\n" +
+            "  \"type\": \"users_export\",\n" +
+            "  \"created_at\": \"\",\n" +
+            "  \"id\": \"job_0000000000000001\",\n" +
+            "  \"connection_id\": \"con_0000000000000001\",\n" +
+            "  \"format\": \"csv\",\n" +
+            "  \"limit\": 5,\n" +
+            "  \"fields\": [\n" +
+            "    [\n" +
+            "      {\n" +
+            "        \"name\": \"user_id\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"name\": \"name\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"name\": \"email\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"name\": \"identities[0].connection\",\n" +
+            "        \"export_as\": \"provider\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"name\": \"user_metadata.some_field\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        final UsersExport usersExport = fromJSON(json, UsersExport.class);
+
+        assertThat(usersExport, is(notNullValue()));
+        assertThat(usersExport.getConnectionId(), is("con_0000000000000001"));
+        assertThat(usersExport.getLimit(), is(5));
+        assertThat(usersExport.getFormat(), is("csv"));
+    }
+
+    @Test
+    public void shouldSetValues() throws Exception {
+        final List<List<Map<String, String>>> fields = Collections.singletonList(
+                Collections.singletonList(
+                        new HashMap<String, String>() {{
+                           put("name", "name");
+                        }}
+                )
+        );
+
+        final UsersExport usersExport = new UsersExport();
+        usersExport.setFormat("json");
+        usersExport.setConnectionId("con_0000000000000001");
+        usersExport.setLimit(5);
+        usersExport.setFields(fields);
+
+        assertThat(usersExport, is(notNullValue()));
+        assertThat(usersExport.getConnectionId(), is("con_0000000000000001"));
+        assertThat(usersExport.getLimit(), is(5));
+        assertThat(usersExport.getFormat(), is("json"));
+        assertThat(usersExport.getFields(), is(notNullValue()));
+    }
+}

--- a/src/test/java/com/auth0/net/StatusCodeRequestTest.java
+++ b/src/test/java/com/auth0/net/StatusCodeRequestTest.java
@@ -1,0 +1,87 @@
+package com.auth0.net;
+
+import com.auth0.client.MockServer;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.json.mgmt.jobs.JobError;
+import okhttp3.Call;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+import static com.auth0.client.MockServer.AUTH_TOKENS;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StatusCodeRequestTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    private OkHttpClient client;
+    private MockServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new OkHttpClient();
+        server = new MockServer();
+    }
+
+    @Test
+    public void shouldGenerateJobError() throws Exception {
+        StatusCodeRequest request = new StatusCodeRequest(client, this.generateUrl());
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+
+        JobError jobError = request.execute();
+        assertThat(jobError, is(notNullValue()));
+        assertThat(jobError.getStatusCode(), is(204));
+
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod(), is("GET"));
+    }
+
+    @Test
+    public void shouldGenerateExceptionOnError() throws Exception {
+        exception.expect(Auth0Exception.class);
+        StatusCodeRequest request = new StatusCodeRequest(client, this.generateUrl());
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(401);
+        request.execute();
+    }
+
+    @Test
+    public void shouldGenerateExceptionOnRequestFailure() throws Exception {
+        exception.expect(Auth0Exception.class);
+        exception.expectCause(Matchers.<Throwable>instanceOf(IOException.class));
+        exception.expectMessage("Failed to execute request");
+
+        OkHttpClient client = mock(OkHttpClient.class);
+        Call call = mock(Call.class);
+        when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
+        when(call.execute()).thenThrow(IOException.class);
+        StatusCodeRequest request = new StatusCodeRequest(client, server.getBaseUrl());
+        request.execute();
+    }
+
+    private String generateUrl() {
+        return HttpUrl.parse(server.getBaseUrl())
+                .newBuilder()
+                .addPathSegments("api/v2/jobs/job_0000000001/error")
+                .build()
+                .toString();
+
+    }
+}

--- a/src/test/resources/mgmt/get_job.json
+++ b/src/test/resources/mgmt/get_job.json
@@ -1,0 +1,10 @@
+{
+  "status": "pending",
+  "type": "users_export",
+  "created_at": "",
+  "id": "job_0000000000000001",
+  "connection_id": "con_0000000000000001",
+  "location": "",
+  "percentage_done": 0,
+  "time_left_seconds": 0
+}

--- a/src/test/resources/mgmt/get_job_error.json
+++ b/src/test/resources/mgmt/get_job_error.json
@@ -1,0 +1,5 @@
+{
+  "statusCode": 401,
+  "error": "unauthorized",
+  "message": "Missing authentication"
+}

--- a/src/test/resources/mgmt/post_users_export.json
+++ b/src/test/resources/mgmt/post_users_export.json
@@ -1,0 +1,29 @@
+{
+  "status": "completed",
+  "type": "users_export",
+  "created_at": "",
+  "id": "job_0000000000000001",
+  "connection_id": "con_0000000000000001",
+  "format": "csv",
+  "limit": 5,
+  "fields": [
+    [
+      {
+        "name": "user_id"
+      },
+      {
+        "name": "name"
+      },
+      {
+        "name": "email"
+      },
+      {
+        "name": "identities[0].connection",
+        "export_as": "provider"
+      },
+      {
+        "name": "user_metadata.some_field"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
This commit adds the ability to create bulk user exports.  With this
update, a new request type of `StatusCodeRequest` was added in order to
handle queries against the `job_error` endpoint which report the error
result of a given job.

Please note:  With this change, consumers of the API will be responsible
for fetching and decompressing the `gzip` file produced from the job
request via the URL provided in the response.