### PR TITLE
Dynamically obtain the project version for telemetry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.8.0'
+        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.9.0'
     }
 }
 

--- a/src/main/java/com/auth0/BuildConfig.java
+++ b/src/main/java/com/auth0/BuildConfig.java
@@ -1,6 +1,0 @@
-package com.auth0;
-
-public interface BuildConfig {
-    String NAME = "auth0-java";
-    String VERSION = "1.0.0";
-}

--- a/src/main/java/com/auth0/net/TelemetryInterceptor.java
+++ b/src/main/java/com/auth0/net/TelemetryInterceptor.java
@@ -1,6 +1,5 @@
 package com.auth0.net;
 
-import com.auth0.BuildConfig;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 
@@ -12,7 +11,7 @@ public class TelemetryInterceptor implements Interceptor {
     private boolean enabled;
 
     public TelemetryInterceptor() {
-        this(new Telemetry(BuildConfig.NAME, BuildConfig.VERSION));
+        this(new Telemetry("auth0-java", Telemetry.class.getPackage().getImplementationVersion()));
     }
 
     TelemetryInterceptor(Telemetry telemetry) {


### PR DESCRIPTION
### Changes

Fixes a bug where the `version` value sent on the telemetry was not obtained dynamically. This fix required a change on our OSS plugin first, that's the reason for the plugin bump.

### Testing
Deployed to the local maven repository and tested on a sample app. After a simple request to the API, the log included the new version.

![image](https://user-images.githubusercontent.com/3900123/57001212-d1724b00-6b8d-11e9-9015-ef9ba3b9663c.png)


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
