### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Get Auth0 Java via Maven:
 or Gradle:
 
 ```gradle
-compile 'com.auth0:auth0:1.9.0'
+implementation 'com.auth0:auth0:1.9.0'
 ```
 
 


### PR DESCRIPTION
The **compile** configuration is now deprecated and should be replaced by implementation or api.
From [Gradle Documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation)