### PR TITLE
Add missing ResourceServer properties

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -29,6 +29,7 @@ public class GrantsEntity extends BaseManagementEntity {
      * See https://auth0.com/docs/api/management/v2#!/Grants/get_grants
      *
      * @param userId The user id of the grants to retrieve
+     * @param filter the filter to use. Can be null.
      * @return a Request to execute.
      */
     public Request<GrantsPage> list(String userId, GrantsFilter filter) {

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -27,6 +27,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
      * Creates request to fetch all resource servers.
      * See <a href=https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers>API documentation</a>
      *
+     * @param filter the filter to use. Can be null.
      * @return request to execute
      */
     public Request<ResourceServersPage> list(ResourceServersFilter filter) {

--- a/src/main/java/com/auth0/client/mgmt/RolesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RolesEntity.java
@@ -6,18 +6,18 @@ import com.auth0.json.mgmt.Permission;
 import com.auth0.json.mgmt.PermissionsPage;
 import com.auth0.json.mgmt.Role;
 import com.auth0.json.mgmt.RolesPage;
-import com.auth0.json.mgmt.users.User;
 import com.auth0.json.mgmt.users.UsersPage;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
 import com.auth0.utils.Asserts;
 import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 
 public class RolesEntity extends BaseManagementEntity {
 

--- a/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailTemplate.java
@@ -46,6 +46,8 @@ public class EmailTemplate {
 
     /**
      * Sets the name of the template.
+     *
+     * @param name the name to set for this template
      */
     @JsonProperty("template")
     public void setName(String name) {

--- a/src/main/java/com/auth0/json/mgmt/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/ResourceServer.java
@@ -1,11 +1,11 @@
 package com.auth0.json.mgmt;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -29,12 +29,16 @@ public class ResourceServer {
     private Boolean skipConsentForVerifiableFirstPartyClients;
     @JsonProperty("token_lifetime")
     private Integer tokenLifetime;
+    @JsonProperty("token_dialect")
+    private String tokenDialect;
     @JsonProperty("token_lifetime_for_web")
     private Integer tokenLifetimeForWeb;
     @JsonProperty("verification_location")
     private String verificationLocation;
     @JsonProperty("is_system")
     private Boolean isSystem;
+    @JsonProperty("enforce_policies")
+    private Boolean enforcePolicies;
 
     @JsonCreator
     public ResourceServer(@JsonProperty("identifier") String identifier) {
@@ -67,6 +71,16 @@ public class ResourceServer {
     @JsonProperty("is_system")
     public Boolean isSystem() {
         return isSystem;
+    }
+
+    @JsonProperty("enforce_policies")
+    public Boolean enforcePolicies() {
+        return enforcePolicies;
+    }
+
+    @JsonProperty("enforce_policies")
+    public void setEnforcePolicies(Boolean enforcePolicies) {
+        this.enforcePolicies = enforcePolicies;
     }
 
     @JsonProperty("identifier")
@@ -132,6 +146,16 @@ public class ResourceServer {
     @JsonProperty("token_lifetime")
     public void setTokenLifetime(Integer tokenLifetime) {
         this.tokenLifetime = tokenLifetime;
+    }
+
+    @JsonProperty("token_dialect")
+    public String getTokenDialect() {
+        return tokenDialect;
+    }
+
+    @JsonProperty("token_dialect")
+    public void setTokenDialect(String tokenDialect) {
+        this.tokenDialect = tokenDialect;
     }
 
     @JsonProperty("verification_location")

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -288,6 +288,8 @@ public class Client {
     /**
      * Setter for the list of grant types for the application.
      * See allowed values at https://auth0.com/docs/applications/application-grant-types.
+     *
+     * @param grantTypes the list of grant types to set.
      */
     @JsonProperty("grant_types")
     public void setGrantTypes(List<String> grantTypes) {
@@ -297,7 +299,7 @@ public class Client {
     /**
      * Getter for the list of grant types for the application.
      *
-     * @return the list of grant types. 
+     * @return the list of grant types.
      */
     @JsonProperty("grant_types")
     public List<String> getGrantTypes() {

--- a/src/main/java/com/auth0/json/mgmt/users/User.java
+++ b/src/main/java/com/auth0/json/mgmt/users/User.java
@@ -219,6 +219,8 @@ public class User implements Serializable {
      * Setter for the user's unique identifier. This is only valid when creating a new user, as the property can't change once set.
      * The server will prepend the connection name and a pipe character before the given id value.
      * i.e. For "auth0" connection with user id "123456789" the final user id would be "auth0|123456789".
+     *
+     * @param userId the id of the user
      */
     @JsonProperty("user_id")
     public void setId(String userId) {

--- a/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
@@ -107,7 +107,9 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         resourceServer.setSigningAlgorithm("RS256");
         resourceServer.setSigningSecret("secret");
         resourceServer.setAllowOfflineAccess(false);
+        resourceServer.setEnforcePolicies(true);
         resourceServer.setSkipConsentForVerifiableFirstPartyClients(false);
+        resourceServer.setTokenDialect("access_token");
         resourceServer.setTokenLifetime(0);
         resourceServer.setVerificationLocation("verification_location");
         Request<ResourceServer> request = api.resourceServers()
@@ -123,7 +125,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body.size(), is(10));
+        assertThat(body.size(), is(12));
         assertThat(body, hasEntry("identifier", (Object) "https://api.my-company.com/api/v2/"));
 
         assertThat(response.getIdentifier(), is("https://api.my-company.com/api/v2/"));

--- a/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
@@ -24,8 +24,10 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(deserialized.getScopes(), hasSize(2));
         assertThat(deserialized.getSigningAlgorithm(), is("RS256"));
         assertThat(deserialized.getSigningSecret(), is("secret"));
+        assertThat(deserialized.isSystem(), is(true));
         assertThat(deserialized.getAllowOfflineAccess(), is(false));
         assertThat(deserialized.getSkipConsentForVerifiableFirstPartyClients(), is(false));
+        assertThat(deserialized.getTokenDialect(), is("access_token"));
         assertThat(deserialized.getTokenLifetime(), is(86400));
         assertThat(deserialized.getVerificationLocation(), is("verification_location"));
     }
@@ -46,9 +48,11 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         entity.setScopes(scopes);
         entity.setSigningAlgorithm("RS256");
         entity.setSigningSecret("secret");
+        entity.setEnforcePolicies(true);
         entity.setAllowOfflineAccess(false);
         entity.setSkipConsentForVerifiableFirstPartyClients(false);
         entity.setTokenLifetime(86400);
+        entity.setTokenDialect("access_token_authz");
         entity.setVerificationLocation("verification_location");
 
         String json = toJSON(entity);
@@ -58,9 +62,11 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(json, hasEntry("identifier", "https://api.my-company.com/api/v2/"));
         assertThat(json, hasEntry("signing_alg", "RS256"));
         assertThat(json, hasEntry("signing_secret", "secret"));
+        assertThat(json, hasEntry("enforce_policies", true));
         assertThat(json, hasEntry("allow_offline_access", false));
         assertThat(json, hasEntry("skip_consent_for_verifiable_first_party_clients", false));
         assertThat(json, hasEntry("token_lifetime", 86400));
+        assertThat(json, hasEntry("token_dialect", "access_token_authz"));
         assertThat(json, hasEntry("verification_location", "verification_location"));
     }
 }

--- a/src/test/resources/mgmt/resource_server.json
+++ b/src/test/resources/mgmt/resource_server.json
@@ -3,6 +3,7 @@
   "name": "Some API",
   "identifier": "https://api.my-company.com/api/v2/",
   "signing_alg": "RS256",
+  "token_dialect": "access_token",
   "token_lifetime": 86400,
   "token_lifetime_for_web": 7200,
   "allow_offline_access": false,
@@ -19,5 +20,6 @@
       "value": "create:client_grants"
     }
   ],
-  "is_system": true
+  "is_system": true,
+  "enforce_policies": false
 }

--- a/src/test/resources/mgmt/resource_servers_list.json
+++ b/src/test/resources/mgmt/resource_servers_list.json
@@ -4,6 +4,7 @@
     "name": "Some API",
     "identifier": "https://api.my-company.com/api/v2/",
     "signing_alg": "RS256",
+    "token_dialect": "access_token",
     "token_lifetime": 86400,
     "token_lifetime_for_web": 7200,
     "allow_offline_access": false,
@@ -18,7 +19,8 @@
         "value": "create:client_grants"
       }
     ],
-    "is_system": true
+    "is_system": true,
+    "enforce_policies": false
   },
   {
     "id": "3223232da",
@@ -39,6 +41,7 @@
         "value": "create:client_grants"
       }
     ],
-    "is_system": true
+    "is_system": true,
+    "enforce_policies": false
   }
 ]

--- a/src/test/resources/mgmt/resource_servers_paged_list.json
+++ b/src/test/resources/mgmt/resource_servers_paged_list.json
@@ -9,6 +9,7 @@
       "name": "Some API",
       "identifier": "https://api.my-company.com/api/v2/",
       "signing_alg": "RS256",
+      "token_dialect": "access_token",
       "token_lifetime": 86400,
       "token_lifetime_for_web": 7200,
       "allow_offline_access": false,
@@ -23,13 +24,15 @@
           "value": "create:client_grants"
         }
       ],
-      "is_system": true
+      "is_system": true,
+      "enforce_policies": false
     },
     {
       "id": "3223232da",
       "name": "Another API",
       "identifier": "https://another-api.my-company.com/api/v2/",
       "signing_alg": "RS256",
+      "token_dialect": "access_token",
       "token_lifetime": 86400,
       "token_lifetime_for_web": 7200,
       "allow_offline_access": false,
@@ -44,7 +47,8 @@
           "value": "create:client_grants"
         }
       ],
-      "is_system": true
+      "is_system": true,
+      "enforce_policies": false
     }
   ]
 }


### PR DESCRIPTION
### Changes

Adds `token_dialect` and `enforce_policies` properties to the `ResourceServer` object

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
