### PR TITLE
Find the right JDK version for Telemetry

### DIFF
--- a/src/main/java/com/auth0/net/Telemetry.java
+++ b/src/main/java/com/auth0/net/Telemetry.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class Telemetry {
     static final String HEADER_NAME = "Auth0-Client";
 
+    private static final String JAVA_SPECIFICATION_VERSION = "java.specification.version";
     private static final String NAME_KEY = "name";
     private static final String VERSION_KEY = "version";
     private static final String LIBRARY_VERSION_KEY = "auth0-java";
@@ -46,7 +47,7 @@ public class Telemetry {
         }
 
         HashMap<String, String> tmpEnv = new HashMap<>();
-        tmpEnv.put(JAVA_KEY, Runtime.class.getPackage().getSpecificationVersion());
+        tmpEnv.put(JAVA_KEY, getJDKVersion());
         if (libraryVersion != null) {
             tmpEnv.put(LIBRARY_VERSION_KEY, libraryVersion);
         }
@@ -85,4 +86,15 @@ public class Telemetry {
     public String getValue() {
         return value;
     }
+
+    private String getJDKVersion() {
+        String version;
+        try {
+            version = System.getProperty(JAVA_SPECIFICATION_VERSION);
+        } catch (Exception ignored) {
+            version = Runtime.class.getPackage().getSpecificationVersion();
+        }
+        return version;
+    }
+
 }


### PR DESCRIPTION
### Changes

JDK 9 was now uploading the right telemetry version, and so a `null` was being registered.

### References

![image](https://user-images.githubusercontent.com/3900123/62565002-4b386580-b85c-11e9-87bd-3245c8593852.png)

### Testing

No additional tests as these are static methods and depend on the JVM they are being run on.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
