### PR TITLE
Update jackson-databind dependency to fix security vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ test {
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.1'
     implementation 'commons-codec:commons-codec:1.11'
 
     testImplementation 'org.mockito:mockito-core:2.18.3'


### PR DESCRIPTION
**Changes**
Bump `jackson-databind` dependency to address CVE-2019-12384 and CVE-2019-12814

**References**
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207