### PR TITLE
Update GET /user documentation on README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ try {
 #### Get
 
 Creates a request to get a User. An API Token with scope `read:users` is needed. If you want the identities.access_token property to be included, you will also need the scope `read:user_idp_tokens`.
-You can pass an optional Filter to narrow the results in the response.
+You can pass an optional Filter to specify the fields you want to include or exclude from the response.
 
 `Request<User> get(String userId, UserFilter filter)`
 


### PR DESCRIPTION
### Changes

The GET /user API endpoint doesn't accept the `q` query parameter. That's only reserved for user listing scenarios. But because the method that calls it accepts a `UserFilter` instance, this PR will clarify that it will only be used to obtain the list of fields to include/exclude from the response.

### References

Closes https://github.com/auth0/auth0-java/issues/188

### Testing

Doc change. No needed.

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
