### PR TITLE
Add test case for PasswordChangeTicket with Email

### DIFF
--- a/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
@@ -31,6 +31,26 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(serialized, JsonMatcher.hasEntry("email", "me@auth0.com"));
     }
 
+    
+    @Test
+    public void shouldSerializeWithCustomizedConnection() throws Exception {
+        PasswordChangeTicket ticket = new PasswordChangeTicket("user@emailprovider.com", "connid123");
+        ticket.setResultUrl("https://page.auth0.com/result");
+        ticket.setTTLSeconds(36000);
+        ticket.setEmail("me@auth0.com");
+        ticket.setNewPassword("pass123");
+        ticket.setUserId("usr123");
+
+        String serialized = toJSON(ticket);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("user_id", "usr123"));
+        assertThat(serialized, JsonMatcher.hasEntry("result_url", "https://page.auth0.com/result"));
+        assertThat(serialized, JsonMatcher.hasEntry("ttl_sec", 36000));
+        assertThat(serialized, JsonMatcher.hasEntry("new_password", "pass123"));
+        assertThat(serialized, JsonMatcher.hasEntry("connection_id", "connid123"));
+        assertThat(serialized, JsonMatcher.hasEntry("email", "me@auth0.com"));
+    }
+    
     @Test
     public void shouldIncludeReadOnlyValuesOnDeserialize() throws Exception {
         PasswordChangeTicket ticket = fromJSON(readOnlyJson, PasswordChangeTicket.class);


### PR DESCRIPTION
Improved unit test coverage, and added a unit test for covering the case of creating a PasswordChangeTicket using an email and custom connection as parameters.

Improved from 70% to 100
<img width="561" alt="screen shot 2019-02-09 at 22 02 33" src="https://user-images.githubusercontent.com/533797/52526440-fa82ee00-2cb8-11e9-9b88-5703f4201591.png">
<img width="1011" alt="screen shot 2019-02-09 at 22 21 06" src="https://user-images.githubusercontent.com/533797/52526441-fa82ee00-2cb8-11e9-9aae-8201eae55f02.png">

%.