### PR TITLE
Include grant_types in Client

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -38,6 +38,8 @@ public class Client {
     private List<String> allowedOrigins;
     @JsonProperty("web_origins")
     private List<String> webOrigins;
+    @JsonProperty("grant_types")
+    private List<String> grantTypes;
     @JsonProperty("client_aliases")
     private List<String> clientAliases;
     @JsonProperty("allowed_clients")
@@ -283,6 +285,23 @@ public class Client {
         return webOrigins;
     }
 
+    /**
+     * Setter for the list of grant types for the application.
+     */
+    @JsonProperty("grant_types")
+    public void setGrantTypes(List<String> grantTypes) {
+        this.grantTypes = grantTypes;
+    }
+
+    /**
+     * Getter for the list of grant types for the application.
+     *
+     * @return the list of grant types. 
+     */
+    @JsonProperty("grant_types")
+    public List<String> getGrantTypes() {
+        return grantTypes;
+    }
 
     /**
      * Getter for the list of application aliases.

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -287,6 +287,7 @@ public class Client {
 
     /**
      * Setter for the list of grant types for the application.
+     * See allowed values at https://auth0.com/docs/applications/application-grant-types.
      */
     @JsonProperty("grant_types")
     public void setGrantTypes(List<String> grantTypes) {

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.*;
 public class ClientTest extends JsonTest<Client> {
 
     private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_first_party\":true,\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
-    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
+    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -31,6 +31,7 @@ public class ClientTest extends JsonTest<Client> {
         client.setCallbacks(stringList);
         client.setAllowedOrigins(stringList);
         client.setWebOrigins(stringList);
+        client.setGrantTypes(stringList);
         client.setClientAliases(stringList);
         client.setAllowedClients(stringList);
         client.setAllowedLogoutUrls(stringList);
@@ -62,6 +63,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("logo_uri", "uri"));
         assertThat(serialized, JsonMatcher.hasEntry("oidc_conformant", true));
         assertThat(serialized, JsonMatcher.hasEntry("callbacks", Collections.singletonList("value")));
+        assertThat(serialized, JsonMatcher.hasEntry("grant_types", Collections.singletonList("value")));
         assertThat(serialized, JsonMatcher.hasEntry("allowed_origins", Collections.singletonList("value")));
         assertThat(serialized, JsonMatcher.hasEntry("client_aliases", Collections.singletonList("value")));
         assertThat(serialized, JsonMatcher.hasEntry("allowed_clients", Collections.singletonList("value")));
@@ -95,6 +97,7 @@ public class ClientTest extends JsonTest<Client> {
 
         assertThat(client.getCallbacks(), contains("value"));
         assertThat(client.getWebOrigins(), contains("value"));
+        assertThat(client.getGrantTypes(), contains("value"));
         assertThat(client.getAllowedOrigins(), contains("value"));
         assertThat(client.getClientAliases(), contains("value"));
         assertThat(client.getAllowedClients(), contains("value"));


### PR DESCRIPTION
This includes missing grant_types in the client and allows for updating
this field with the ClientEntity.

This fixes #162