### PR TITLE
Add "mark_email_as_verified" property to PasswordChangeTicket

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -28,6 +28,8 @@ public class PasswordChangeTicket {
     private String email;
     @JsonProperty("ticket")
     private String ticket;
+    @JsonProperty("mark_email_as_verified")
+    private Boolean markEmailAsVerified;
 
     @JsonCreator
     public PasswordChangeTicket(@JsonProperty("user_id") String userId) {
@@ -97,6 +99,16 @@ public class PasswordChangeTicket {
     @JsonProperty("email")
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    /**
+     * Setter for the mark_email_as_verified to define if user.email_verified should be set to true after ticket is consumed.
+     *
+     * @param  markEmailAsVerified true if email_verified attribute must be set to true once password is changed, false if email_verified attribute should not be updated.
+     */
+    @JsonProperty("set_email_as_verified")
+    public void setMarkEmailAsVerified(Boolean markEmailAsVerified){
+        this.markEmailAsVerified = markEmailAsVerified;
     }
 
     /**

--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -106,7 +106,7 @@ public class PasswordChangeTicket {
      *
      * @param  markEmailAsVerified true if email_verified attribute must be set to true once password is changed, false if email_verified attribute should not be updated.
      */
-    @JsonProperty("set_email_as_verified")
+    @JsonProperty("mark_email_as_verified")
     public void setMarkEmailAsVerified(Boolean markEmailAsVerified){
         this.markEmailAsVerified = markEmailAsVerified;
     }

--- a/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
@@ -20,6 +20,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         ticket.setConnectionId("12");
         ticket.setEmail("me@auth0.com");
         ticket.setNewPassword("pass123");
+        ticket.setMarkEmailAsVerified(true);
 
         String serialized = toJSON(ticket);
         assertThat(serialized, is(notNullValue()));
@@ -29,6 +30,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(serialized, JsonMatcher.hasEntry("new_password", "pass123"));
         assertThat(serialized, JsonMatcher.hasEntry("connection_id", "12"));
         assertThat(serialized, JsonMatcher.hasEntry("email", "me@auth0.com"));
+        assertThat(serialized, JsonMatcher.hasEntry("mark_email_as_verified", true));
     }
 
     @Test


### PR DESCRIPTION
Hi Auth0 Team,

according to the Management API v2 documentation, _/password-change_ endpoint accepts a new extra parameter, namely **mark_email_as_verified**.  The current version of auth0-java client API is missing this feature. 

We would like to utilize this feature in our service and use the official client library. 

Thank you in advance.

Best regards,
Yevhenii.

### Changes
A new field has been added to the class definition and a corresponding unit test has been updated.

### References

[Management API v2: Create a password change ticket](https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change)

### Testing

Although the change is really small and is covered by a test, I performed a small local test and creating a password change ticket using the patched auth0-java library:

```kotlin
import com.auth0.client.mgmt.ManagementAPI
import com.auth0.json.mgmt.tickets.PasswordChangeTicket

fun main(){
    val management = ManagementAPI("domain", "token");
    val ticket = PasswordChangeTicket("userid")
    ticket.setMarkEmailAsVerified(true);
    val response = management.tickets().requestPasswordChange(ticket).execute();
    print("Your ticket is" + response.ticket)
}
```
- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
