### PR TITLE
Make CreatedUser take the id from different properties

### DIFF
--- a/src/main/java/com/auth0/json/auth/CreatedUser.java
+++ b/src/main/java/com/auth0/json/auth/CreatedUser.java
@@ -1,5 +1,6 @@
 package com.auth0.json.auth;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class CreatedUser {
 
     @JsonProperty("_id")
+    @JsonAlias({"_id", "id", "user_id"})
     private String userId;
     @JsonProperty("email")
     private String email;
@@ -22,6 +24,7 @@ public class CreatedUser {
     private Boolean emailVerified;
 
     @JsonProperty("_id")
+    @JsonAlias({"_id", "id", "user_id"})
     public String getUserId() {
         return userId;
     }

--- a/src/test/java/com/auth0/json/auth/CreatedUserTest.java
+++ b/src/test/java/com/auth0/json/auth/CreatedUserTest.java
@@ -1,0 +1,64 @@
+package com.auth0.json.auth;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class CreatedUserTest extends JsonTest<CreatedUser> {
+
+    private static final String jsonStandard = "{\"email\":\"sample@email.com\",\"username\":\"john.doe\",\"email_verified\":true,\"_id\": \"from|_id\"}";
+    private static final String jsonCustom = "{\"email\":\"sample@email.com\",\"username\":\"john.doe\",\"email_verified\":true,\"id\": \"from|id\"}";
+    private static final String jsonCustomExternal = "{\"email\":\"sample@email.com\",\"username\":\"john.doe\",\"email_verified\":true,\"user_id\": \"from|user_id\"}";
+    private static final String jsonMultiple = "{\"email\":\"sample@email.com\",\"username\":\"john.doe\",\"email_verified\":true,\"user_id\": \"from|user_id\",\"id\": \"from|id\",\"_id\": \"from|_id\"}";
+
+    @Test
+    public void shouldDeserializePreferringStandardUserId() throws Exception {
+        CreatedUser user = fromJSON(jsonMultiple, CreatedUser.class);
+
+        assertThat(user, is(notNullValue()));
+
+        assertThat(user.getEmail(), is("sample@email.com"));
+        assertThat(user.getUsername(), is("john.doe"));
+        assertThat(user.isEmailVerified(), is(true));
+        assertThat(user.getUserId(), is("from|_id"));
+    }
+
+    @Test
+    public void shouldDeserializeStandardConnectionUser() throws Exception {
+        CreatedUser user = fromJSON(jsonStandard, CreatedUser.class);
+
+        assertThat(user, is(notNullValue()));
+
+        assertThat(user.getEmail(), is("sample@email.com"));
+        assertThat(user.getUsername(), is("john.doe"));
+        assertThat(user.isEmailVerified(), is(true));
+        assertThat(user.getUserId(), is("from|_id"));
+    }
+
+    @Test
+    public void shouldDeserializeCustomConnectionUser() throws Exception {
+        CreatedUser user = fromJSON(jsonCustom, CreatedUser.class);
+
+        assertThat(user, is(notNullValue()));
+
+        assertThat(user.getEmail(), is("sample@email.com"));
+        assertThat(user.getUsername(), is("john.doe"));
+        assertThat(user.isEmailVerified(), is(true));
+        assertThat(user.getUserId(), is("from|id"));
+    }
+
+    @Test
+    public void shouldDeserializeCustomExternalConnectionUser() throws Exception {
+        CreatedUser user = fromJSON(jsonCustomExternal, CreatedUser.class);
+
+        assertThat(user, is(notNullValue()));
+
+        assertThat(user.getEmail(), is("sample@email.com"));
+        assertThat(user.getUsername(), is("john.doe"));
+        assertThat(user.isEmailVerified(), is(true));
+        assertThat(user.getUserId(), is("from|user_id"));
+    }
+}


### PR DESCRIPTION
### Changes
When a new user is created via the signup endpoint, the user id value could be returned in different properties, depending on the connection where this user was created on. The properties include `_id` (default), `id` (custom DB connections), and `user_id` (custom external DB connections).

Luckily, this was easy to solve using Jackson annotations for providing alternative aliases. 

### References
Fixes https://github.com/auth0/auth0-java/issues/176.

### Testing

Tests were added to ensure there was no introduced breaking change in behavior.

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
