### PR TITLE
Update jackson-databind to address CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ test {
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0.pr3'
     implementation 'commons-codec:commons-codec:1.13'
 
 


### PR DESCRIPTION
### Changes

Update `jackson-databind` dependency to 2.10.0.pr3 to address CVE.

### References

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14540

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
