### PR TITLE
Allow to set the client is_first_party property

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -209,7 +209,7 @@ public class Client {
      * Setter for whether this application is a first party client or not.
      */
     @JsonProperty("is_first_party")
-    public void setFirstParty(Boolean isFirstParty) {
+    public void setIsFirstParty(Boolean isFirstParty) {
         this.isFirstParty = isFirstParty;
     }
 

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -206,6 +206,14 @@ public class Client {
     }
 
     /**
+     * Setter for whether this application is a first party client or not.
+     */
+    @JsonProperty("is_first_party")
+    public void setFirstParty(Boolean isFirstParty) {
+        this.isFirstParty = isFirstParty;
+    }
+
+    /**
      * Whether this application will conform to strict Open ID Connect specifications or not.
      *
      * @return true if the application will conform to strict OIDC specifications, false otherwise.

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.*;
 
 public class ClientTest extends JsonTest<Client> {
 
-    private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_first_party\":true,\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
-    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
+    private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
+    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -27,6 +27,7 @@ public class ClientTest extends JsonTest<Client> {
         client.setAppType("type");
         client.setLogoUri("uri");
         client.setOIDCConformant(true);
+        client.setFirstParty(true);
         List<String> stringList = Collections.singletonList("value");
         client.setCallbacks(stringList);
         client.setAllowedOrigins(stringList);
@@ -62,6 +63,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("app_type", "type"));
         assertThat(serialized, JsonMatcher.hasEntry("logo_uri", "uri"));
         assertThat(serialized, JsonMatcher.hasEntry("oidc_conformant", true));
+        assertThat(serialized, JsonMatcher.hasEntry("is_first_party", true));
         assertThat(serialized, JsonMatcher.hasEntry("callbacks", Collections.singletonList("value")));
         assertThat(serialized, JsonMatcher.hasEntry("grant_types", Collections.singletonList("value")));
         assertThat(serialized, JsonMatcher.hasEntry("allowed_origins", Collections.singletonList("value")));
@@ -94,6 +96,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getLogoUri(), is("uri"));
 
         assertThat(client.isOIDCConformant(), is(true));
+        assertThat(client.isFirstParty(), is(true));
 
         assertThat(client.getCallbacks(), contains("value"));
         assertThat(client.getWebOrigins(), contains("value"));
@@ -126,7 +129,6 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client, is(notNullValue()));
 
         assertThat(client.getClientId(), is("clientId"));
-        assertThat(client.isFirstParty(), is(true));
         assertThat(client.isHerokuApp(), is(true));
         assertThat(client.getSigningKeys(), is(notNullValue()));
     }

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -27,7 +27,7 @@ public class ClientTest extends JsonTest<Client> {
         client.setAppType("type");
         client.setLogoUri("uri");
         client.setOIDCConformant(true);
-        client.setFirstParty(true);
+        client.setIsFirstParty(true);
         List<String> stringList = Collections.singletonList("value");
         client.setCallbacks(stringList);
         client.setAllowedOrigins(stringList);


### PR DESCRIPTION
### Changes

The property should be modifiable, as per the updated docs.

### References

Closes #229 

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
