### PR TITLE
deprecated string password APIs

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -249,7 +249,10 @@ public class AuthAPI {
      * @param password   the desired user's password.
      * @param connection the database connection where the user is going to be created.
      * @return a Request to configure and execute.
+     *
+     * @deprecated Use {@linkplain #signUp(String, String, char[], String)} instead.
      */
+    @Deprecated
     public SignUpRequest signUp(String email, String username, String password, String connection) {
         return this.signUp(email, username, password != null ? password.toCharArray() : null, connection);
     }
@@ -311,7 +314,10 @@ public class AuthAPI {
      * @param password   the desired user's password.
      * @param connection the database connection where the user is going to be created.
      * @return a Request to configure and execute.
+     *
+     * @deprecated Use {@linkplain #signUp(String, char[], String)} instead.
      */
+    @Deprecated
     public SignUpRequest signUp(String email, String password, String connection) {
         return this.signUp(email, password != null ? password.toCharArray() : null, connection);
     }
@@ -378,7 +384,10 @@ public class AuthAPI {
      * @param emailOrUsername the identity of the user.
      * @param password        the password of the user.
      * @return a Request to configure and execute.
+     *
+     * @deprecated Use {@linkplain #login(String, char[])} instead.
      */
+    @Deprecated
     public AuthRequest login(String emailOrUsername, String password) {
         return this.login(emailOrUsername, password != null ? password.toCharArray() : null);
     }
@@ -442,7 +451,10 @@ public class AuthAPI {
      * @param password        the password of the user.
      * @param realm           the realm to use.
      * @return a Request to configure and execute.
+     *
+     * @deprecated Use {@linkplain #login(String, char[], String)} instead.
      */
+    @Deprecated
     public AuthRequest login(String emailOrUsername, String password, String realm) {
         return this.login(emailOrUsername, password != null ? password.toCharArray() : null, realm);
     }

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -207,6 +207,8 @@ public class Client {
 
     /**
      * Setter for whether this application is a first party client or not.
+     *
+     * @param isFirstParty whether the application is a first party client or not.
      */
     @JsonProperty("is_first_party")
     public void setIsFirstParty(Boolean isFirstParty) {

--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -75,8 +75,11 @@ public class PasswordChangeTicket {
      * Setter for the new password to set after the ticket is used.
      *
      * @param newPassword the new password to set.
+     *
+     * @deprecated Use {@linkplain #setNewPassword(char[])} instead.
      */
     @JsonProperty("new_password")
+    @Deprecated
     public void setNewPassword(String newPassword) {
         setNewPassword(newPassword != null ? newPassword.toCharArray() : null);
     }

--- a/src/main/java/com/auth0/json/mgmt/users/User.java
+++ b/src/main/java/com/auth0/json/mgmt/users/User.java
@@ -99,8 +99,11 @@ public class User implements Serializable {
      * Setter for the password this user will have once created.
      *
      * @param password the password to set.
+     *
+     * @deprecated Use {@linkplain #setPassword(char[])} instead.
      */
     @JsonProperty("password")
+    @Deprecated
     public void setPassword(String password) {
         setPassword(password != null ? password.toCharArray() : null);
     }


### PR DESCRIPTION
### Changes

* Deprecates APIs that use passwords as Strings.

### References

* Related to #242 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
