### PR TITLE
Use char array for passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,13 +94,7 @@ gradle-app.setting
 .idea/tasks.xml
 
 # Sensitive or high-churn files:
-.idea/dataSources/
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
+.idea/
 
 # Gradle:
 .idea/gradle.xml

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -251,6 +251,36 @@ public class AuthAPI {
      * @return a Request to configure and execute.
      */
     public SignUpRequest signUp(String email, String username, String password, String connection) {
+        return this.signUp(email, username, password != null ? password.toCharArray() : null, connection);
+    }
+
+    /**
+     * Creates a sign up request with the given credentials and database connection.
+     * "Requires Username" option must be turned on in the Connection's configuration first.
+     * i.e.:
+     * <pre>
+     * {@code
+     * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * try {
+     *      Map<String, String> fields = new HashMap<String, String>();
+     *      fields.put("age", "25);
+     *      fields.put("city", "Buenos Aires");
+     *      auth.signUp("me@auth0.com", "myself", new char[]{'s','e','c','r','e','t'}, "db-connection")
+     *          .setCustomFields(fields)
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param email      the desired user's email.
+     * @param username   the desired user's username.
+     * @param password   the desired user's password.
+     * @param connection the database connection where the user is going to be created.
+     * @return a Request to configure and execute.
+     */
+    public SignUpRequest signUp(String email, String username, char[] password, String connection) {
         Asserts.assertNotNull(username, "username");
 
         CreateUserRequest request = (CreateUserRequest) this.signUp(email, password, connection);
@@ -283,6 +313,34 @@ public class AuthAPI {
      * @return a Request to configure and execute.
      */
     public SignUpRequest signUp(String email, String password, String connection) {
+        return this.signUp(email, password != null ? password.toCharArray() : null, connection);
+    }
+
+    /**
+     * Creates a sign up request with the given credentials and database connection.
+     * i.e.:
+     * <pre>
+     * {@code
+     * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * try {
+     *      Map<String, String> fields = new HashMap<String, String>();
+     *      fields.put("age", "25);
+     *      fields.put("city", "Buenos Aires");
+     *      auth.signUp("me@auth0.com", new char[]{'s','e','c','r','e','t'}, "db-connection")
+     *          .setCustomFields(fields)
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param email      the desired user's email.
+     * @param password   the desired user's password.
+     * @param connection the database connection where the user is going to be created.
+     * @return a Request to configure and execute.
+     */
+    public SignUpRequest signUp(String email, char[] password, String connection) {
         Asserts.assertNotNull(email, "email");
         Asserts.assertNotNull(password, "password");
         Asserts.assertNotNull(connection, "connection");
@@ -322,6 +380,30 @@ public class AuthAPI {
      * @return a Request to configure and execute.
      */
     public AuthRequest login(String emailOrUsername, String password) {
+        return this.login(emailOrUsername, password != null ? password.toCharArray() : null);
+    }
+
+    /**
+     * Creates a log in request using the 'Password' grant and the given credentials.
+     * i.e.:
+     * <pre>
+     * {@code
+     * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * try {
+     *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t})
+     *          .setScope("openid email nickname")
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param emailOrUsername the identity of the user.
+     * @param password        the password of the user.
+     * @return a Request to configure and execute.
+     */
+    public AuthRequest login(String emailOrUsername, char[] password) {
         Asserts.assertNotNull(emailOrUsername, "email or username");
         Asserts.assertNotNull(password, "password");
 
@@ -362,6 +444,31 @@ public class AuthAPI {
      * @return a Request to configure and execute.
      */
     public AuthRequest login(String emailOrUsername, String password, String realm) {
+        return this.login(emailOrUsername, password != null ? password.toCharArray() : null, realm);
+    }
+
+    /**
+     * Creates a log in request using the 'Password Realm' grant and the given credentials.
+     * Default used realm and audience are defined in the "API Authorization Settings" in the account's advanced settings in the Auth0 Dashboard.
+     * <pre>
+     * {@code
+     * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * try {
+     *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t'}, "my-realm")
+     *          .setAudience("https://myapi.me.auth0.com/users")
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param emailOrUsername the identity of the user.
+     * @param password        the password of the user.
+     * @param realm           the realm to use.
+     * @return a Request to configure and execute.
+     */
+    public AuthRequest login(String emailOrUsername, char[] password, String realm) {
         Asserts.assertNotNull(emailOrUsername, "email or username");
         Asserts.assertNotNull(password, "password");
         Asserts.assertNotNull(realm, "realm");

--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -21,7 +21,7 @@ public class PasswordChangeTicket {
     @JsonProperty("ttl_sec")
     private Integer ttlSec;
     @JsonProperty("new_password")
-    private String newPassword;
+    private char[] newPassword;
     @JsonProperty("connection_id")
     private String connectionId;
     @JsonProperty("email")
@@ -78,6 +78,11 @@ public class PasswordChangeTicket {
      */
     @JsonProperty("new_password")
     public void setNewPassword(String newPassword) {
+        setNewPassword(newPassword != null ? newPassword.toCharArray() : null);
+    }
+
+    @JsonProperty("new_password")
+    public void setNewPassword(char[] newPassword) {
         this.newPassword = newPassword;
     }
 

--- a/src/main/java/com/auth0/json/mgmt/users/User.java
+++ b/src/main/java/com/auth0/json/mgmt/users/User.java
@@ -21,7 +21,7 @@ public class User implements Serializable {
     @JsonProperty("connection")
     private String connection;
     @JsonProperty("password")
-    private String password;
+    private char[] password;
     @JsonProperty("verify_password")
     private Boolean verifyPassword;
     @JsonProperty("username")
@@ -102,6 +102,16 @@ public class User implements Serializable {
      */
     @JsonProperty("password")
     public void setPassword(String password) {
+        setPassword(password != null ? password.toCharArray() : null);
+    }
+
+    /**
+     * Setter for the password this user will have once created.
+     *
+     * @param password the password to set.
+     */
+    @JsonProperty("password")
+    public void setPassword(char[] password) {
         this.password = password;
     }
 
@@ -501,7 +511,7 @@ public class User implements Serializable {
     }
 
     @JsonProperty("password")
-    String getPassword() {
+    char[] getPassword() {
         return password;
     }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -369,10 +369,17 @@ public class AuthAPITest {
     }
 
     @Test
-    public void shouldThrowOnSignUpWithNullPassword() throws Exception {
+    public void shouldThrowOnSignUpWithNullPasswordString() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'password' cannot be null!");
-        api.signUp("me@auth0.com", null, "my-connection");
+        api.signUp("me@auth0.com", (String) null, "my-connection");
+    }
+
+    @Test
+    public void shouldThrowOnSignUpWithNullPasswordCharArray() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'password' cannot be null!");
+        api.signUp("me@auth0.com", (char[]) null, "my-connection");
     }
 
     @Test
@@ -397,10 +404,17 @@ public class AuthAPITest {
     }
 
     @Test
-    public void shouldThrowOnUsernameSignUpWithNullPassword() throws Exception {
+    public void shouldThrowOnUsernameSignUpWithNullPasswordString() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'password' cannot be null!");
-        api.signUp("me@auth0.com", "me", null, "my-connection");
+        api.signUp("me@auth0.com", "me", (String) null, "my-connection");
+    }
+
+    @Test
+    public void shouldThrowOnUsernameSignUpWithNullPasswordCharArray() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'password' cannot be null!");
+        api.signUp("me@auth0.com", "me", (char[]) null, "my-connection");
     }
 
     @Test
@@ -611,7 +625,14 @@ public class AuthAPITest {
     public void shouldThrowOnLogInWithPasswordWithNullPassword() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'password' cannot be null!");
-        api.login("me", null);
+        api.login("me", (String) null);
+    }
+
+    @Test
+    public void shouldThrowOnLogInWithCharPasswordWithNullPassword() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'password' cannot be null!");
+        api.login("me", (char[]) null);
     }
 
     @Test
@@ -685,10 +706,17 @@ public class AuthAPITest {
     }
 
     @Test
-    public void shouldThrowOnLogInWithPasswordRealmWithNullPassword() throws Exception {
+    public void shouldThrowOnLogInWithPasswordRealmWithNullPasswordString() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'password' cannot be null!");
-        api.login("me", null, "realm");
+        api.login("me", (String) null, "realm");
+    }
+
+    @Test
+    public void shouldThrowOnLogInWithPasswordRealmWithNullPasswordCharArray() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'password' cannot be null!");
+        api.login("me", (char[]) null, "realm");
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
@@ -61,4 +61,19 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(ticket.getTicket(), is("https://page.auth0.com/tickets/123"));
     }
 
+    @Test
+    public void shouldHandleNullPasswordString() throws Exception {
+        PasswordChangeTicket ticket = new PasswordChangeTicket("userId");
+        ticket.setNewPassword((String) null);
+
+        assertThat(ticket, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldHandleNullPasswordCharArray() throws Exception {
+        PasswordChangeTicket ticket = new PasswordChangeTicket("userId");
+        ticket.setNewPassword((char[]) null);
+
+        assertThat(ticket, is(notNullValue()));
+    }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 public class UserTest extends JsonTest<User> {
@@ -81,7 +82,7 @@ public class UserTest extends JsonTest<User> {
         assertThat(user, is(notNullValue()));
         assertThat(user.getId(), is("user|123"));
         assertThat(user.getConnection(), is("auth0"));
-        assertThat(user.getPassword(), is("pwd"));
+        assertThat(user.getPassword(), is(new char[]{'p','w','d'}));
         assertThat(user.willVerifyPassword(), is(true));
         assertThat(user.getUsername(), is("usr"));
         assertThat(user.getEmail(), is("me@auth0.com"));
@@ -115,5 +116,21 @@ public class UserTest extends JsonTest<User> {
         assertThat(user.getIdentities(), is(notNullValue()));
         assertThat(user.getLastIP(), is("10.0.0.1"));
         assertThat(user.getLoginsCount(), is(10));
+    }
+
+    @Test
+    public void shouldHandleNullPasswordString() throws Exception {
+        User user = new User();
+        user.setPassword((String) null);
+
+        assertThat(user.getPassword(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNullPasswordCharArray() throws Exception {
+        User user = new User();
+        user.setPassword((char[]) null);
+
+        assertThat(user.getPassword(), is(nullValue()));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -119,7 +119,7 @@ public class UserTest extends JsonTest<User> {
     }
 
     @Test
-    public void shouldHandleNullPasswordString() throws Exception {
+    public void shouldHandleNullPasswordString() {
         User user = new User();
         user.setPassword((String) null);
 
@@ -127,10 +127,19 @@ public class UserTest extends JsonTest<User> {
     }
 
     @Test
-    public void shouldHandleNullPasswordCharArray() throws Exception {
+    public void shouldHandleNullPasswordCharArray() {
         User user = new User();
         user.setPassword((char[]) null);
 
         assertThat(user.getPassword(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetPasswordAsCharArray() {
+        String password = "secret";
+        User user = new User();
+        user.setPassword(password);
+
+        assertThat(user.getPassword(), is(password.toCharArray()));
     }
 }


### PR DESCRIPTION
### Changes

Fixes #234 

**Included changes:**
* Use a character array (`char[]`) instead of `String` for password fields

**Changes to follow, not in this PR:**
* Deprecation of String-based password APIs. Will be done in separate PR for changelog and tracking purposes

### References

* GH issue: #234
* [Baeldung article about using char array instead of strings for passwords](https://www.baeldung.com/java-storing-passwords)
* [StackOverflow discussion](https://stackoverflow.com/questions/8881291/why-is-char-preferred-over-string-for-passwords)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
