### PR TITLE
Fix JavaDoc

### DIFF
--- a/src/main/java/com/auth0/json/auth/TokenHolder.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolder.java
@@ -66,7 +66,7 @@ public class TokenHolder {
     /**
      * Getter for the duration of this token in seconds since it was issued.
      *
-     * @returns the number of seconds in which this token will expire, since the time it was issued.
+     * @return the number of seconds in which this token will expire, since the time it was issued.
      */
     @JsonProperty("expires_in")
     public long getExpiresIn() {


### PR DESCRIPTION
### Changes

- JavaDoc fix for `TokenHolder.getExpiresIn()`. Should be `@return` not `@returns`. 
- This fixes failure on javaDoc Gradle task (also included when running the `build` task)

### References

- N/A

### Testing

- Successful `build` and `check` tasks ran.

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
