### PR TITLE
Remove default version for search_engine

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/UserFilter.java
@@ -6,14 +6,13 @@ package com.auth0.client.mgmt.filter;
 public class UserFilter extends QueryFilter {
 
     /**
-     * Creates a new instance using the search engine 'v2'.
+     * Creates a new instance using the latest search engine version.
      * <p>
-     * This version of the search engine is now deprecated and will stop working on November 13th 2018.
-     * Please, migrate as soon as possible and use the {@link #withSearchEngine(String)} method to specify version 'v3'.
-     * See the migration guide at https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3
+     * Since version 1.12.0 this SDK no longer specifies a search engine version by default. If you need to use
+     * a version different than the latest one, please set it explicitly by calling {@link #withSearchEngine(String)}.
+     * See the latest user search doc: https://auth0.com/docs/users/search/
      */
     public UserFilter() {
-        withSearchEngine("v2");
     }
 
     @Override
@@ -23,10 +22,9 @@ public class UserFilter extends QueryFilter {
     }
 
     /**
-     * Selects which Search Engine version to use.
+     * Selects which Search Engine version to use when querying for users.
      * <p>
-     * Version 2 is now deprecated and will stop working on November 13th 2018. Please, migrate as soon as possible to 'v3'.
-     * See the migration guide at https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3
+     * See the latest user search doc: https://auth0.com/docs/users/search/
      *
      * @param searchEngineVersion the search engine version to use on queries.
      * @return this filter instance

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -167,7 +167,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("search_engine", "v2"));
+        assertThat(recordedRequest, not(hasQueryParameter("search_engine")));
         assertThat(recordedRequest, hasQueryParameter("q", "email%3A%5C*%40gmail.com"));
 
         assertThat(response, is(notNullValue()));

--- a/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
@@ -4,8 +4,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 public class UserFilterTest {
@@ -18,9 +17,9 @@ public class UserFilterTest {
     }
 
     @Test
-    public void shouldUseSearchEngineV2ByDefault() throws Exception {
+    public void shouldNotSetADefaultSearchEngineValue() throws Exception {
         assertThat(filter.getAsMap(), is(notNullValue()));
-        assertThat(filter.getAsMap(), Matchers.hasEntry("search_engine", (Object) "v2"));
+        assertThat(filter.getAsMap(), not(Matchers.hasKey("search_engine")));
     }
 
     @Test


### PR DESCRIPTION
### Changes

This SDK was hardcoding the `search_engine` to `v2` by default. This version was deprecated on June and is **no longer available since November 13th 2018**. This PR removes the default value in order to make use of the server's default (latest). Currently, this version is `v3`.

If this change is not introduced and users do not set explicitly a version e.g. v3, then requests would fail with an "invalid search_engine version" message.

We encourage the users to migrate to the latest version by following the guide [here](https://auth0.com/docs/users/search/v3/migrate-search-v2-v3).

### References

- V3: https://auth0.com/docs/users/search/v3
- V2: https://auth0.com/docs/users/search/v2
- Migration: https://auth0.com/docs/users/search/v3/migrate-search-v2-v3

### Testing


- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
