### PR TITLE
Fix for issue #198: Core Authorization fails when adding Roles to User

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -491,15 +491,15 @@ public class UsersEntity extends BaseManagementEntity {
      * See https://auth0.com/docs/api/management/v2#!/Users/delete_user_roles
      *
      * @param userId the user id
-     * @param roles a list of role objects to remove from the user
+     * @param roleIds a list of role ids to remove from the user
      * @return a Request to execute
      */
-    public Request removeRoles(String userId, List<Role> roles) {
+    public Request removeRoles(String userId, List<String> roleIds) {
         Asserts.assertNotNull(userId, "user id");
-        Asserts.assertNotEmpty(roles, "roles");
+        Asserts.assertNotEmpty(roleIds, "role ids");
 
-        Map<String, List<Role>> body = new HashMap<>();
-        body.put("roles", roles);
+        Map<String, List<String>> body = new HashMap<>();
+        body.put("roles", roleIds);
 
         final String url = baseUrl
             .newBuilder()
@@ -520,15 +520,15 @@ public class UsersEntity extends BaseManagementEntity {
      * See https://auth0.com/docs/api/management/v2#!/Users/post_user_roles
      *
      * @param userId the user id
-     * @param roles a list of role objects to assign to the user
+     * @param roleIds a list of role ids to assign to the user
      * @return a Request to execute
      */
-    public Request addRoles(String userId, List<Role> roles) {
+    public Request addRoles(String userId, List<String> roleIds) {
         Asserts.assertNotNull(userId, "user id");
-        Asserts.assertNotEmpty(roles, "roles");
+        Asserts.assertNotEmpty(roleIds, "role ids");
 
-        Map<String, List<Role>> body = new HashMap<>();
-        body.put("roles", roles);
+        Map<String, List<String>> body = new HashMap<>();
+        body.put("roles", roleIds);
 
         final String url = baseUrl
             .newBuilder()

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -739,23 +739,20 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldThrowOnAddRolesWithNullList() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'roles' cannot be null!");
+        exception.expectMessage("'role ids' cannot be null!");
         api.users().addRoles("1", null);
     }
 
     @Test
     public void shouldThrowOnAddRolesWithEmptyList() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'roles' cannot be empty!");
+        exception.expectMessage("'role ids' cannot be empty!");
         api.users().addRoles("1", Collections.emptyList());
     }
 
     @Test
     public void shouldAddRoles() throws Exception {
-        Role role = new Role();
-        role.setName("roleId");
-
-        Request request = api.users().addRoles("1",  Collections.singletonList(role));
+        Request request = api.users().addRoles("1",  Collections.singletonList("roleId"));
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
@@ -783,23 +780,20 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldThrowOnRemoveRolesWithNullList() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'roles' cannot be null!");
+        exception.expectMessage("'role ids' cannot be null!");
         api.users().removeRoles("1", null);
     }
 
     @Test
     public void shouldThrowOnRemoveRolesWithEmptyList() throws Exception {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'roles' cannot be empty!");
+        exception.expectMessage("'role ids' cannot be empty!");
         api.users().removeRoles("1", Collections.emptyList());
     }
 
     @Test
     public void shouldRemoveRoles() throws Exception {
-        Role role = new Role();
-        role.setName("roleId");
-
-        Request request = api.users().removeRoles("1", Collections.singletonList(role));
+        Request request = api.users().removeRoles("1", Collections.singletonList("roleId"));
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse( 200);


### PR DESCRIPTION
This is to resolve the problem described in issue #198. 

### Changes

- Update to the `removeRoles` and `addRoles` methods of the `UsersEntity` class to accept a list of strings instead of a list of roles. 
- Update to the `UsersEntityTest` to correctly invoke the updated methods. 

### References

Issue #198 

### Testing

- [x] This change updates test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
