### PR TITLE
support to retrieve rate limits values from response headers #99

### DIFF
--- a/src/main/java/com/auth0/exception/RateLimitException.java
+++ b/src/main/java/com/auth0/exception/RateLimitException.java
@@ -6,7 +6,7 @@ package com.auth0.exception;
  * Getters for {@code limit, remaining} and {@code reset} corresponds to {@code X-RateLimit-Limit, X-RateLimit-Remaining} and {@code X-RateLimit-Reset} HTTP headers.
  * If the value of any headers is missing, then a default value -1 will assigned.
  * <p>
- * "To learn more about rate limits, visit <a href="https://auth0.com/docs/policies/rate-limits">https://auth0.com/docs/policies/rate-limits</a>
+ * To learn more about rate limits, visit <a href="https://auth0.com/docs/policies/rate-limits">https://auth0.com/docs/policies/rate-limits</a>
  */
 public class RateLimitException extends APIException {
 
@@ -25,7 +25,7 @@ public class RateLimitException extends APIException {
 
     /**
      * Getter for the maximum number of requests available in the current time frame.
-     * @return The maximun number of requests.
+     * @return The maximum number of requests or -1 if missing.
      */
     public long getLimit() {
         return limit;
@@ -33,7 +33,7 @@ public class RateLimitException extends APIException {
 
     /**
      * Getter for the number of remaining requests in the current time frame.
-     * @return Number of remaining requests.
+     * @return Number of remaining requests or -1 if missing.
      */
     public long getRemaining() {
         return remaining;
@@ -41,7 +41,7 @@ public class RateLimitException extends APIException {
 
     /**
      * Getter for the UNIX timestamp of the expected time when the rate limit will reset.
-     * @return The UNIX timestamp.
+     * @return The UNIX timestamp or -1 if missing.
      */
     public long getReset() {
         return reset;

--- a/src/main/java/com/auth0/exception/RateLimitException.java
+++ b/src/main/java/com/auth0/exception/RateLimitException.java
@@ -2,6 +2,11 @@ package com.auth0.exception;
 
 /**
  * Represents a server error when a rate limit has been exceeded.
+ * <p>
+ * Getters for {@code limit, remaining} and {@code reset} corresponds to {@code X-RateLimit-Limit, X-RateLimit-Remaining} and {@code X-RateLimit-Reset} HTTP headers.
+ * If the value of any headers is missing, then a default value -1 will assigned.
+ * <p>
+ * "To learn more about rate limits, visit <a href="https://auth0.com/docs/policies/rate-limits">https://auth0.com/docs/policies/rate-limits</a>
  */
 public class RateLimitException extends APIException {
 
@@ -9,21 +14,35 @@ public class RateLimitException extends APIException {
     private final long remaining;
     private final long reset;
 
-    public RateLimitException(long limit, long remaining, long reset, String message) {
-        super(message, 429, null);
+    private static final int STATUS_CODE_TOO_MANY_REQUEST = 429;
+
+    public RateLimitException(long limit, long remaining, long reset) {
+        super("Rate limit reached", STATUS_CODE_TOO_MANY_REQUEST, null);
         this.limit = limit;
         this.remaining = remaining;
         this.reset = reset;
     }
 
+    /**
+     * Getter for the maximum number of requests available in the current time frame.
+     * @return The maximun number of requests.
+     */
     public long getLimit() {
         return limit;
     }
 
+    /**
+     * Getter for the number of remaining requests in the current time frame.
+     * @return Number of remaining requests.
+     */
     public long getRemaining() {
         return remaining;
     }
 
+    /**
+     * Getter for the UNIX timestamp of the expected time when the rate limit will reset.
+     * @return The UNIX timestamp.
+     */
     public long getReset() {
         return reset;
     }

--- a/src/main/java/com/auth0/exception/RateLimitException.java
+++ b/src/main/java/com/auth0/exception/RateLimitException.java
@@ -1,0 +1,31 @@
+package com.auth0.exception;
+
+/**
+ * Represents a server error when a rate limit has been exceeded.
+ */
+public class RateLimitException extends APIException {
+
+    private final long limit;
+    private final long remaining;
+    private final long reset;
+
+    public RateLimitException(long limit, long remaining, long reset, String message) {
+        super(message, 429, null);
+        this.limit = limit;
+        this.remaining = remaining;
+        this.reset = reset;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    public long getRemaining() {
+        return remaining;
+    }
+
+    public long getReset() {
+        return reset;
+    }
+
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -10,7 +10,6 @@ import okio.Buffer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -109,11 +108,12 @@ public class MockServer {
         server.enqueue(response);
     }
     
-    public void rateLimitResponse() throws IOException {
+    public void rateLimitReachedResponse(long limit, long remaining, long reset) throws IOException {
         MockResponse response = new MockResponse()
                 .setResponseCode(429)
-                .addHeader("X-RateLimit-Limit", "100")
-                .addHeader("X-RateLimit-Remaining", "10");
+                .addHeader("X-RateLimit-Limit", String.valueOf(limit))
+                .addHeader("X-RateLimit-Remaining", String.valueOf(remaining))
+                .addHeader("X-RateLimit-Reset", String.valueOf(reset));
         server.enqueue(response);
     }
 

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -10,6 +10,7 @@ import okio.Buffer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -105,6 +106,14 @@ public class MockServer {
                 .setResponseCode(statusCode)
                 .addHeader("Content-Type", "application/json")
                 .setBody(readTextFile(path));
+        server.enqueue(response);
+    }
+    
+    public void rateLimitResponse() throws IOException {
+        MockResponse response = new MockResponse()
+                .setResponseCode(429)
+                .addHeader("X-RateLimit-Limit", "100")
+                .addHeader("X-RateLimit-Remaining", "10");
         server.enqueue(response);
     }
 

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -76,7 +76,6 @@ public class MockServer {
     public static final String MGMT_EMPTY_LIST = "src/test/resources/mgmt/empty_list.json";
     public static final String MGMT_JOB_POST_VERIFICATION_EMAIL = "src/test/resources/mgmt/post_verification_email.json";
 
-
     private final MockWebServer server;
 
     public MockServer() throws Exception {
@@ -107,13 +106,18 @@ public class MockServer {
                 .setBody(readTextFile(path));
         server.enqueue(response);
     }
-    
+
     public void rateLimitReachedResponse(long limit, long remaining, long reset) throws IOException {
-        MockResponse response = new MockResponse()
-                .setResponseCode(429)
-                .addHeader("X-RateLimit-Limit", String.valueOf(limit))
-                .addHeader("X-RateLimit-Remaining", String.valueOf(remaining))
-                .addHeader("X-RateLimit-Reset", String.valueOf(reset));
+        MockResponse response = new MockResponse().setResponseCode(429);
+        if (limit != -1) {
+            response.addHeader("X-RateLimit-Limit", String.valueOf(limit));
+        }
+        if (remaining != -1) {
+            response.addHeader("X-RateLimit-Remaining", String.valueOf(remaining));
+        }
+        if (reset != -1) {
+            response.addHeader("X-RateLimit-Reset", String.valueOf(reset));
+        }
         server.enqueue(response);
     }
 

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -306,7 +306,7 @@ public class CustomRequestTest {
     @Test
     public void shouldReceiveRateLimitsResponse() throws Exception {
         CustomRequest<List> request = new CustomRequest<>(client, server.getBaseUrl(), "GET", listType);
-        server.rateLimitResponse();
+        server.rateLimitReachedResponse(100, 10, 5);
         Exception exception = null;
         try {
             request.execute();
@@ -319,16 +319,14 @@ public class CustomRequestTest {
         assertThat(exception, is(instanceOf(RateLimitException.class)));
         assertThat(exception.getCause(), is(nullValue()));
         assertThat(exception.getMessage(), is("Request failed with status code 429: Rate limits reached"));
-        APIException authException = (APIException) exception;
-        assertThat(authException.getDescription(), is("Rate limits reached"));
-        assertThat(authException.getError(), is(nullValue()));
-        assertThat(authException.getValue("non_existing_key"), is(nullValue()));
-        assertThat(authException.getStatusCode(), is(429));
-        
-        RateLimitException rateLimitException = (RateLimitException) authException;
+        RateLimitException rateLimitException = (RateLimitException) exception;
+        assertThat(rateLimitException.getDescription(), is("Rate limits reached"));
+        assertThat(rateLimitException.getError(), is(nullValue()));
+        assertThat(rateLimitException.getValue("non_existing_key"), is(nullValue()));
+        assertThat(rateLimitException.getStatusCode(), is(429));
         assertThat(rateLimitException.getLimit(), is(100L));
         assertThat(rateLimitException.getRemaining(), is(10L));
-        assertThat(rateLimitException.getReset(), is(-1L));
+        assertThat(rateLimitException.getReset(), is(5L));
     }
 
 }

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -304,9 +304,9 @@ public class CustomRequestTest {
     }
     
     @Test
-    public void shouldReceiveRateLimitsResponse() throws Exception {
+    public void shouldParseRateLimitsHeaders() throws Exception {
         CustomRequest<List> request = new CustomRequest<>(client, server.getBaseUrl(), "GET", listType);
-        server.rateLimitReachedResponse(100, -1, 5);
+        server.rateLimitReachedResponse(100, 10, 5);
         Exception exception = null;
         try {
             request.execute();
@@ -324,12 +324,12 @@ public class CustomRequestTest {
         assertThat(rateLimitException.getValue("non_existing_key"), is(nullValue()));
         assertThat(rateLimitException.getStatusCode(), is(429));
         assertThat(rateLimitException.getLimit(), is(100L));
-        assertThat(rateLimitException.getRemaining(), is(-1L));
+        assertThat(rateLimitException.getRemaining(), is(10L));
         assertThat(rateLimitException.getReset(), is(5L));
     }
     
     @Test
-    public void shouldReceiveDefaultsRateLimitsResponse() throws Exception {
+    public void shouldDefaultRateLimitsHeadersWhenMissing() throws Exception {
         CustomRequest<List> request = new CustomRequest<>(client, server.getBaseUrl(), "GET", listType);
         server.rateLimitReachedResponse(-1, -1, -1);
         Exception exception = null;

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -315,12 +315,11 @@ public class CustomRequestTest {
             exception = e;
         }
         assertThat(exception, is(notNullValue()));
-        assertThat(exception, is(instanceOf(APIException.class)));
         assertThat(exception, is(instanceOf(RateLimitException.class)));
         assertThat(exception.getCause(), is(nullValue()));
-        assertThat(exception.getMessage(), is("Request failed with status code 429: Rate limits reached"));
+        assertThat(exception.getMessage(), is("Request failed with status code 429: Rate limit reached"));
         RateLimitException rateLimitException = (RateLimitException) exception;
-        assertThat(rateLimitException.getDescription(), is("Rate limits reached"));
+        assertThat(rateLimitException.getDescription(), is("Rate limit reached"));
         assertThat(rateLimitException.getError(), is(nullValue()));
         assertThat(rateLimitException.getValue("non_existing_key"), is(nullValue()));
         assertThat(rateLimitException.getStatusCode(), is(429));

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -306,7 +306,7 @@ public class CustomRequestTest {
     @Test
     public void shouldReceiveRateLimitsResponse() throws Exception {
         CustomRequest<List> request = new CustomRequest<>(client, server.getBaseUrl(), "GET", listType);
-        server.textResponse(AUTH_ERROR_PLAINTEXT, 429);
+        server.rateLimitResponse();
         Exception exception = null;
         try {
             request.execute();
@@ -324,6 +324,11 @@ public class CustomRequestTest {
         assertThat(authException.getError(), is(nullValue()));
         assertThat(authException.getValue("non_existing_key"), is(nullValue()));
         assertThat(authException.getStatusCode(), is(429));
+        
+        RateLimitException rateLimitException = (RateLimitException) authException;
+        assertThat(rateLimitException.getLimit(), is(100L));
+        assertThat(rateLimitException.getRemaining(), is(10L));
+        assertThat(rateLimitException.getReset(), is(-1L));
     }
 
 }


### PR DESCRIPTION
This PR resolve #99 to allow get the rate limit values from `X-RateLimit-*` headers.
I have made some decisions for default values, for example, when an http response code with value `429` is received then the information about rate limits should be recovered from headers `X-RateLimit-*`, but I don't know if these values are always sent so, if I couldn't get some header then a default `-1` will be assigned.
The primitive data type chosen was `long` since the `X-RateLimit-Reset` is a Unix timestamp and the others values are normal numbers.