### PR TITLE
Add getter for DeviceCredentials client_id

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/DeviceCredentials.java
+++ b/src/main/java/com/auth0/json/mgmt/DeviceCredentials.java
@@ -128,6 +128,17 @@ public class DeviceCredentials {
     }
 
     /**
+     * Getter for the client id of the application for which the credential is created.
+     *
+     * @return the client id.
+     */
+    @JsonProperty("client_id")
+    public String getClientId() {
+        return clientId;
+    }
+
+
+    /**
      * Getter for the user id of the device
      *
      * @return the user if

--- a/src/test/java/com/auth0/json/mgmt/DeviceCredentialsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/DeviceCredentialsTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class DeviceCredentialsTest extends JsonTest<DeviceCredentials> {
 
-    private static final String json = "{\"device_name\":\"devName\",\"type\":\"publicKey\",\"device_id\":\"dev123\",\"user_id\":\"theUserId\"}";
+    private static final String json = "{\"device_name\":\"devName\",\"type\":\"publicKey\",\"device_id\":\"dev123\",\"user_id\":\"theUserId\",\"client_id\":\"client123\"}";
     private static final String readOnlyJson = "{\"id\":\"credentialsId\"}";
 
     @Test
@@ -37,6 +37,7 @@ public class DeviceCredentialsTest extends JsonTest<DeviceCredentials> {
         assertThat(credentials.getType(), is("publicKey"));
         assertThat(credentials.getDeviceId(), is("dev123"));
         assertThat(credentials.getUserId(), is("theUserId"));
+        assertThat(credentials.getClientId(), is("client123"));
     }
 
     @Test

--- a/src/test/resources/mgmt/device_credentials.json
+++ b/src/test/resources/mgmt/device_credentials.json
@@ -2,5 +2,6 @@
   "id": "dcr_0INpgifmKRm5z",
   "device_name": "Google Nexus 5X - 6.0.0 - API 23 - 1080x1920",
   "user_id": "auth0|121212",
-  "type": "refresh_token"
+  "type": "refresh_token",
+  "client_id": "client987"
 }

--- a/src/test/resources/mgmt/device_credentials_list.json
+++ b/src/test/resources/mgmt/device_credentials_list.json
@@ -3,12 +3,14 @@
     "id": "dcr_03YxCFDQfS7RT",
     "device_name": "Google Nexus 4 - 5.1.0 - API 22 - 768x1280",
     "user_id": "twitter|323232",
-    "type": "refresh_token"
+    "type": "refresh_token",
+    "client_id": "client987"
   },
   {
     "id": "dcr_0INpgifmKRm5z",
     "device_name": "Google Nexus 5X - 6.0.0 - API 23 - 1080x1920",
     "user_id": "auth0|121212",
-    "type": "refresh_token"
+    "type": "refresh_token",
+    "client_id": "client987"
   }
 ]


### PR DESCRIPTION
### Changes

This `client_id` getter was missing from `DeviceCredentials` 

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
