### PR TITLE
Add a new class to handle Multipart requests

### DIFF
--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -1,41 +1,29 @@
 package com.auth0.net;
 
-import com.auth0.exception.APIException;
-import com.auth0.exception.Auth0Exception;
-import com.auth0.exception.RateLimitException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.MapType;
-import okhttp3.*;
-import okhttp3.Request;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("WeakerAccess")
-public class CustomRequest<T> extends BaseRequest<T> implements CustomizableRequest<T> {
+public class CustomRequest<T> extends ExtendedBaseRequest<T> implements CustomizableRequest<T> {
 
     private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
 
-    private final String url;
-    private final String method;
     private final ObjectMapper mapper;
     private final TypeReference<T> tType;
-    private final Map<String, String> headers;
     private final Map<String, Object> parameters;
     private Object body;
 
-    private static final int STATUS_CODE_TOO_MANY_REQUEST = 429;
-
     CustomRequest(OkHttpClient client, String url, String method, ObjectMapper mapper, TypeReference<T> tType) {
-        super(client);
-        this.url = url;
-        this.method = method;
+        super(client, url, method, mapper);
         this.mapper = mapper;
         this.tType = tType;
-        this.headers = new HashMap<>();
         this.parameters = new HashMap<>();
     }
 
@@ -44,34 +32,24 @@ public class CustomRequest<T> extends BaseRequest<T> implements CustomizableRequ
     }
 
     @Override
-    protected Request createRequest() throws Auth0Exception {
-        Request.Builder builder = new Request.Builder()
-                .url(url)
-                .method(method, createBody());
-        for (Map.Entry<String, String> e : headers.entrySet()) {
-            builder.addHeader(e.getKey(), e.getValue());
+    protected RequestBody createRequestBody() throws IOException {
+        if (body == null && parameters.isEmpty()) {
+            return null;
         }
-        builder.addHeader("Content-Type", CONTENT_TYPE_APPLICATION_JSON);
-        return builder.build();
+        byte[] jsonBody = mapper.writeValueAsBytes(body != null ? body : parameters);
+        return RequestBody.create(MediaType.parse(CONTENT_TYPE_APPLICATION_JSON), jsonBody);
     }
 
     @Override
-    protected T parseResponse(Response response) throws Auth0Exception {
-        if (!response.isSuccessful()) {
-            throw createResponseException(response);
-        }
-
-        try (ResponseBody body = response.body()) {
-            String payload = body.string();
-            return mapper.readValue(payload, tType);
-        } catch (IOException e) {
-            throw new APIException("Failed to parse json body", response.code(), e);
-        }
+    protected T readResponseBody(ResponseBody body) throws IOException {
+        String payload = body.string();
+        return mapper.readValue(payload, tType);
     }
 
     @Override
     public CustomRequest<T> addHeader(String name, String value) {
-        headers.put(name, value);
+        //This is to avoid returning a different type
+        super.addHeader(name, value);
         return this;
     }
 
@@ -85,41 +63,5 @@ public class CustomRequest<T> extends BaseRequest<T> implements CustomizableRequ
     public CustomRequest<T> setBody(Object value) {
         body = value;
         return this;
-    }
-
-    protected RequestBody createBody() throws Auth0Exception {
-        if (body == null && parameters.isEmpty()) {
-            return null;
-        }
-        try {
-            byte[] jsonBody = mapper.writeValueAsBytes(body != null ? body : parameters);
-            return RequestBody.create(MediaType.parse(CONTENT_TYPE_APPLICATION_JSON), jsonBody);
-        } catch (JsonProcessingException e) {
-            throw new Auth0Exception("Couldn't create the request body.", e);
-        }
-    }
-
-    protected Auth0Exception createResponseException(Response response) {
-        if (response.code() == STATUS_CODE_TOO_MANY_REQUEST) {
-            return createRateLimitException(response);
-        }
-
-        String payload = null;
-        try (ResponseBody body = response.body()) {
-            payload = body.string();
-            MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
-            Map<String, Object> values = mapper.readValue(payload, mapType);
-            return new APIException(values, response.code());
-        } catch (IOException e) {
-            return new APIException(payload, response.code(), e);
-        }
-    }
-
-    private RateLimitException createRateLimitException(Response response) {
-        // -1 as default value if the header could not be found.
-        long limit = Long.parseLong(response.header("X-RateLimit-Limit", "-1"));
-        long remaining = Long.parseLong(response.header("X-RateLimit-Remaining", "-1"));
-        long reset = Long.parseLong(response.header("X-RateLimit-Reset", "-1"));
-        return new RateLimitException(limit, remaining, reset);
     }
 }

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -11,6 +11,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Request class that accepts parameters to be sent as part of its body.
+ * The content type of this request is "application/json".
+ *
+ * @param <T> The type expected to be received as part of the response.
+ */
 public class CustomRequest<T> extends ExtendedBaseRequest<T> implements CustomizableRequest<T> {
 
     private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";

--- a/src/main/java/com/auth0/net/CustomizableRequest.java
+++ b/src/main/java/com/auth0/net/CustomizableRequest.java
@@ -1,10 +1,37 @@
 package com.auth0.net;
 
+/**
+ * A request class that can be customized in different ways.
+ * i.e. setting headers, body parameters, etc.
+ *
+ * @param <T> The type expected to be received as part of the response.
+ */
+@SuppressWarnings("UnusedReturnValue")
 interface CustomizableRequest<T> extends Request<T> {
 
+    /**
+     * Adds an HTTP header to the request
+     *
+     * @param name  the name of the header
+     * @param value the value of the header
+     * @return this same request instance
+     */
     CustomizableRequest<T> addHeader(String name, String value);
 
+    /**
+     * Adds an body parameter to the request
+     *
+     * @param name  the name of the parameter
+     * @param value the value of the parameter
+     * @return this same request instance
+     */
     CustomizableRequest<T> addParameter(String name, Object value);
 
+    /**
+     * Sets the response's body directly
+     *
+     * @param body the value to set as body
+     * @return this same request instance
+     */
     CustomizableRequest<T> setBody(Object body);
 }

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -4,6 +4,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 
+/**
+ * Request class that accepts parameters to be sent as part of its body
+ * but ignores the response's body.
+ * The content type of this request is "application/json".
+ *
+ * @param <T> The type expected to be received as part of the response.
+ * @see CustomRequest
+ */
 public class EmptyBodyRequest<T> extends CustomRequest<T> {
 
     public EmptyBodyRequest(OkHttpClient client, String url, String method, TypeReference<T> tType) {

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -5,8 +5,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 
 /**
- * Request class that accepts parameters to be sent as part of its body
- * but ignores the response's body.
+ * Request class that does not accept parameters to be sent as part of its body.
  * The content type of this request is "application/json".
  *
  * @param <T> The type expected to be received as part of the response.

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -1,9 +1,10 @@
 package com.auth0.net;
 
-import com.auth0.exception.Auth0Exception;
 import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
+
+import java.io.IOException;
 
 public class EmptyBodyRequest<T> extends CustomRequest<T> {
 
@@ -12,7 +13,7 @@ public class EmptyBodyRequest<T> extends CustomRequest<T> {
     }
 
     @Override
-    protected RequestBody createBody() throws Auth0Exception {
+    protected RequestBody createRequestBody() throws IOException {
         return RequestBody.create(null, new byte[0]);
     }
 

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 
-import java.io.IOException;
-
 public class EmptyBodyRequest<T> extends CustomRequest<T> {
 
     public EmptyBodyRequest(OkHttpClient client, String url, String method, TypeReference<T> tType) {
@@ -13,7 +11,7 @@ public class EmptyBodyRequest<T> extends CustomRequest<T> {
     }
 
     @Override
-    protected RequestBody createRequestBody() throws IOException {
+    protected RequestBody createRequestBody() {
         return RequestBody.create(null, new byte[0]);
     }
 

--- a/src/main/java/com/auth0/net/ExtendedBaseRequest.java
+++ b/src/main/java/com/auth0/net/ExtendedBaseRequest.java
@@ -1,0 +1,102 @@
+package com.auth0.net;
+
+import com.auth0.exception.APIException;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.exception.RateLimitException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import okhttp3.Request;
+import okhttp3.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+//Package-Private on purpose
+abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
+
+    private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+
+    private final String url;
+    private final String method;
+    private final ObjectMapper mapper;
+    private final Map<String, String> headers;
+
+    private static final int STATUS_CODE_TOO_MANY_REQUEST = 429;
+
+    ExtendedBaseRequest(OkHttpClient client, String url, String method, ObjectMapper mapper) {
+        super(client);
+        this.url = url;
+        this.method = method;
+        this.mapper = mapper;
+        this.headers = new HashMap<>();
+    }
+
+    @Override
+    protected Request createRequest() throws Auth0Exception {
+        RequestBody body;
+        try {
+            body = this.createRequestBody();
+        } catch (Exception e) {
+            throw new Auth0Exception("Couldn't create the request body.", e);
+        }
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .method(method, body);
+        for (Map.Entry<String, String> e : headers.entrySet()) {
+            builder.addHeader(e.getKey(), e.getValue());
+        }
+        builder.addHeader("Content-Type", getContentType());
+        return builder.build();
+    }
+
+    @Override
+    protected T parseResponse(Response response) throws Auth0Exception {
+        if (!response.isSuccessful()) {
+            throw createResponseException(response);
+        }
+
+        try (ResponseBody body = response.body()) {
+            return readResponseBody(body);
+        } catch (Exception e) {
+            throw new APIException("Failed to parse json body", response.code(), e);
+        }
+    }
+
+    protected String getContentType() {
+        return CONTENT_TYPE_APPLICATION_JSON;
+    }
+
+    protected abstract RequestBody createRequestBody() throws IOException;
+
+    protected abstract T readResponseBody(ResponseBody body) throws IOException;
+
+    public ExtendedBaseRequest<T> addHeader(String name, String value) {
+        headers.put(name, value);
+        return this;
+    }
+
+    protected Auth0Exception createResponseException(Response response) {
+        if (response.code() == STATUS_CODE_TOO_MANY_REQUEST) {
+            return createRateLimitException(response);
+        }
+
+        String payload = null;
+        try (ResponseBody body = response.body()) {
+            payload = body.string();
+            MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
+            Map<String, Object> values = mapper.readValue(payload, mapType);
+            return new APIException(values, response.code());
+        } catch (IOException e) {
+            return new APIException(payload, response.code(), e);
+        }
+    }
+
+    private RateLimitException createRateLimitException(Response response) {
+        // -1 as default value if the header could not be found.
+        long limit = Long.parseLong(response.header("X-RateLimit-Limit", "-1"));
+        long remaining = Long.parseLong(response.header("X-RateLimit-Remaining", "-1"));
+        long reset = Long.parseLong(response.header("X-RateLimit-Reset", "-1"));
+        return new RateLimitException(limit, remaining, reset);
+    }
+}

--- a/src/main/java/com/auth0/net/ExtendedBaseRequest.java
+++ b/src/main/java/com/auth0/net/ExtendedBaseRequest.java
@@ -12,8 +12,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-//Package-Private on purpose
-//TODO: Merge with #BaseRequest on next major
+/**
+ * A request class that is able to interact fluently with the Auth0 server.
+ * The default content type of this request is "application/json".
+ * <p>
+ * //TODO: Merge with #BaseRequest on next major
+ *
+ * @param <T> The type expected to be received as part of the response.
+ */
 abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
 
     private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
@@ -64,19 +70,51 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
         }
     }
 
+    /**
+     * Getter for the content-type header value to use on this request
+     *
+     * @return the content-type
+     */
     protected String getContentType() {
         return CONTENT_TYPE_APPLICATION_JSON;
     }
 
+    /**
+     * Responsible for creating the payload that will be set as body on this request.
+     *
+     * @return the body to send as part of the request.
+     * @throws IOException if an error is raised during the creation of the body.
+     */
     protected abstract RequestBody createRequestBody() throws IOException;
 
+    /**
+     * Responsible for parsing the payload that is received as part of the response.
+     *
+     * @param body the received body payload. The body buffer will automatically closed.
+     * @return the instance of type T, result of interpreting the payload.
+     * @throws IOException if an error is raised during the parsing of the body.
+     */
     protected abstract T readResponseBody(ResponseBody body) throws IOException;
 
+    /**
+     * Adds an HTTP header to the request
+     *
+     * @param name  the name of the header
+     * @param value the value of the header
+     * @return this same request instance
+     */
     public ExtendedBaseRequest<T> addHeader(String name, String value) {
         headers.put(name, value);
         return this;
     }
 
+    /**
+     * Responsible for parsing an unsuccessful request (status code other than 200)
+     * and generating a developer-friendly exception with the error details.
+     *
+     * @param response the unsuccessful response, as received. If its body is accessed, the buffer must be closed.
+     * @return the exception with the error details.
+     */
     protected Auth0Exception createResponseException(Response response) {
         if (response.code() == STATUS_CODE_TOO_MANY_REQUEST) {
             return createRateLimitException(response);

--- a/src/main/java/com/auth0/net/ExtendedBaseRequest.java
+++ b/src/main/java/com/auth0/net/ExtendedBaseRequest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 //Package-Private on purpose
+//TODO: Merge with #BaseRequest on next major
 abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
 
     private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
@@ -37,7 +38,7 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
         RequestBody body;
         try {
             body = this.createRequestBody();
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new Auth0Exception("Couldn't create the request body.", e);
         }
         Request.Builder builder = new Request.Builder()
@@ -58,8 +59,8 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
 
         try (ResponseBody body = response.body()) {
             return readResponseBody(body);
-        } catch (Exception e) {
-            throw new APIException("Failed to parse json body", response.code(), e);
+        } catch (IOException e) {
+            throw new APIException("Failed to parse the response body.", response.code(), e);
         }
     }
 

--- a/src/main/java/com/auth0/net/FormDataRequest.java
+++ b/src/main/java/com/auth0/net/FormDataRequest.java
@@ -4,8 +4,6 @@ import java.io.File;
 
 interface FormDataRequest<T> extends Request<T> {
 
-    FormDataRequest<T> addHeader(String name, String value);
-
     FormDataRequest<T> addPart(String name, String value);
 
     FormDataRequest<T> addPart(String name, File file, String dataType);

--- a/src/main/java/com/auth0/net/FormDataRequest.java
+++ b/src/main/java/com/auth0/net/FormDataRequest.java
@@ -2,9 +2,31 @@ package com.auth0.net;
 
 import java.io.File;
 
+/**
+ * A request class that encodes its content as a form.
+ * i.e. for uploading attachments.
+ *
+ * @param <T> The type expected to be received as part of the response.
+ */
+@SuppressWarnings("UnusedReturnValue")
 interface FormDataRequest<T> extends Request<T> {
 
+    /**
+     * Adds a key-value part to the form of this request
+     *
+     * @param name  the name of the part
+     * @param value the value of the part
+     * @return this same request instance
+     */
     FormDataRequest<T> addPart(String name, String value);
 
-    FormDataRequest<T> addPart(String name, File file, String dataType);
+    /**
+     * Adds a file part to the form of this request
+     *
+     * @param name      the name of the part
+     * @param file      the file contents to send in this part
+     * @param mediaType the file contents media type
+     * @return this same request instance
+     */
+    FormDataRequest<T> addPart(String name, File file, String mediaType);
 }

--- a/src/main/java/com/auth0/net/FormDataRequest.java
+++ b/src/main/java/com/auth0/net/FormDataRequest.java
@@ -1,0 +1,12 @@
+package com.auth0.net;
+
+import java.io.File;
+
+interface FormDataRequest<T> extends Request<T> {
+
+    FormDataRequest<T> addHeader(String name, String value);
+
+    FormDataRequest<T> addPart(String name, String value);
+
+    FormDataRequest<T> addPart(String name, File file, String dataType);
+}

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -1,0 +1,127 @@
+package com.auth0.net;
+
+import com.auth0.exception.APIException;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.exception.RateLimitException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import okhttp3.Request;
+import okhttp3.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.auth0.utils.Asserts.assertNotNull;
+
+@SuppressWarnings("WeakerAccess")
+public class MultipartRequest<T> extends BaseRequest<T> implements FormDataRequest<T> {
+
+    private static final String CONTENT_TYPE_FORM_DATA = "multipart/form-data";
+    private final MultipartBody.Builder bodyBuilder;
+
+    private final String url;
+    private final String method;
+    private final HashMap<String, String> headers;
+    private final ObjectMapper mapper;
+    private final TypeReference<T> tType;
+
+    private static final int STATUS_CODE_TOO_MANY_REQUEST = 429;
+
+    MultipartRequest(OkHttpClient client, String url, String method, ObjectMapper mapper, TypeReference<T> tType) {
+        super(client);
+        this.url = url;
+        this.method = method;
+        this.mapper = mapper;
+        this.tType = tType;
+        this.headers = new HashMap<>();
+        this.bodyBuilder = new MultipartBody.Builder()
+                .setType(MultipartBody.FORM);
+    }
+
+    public MultipartRequest(OkHttpClient client, String url, String method, TypeReference<T> tType) {
+        this(client, url, method, new ObjectMapper(), tType);
+    }
+
+    @Override
+    public FormDataRequest<T> addHeader(String name, String value) {
+        headers.put(name, value);
+        return this;
+    }
+
+    public MultipartRequest<T> addPart(String name, File file, String mediaType) {
+        assertNotNull(name, "name");
+        assertNotNull(name, "file");
+        if (!file.exists()) {
+            throw new IllegalArgumentException("The file does not exist");
+        }
+        bodyBuilder.addFormDataPart(name, file.getName(),
+                RequestBody.create(MediaType.parse(mediaType), file));
+        return this;
+    }
+
+    public MultipartRequest<T> addPart(String name, String value) {
+        assertNotNull(name, "name");
+        assertNotNull(value, "value");
+        bodyBuilder.addFormDataPart(name, value);
+        return this;
+    }
+
+    @Override
+    protected Request createRequest() {
+        //FIXME: Copies from #com.auth0.net.CustomRequest
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .method(method, bodyBuilder.build());
+        //TODO: Move to "getBody" abstract method. Handle parts size.
+        for (Map.Entry<String, String> e : headers.entrySet()) {
+            builder.addHeader(e.getKey(), e.getValue());
+        }
+        builder.addHeader("Content-Type", CONTENT_TYPE_FORM_DATA);
+        return builder.build();
+    }
+
+    @Override
+    protected T parseResponse(Response response) throws Auth0Exception {
+        //FIXME: Copies from #com.auth0.net.CustomRequest
+        if (!response.isSuccessful()) {
+            throw createResponseException(response);
+        }
+
+        try (ResponseBody body = response.body()) {
+            String payload = body.string();
+            //TODO: Move to "readBody" abstract method.
+            return mapper.readValue(payload, tType);
+        } catch (IOException e) {
+            throw new APIException("Failed to parse json body", response.code(), e);
+        }
+    }
+
+    protected Auth0Exception createResponseException(Response response) {
+        //FIXME: Copies from #com.auth0.net.CustomRequest
+        if (response.code() == STATUS_CODE_TOO_MANY_REQUEST) {
+            return createRateLimitException(response);
+        }
+
+        String payload = null;
+        try (ResponseBody body = response.body()) {
+            payload = body.string();
+            MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
+            Map<String, Object> values = mapper.readValue(payload, mapType);
+            return new APIException(values, response.code());
+        } catch (IOException e) {
+            return new APIException(payload, response.code(), e);
+        }
+    }
+
+    private RateLimitException createRateLimitException(Response response) {
+        //FIXME: Copies from #com.auth0.net.CustomRequest
+        // -1 as default value if the header could not be found.
+        long limit = Long.parseLong(response.header("X-RateLimit-Limit", "-1"));
+        long remaining = Long.parseLong(response.header("X-RateLimit-Remaining", "-1"));
+        long reset = Long.parseLong(response.header("X-RateLimit-Reset", "-1"));
+        return new RateLimitException(limit, remaining, reset);
+    }
+}

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -9,7 +9,12 @@ import java.io.IOException;
 
 import static com.auth0.utils.Asserts.assertNotNull;
 
-@SuppressWarnings("WeakerAccess")
+/**
+ * Request class that accepts parts to be sent encoded in a form.
+ * The content type of this request is "multipart/form-data".
+ *
+ * @param <T> The type expected to be received as part of the response.
+ */
 public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormDataRequest<T> {
 
     private static final String CONTENT_TYPE_FORM_DATA = "multipart/form-data";
@@ -60,6 +65,7 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
         return this;
     }
 
+    @Override
     public MultipartRequest<T> addPart(String name, File file, String mediaType) {
         assertNotNull(name, "name");
         assertNotNull(name, "file");
@@ -72,6 +78,7 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
         return this;
     }
 
+    @Override
     public MultipartRequest<T> addPart(String name, String value) {
         assertNotNull(name, "name");
         assertNotNull(value, "value");

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -154,4 +154,10 @@ public class MockServer {
             return mapper.readValue(body.inputStream(), mapType);
         }
     }
+
+    public static String readFromRequest(RecordedRequest request) {
+        try (Buffer body = request.getBody()) {
+            return body.readUtf8();
+        }
+    }
 }

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -179,9 +179,9 @@ public class CustomRequestTest {
         assertThat(exception, is(notNullValue()));
         assertThat(exception, is(instanceOf(APIException.class)));
         assertThat(exception.getCause(), is(instanceOf(JsonMappingException.class)));
-        assertThat(exception.getMessage(), is("Request failed with status code 200: Failed to parse json body"));
+        assertThat(exception.getMessage(), is("Request failed with status code 200: Failed to parse the response body."));
         APIException authException = (APIException) exception;
-        assertThat(authException.getDescription(), is("Failed to parse json body"));
+        assertThat(authException.getDescription(), is("Failed to parse the response body."));
         assertThat(authException.getError(), is(nullValue()));
         assertThat(authException.getStatusCode(), is(200));
     }

--- a/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
@@ -1,0 +1,66 @@
+package com.auth0.net;
+
+import com.auth0.client.MockServer;
+import com.auth0.json.auth.TokenHolder;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.auth0.client.MockServer.AUTH_TOKENS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+
+public class EmptyBodyRequestTest {
+
+    private MockServer server;
+    private OkHttpClient client;
+
+    private TypeReference<TokenHolder> tokenHolderType;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockServer();
+        client = new OkHttpClient();
+        tokenHolderType = new TypeReference<TokenHolder>() {
+        };
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void shouldCreateEmptyRequestBody() throws Exception {
+        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, server.getBaseUrl(), "POST", tokenHolderType);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+        Assert.assertThat(recordedRequest.getMethod(), is("POST"));
+        Assert.assertThat(recordedRequest.getBodySize(), is(0L));
+    }
+
+    @Test
+    public void shouldNotAddParameters() throws Exception {
+        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, server.getBaseUrl(), "POST", tokenHolderType);
+        Map mapValue = mock(Map.class);
+        request.addParameter("key", "value");
+        request.addParameter("map", mapValue);
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+        Assert.assertThat(recordedRequest.getMethod(), is("POST"));
+        Assert.assertThat(recordedRequest.getBodySize(), is(0L));
+    }
+}

--- a/src/test/java/com/auth0/net/multipart/FilePart.java
+++ b/src/test/java/com/auth0/net/multipart/FilePart.java
@@ -1,0 +1,21 @@
+package com.auth0.net.multipart;
+
+public class FilePart extends KeyValuePart {
+
+    private final String filename;
+    private final String contentType;
+
+    public FilePart(String key, String value, String filename, String contentType) {
+        super(key, value);
+        this.filename = filename;
+        this.contentType = contentType;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/src/test/java/com/auth0/net/multipart/KeyValuePart.java
+++ b/src/test/java/com/auth0/net/multipart/KeyValuePart.java
@@ -1,0 +1,20 @@
+package com.auth0.net.multipart;
+
+public class KeyValuePart {
+
+    private final String key;
+    private final String value;
+
+    public KeyValuePart(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/test/java/com/auth0/net/multipart/RecordedMultipartRequest.java
+++ b/src/test/java/com/auth0/net/multipart/RecordedMultipartRequest.java
@@ -1,0 +1,101 @@
+package com.auth0.net.multipart;
+
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RecordedMultipartRequest {
+
+    private Map<String, KeyValuePart> parts = new HashMap<>();
+    private String boundary;
+
+    public RecordedMultipartRequest(RecordedRequest request) throws IOException {
+        parseBody(request.getBody());
+    }
+
+    public KeyValuePart getKeyValuePart(String name) {
+        return parts.get(name);
+    }
+
+    public FilePart getFilePart(String name) {
+        return (FilePart) parts.get(name);
+    }
+
+    public int getPartsCount() {
+        return parts.size();
+    }
+
+    public String getBoundary() {
+        return boundary;
+    }
+
+    private void parseBody(Buffer body) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(body.inputStream()));
+        //Obtain the boundary
+        String separator = br.readLine();
+        String eof = separator + "--";
+        boundary = separator.replaceFirst("--", "");
+
+        String strLine;
+        while (!eof.equals(strLine = br.readLine())) {
+            if (strLine.equals(separator) || strLine.isEmpty()) {
+                continue;
+            }
+
+            //Start reading the content description
+            String[] sections = strLine.split("; ");
+
+            String keyName = null;
+            String keyValue = null;
+            String keyFilename = null;
+            String keyContentType = null;
+            int keyContentLength = 0;
+            for (String section : sections) {
+                String[] secParts = section.split("=");
+                if ("name".equals(secParts[0])) {
+                    keyName = secParts[1];
+                    keyName = keyName.substring(1, keyName.length() - 1);
+                } else if ("filename".equals(secParts[0])) {
+                    keyFilename = secParts[1];
+                    keyFilename = keyFilename.substring(1, keyFilename.length() - 1);
+                }
+            }
+            //Try to find type
+            strLine = br.readLine();
+            if (strLine.startsWith("Content-Type: ")) {
+                keyContentType = strLine.split("Content-Type: ")[1];
+                strLine = br.readLine();
+            }
+            //Try to find length
+            if (strLine.startsWith("Content-Length: ")) {
+                keyContentLength = Integer.parseInt(strLine.split("Content-Length: ")[1]);
+                strLine = br.readLine();
+            }
+            //Try to find value
+            if (strLine.isEmpty()) {
+                //Start reading the keyValue
+                char[] valueBuffer = new char[keyContentLength];
+                br.read(valueBuffer, 0, keyContentLength);
+                keyValue = new String(valueBuffer);
+                if (keyValue.length() != keyContentLength) {
+                    System.out.println("-" + keyValue + "-");
+                    throw new IllegalStateException("Content-Length value and the found size do not match");
+                }
+            }
+
+            //Write the part
+            KeyValuePart part;
+            if (keyFilename != null) {
+                part = new FilePart(keyName, keyValue, keyFilename, keyContentType);
+            } else {
+                part = new KeyValuePart(keyName, keyValue);
+            }
+            parts.put(keyName, part);
+        }
+    }
+}

--- a/src/test/resources/mgmt/multipart-sample.json
+++ b/src/test/resources/mgmt/multipart-sample.json
@@ -1,0 +1,4 @@
+{
+  "name": "John Doe",
+  "age": 99
+}


### PR DESCRIPTION
### Changes
Implements a new class to handle multipart requests. This is required before implementing the "import users" Job endpoint.

These multipart requests are only allowed for HTTP methods other than GET. Some of the shared logic between `CustomRequest` and the introduced `MultipartRequest` has been moved _up_ to a class named `ExtendedBaseRequest` (as it's adding things on top of `BaseRequest`). This shared logic class is package-private!

**To review:**
- [ ] Name of the introduced request class: `MultipartRequest`.
- [ ] The existence (or not) of the `FormDataRequest` interface.
- [ ] The exceptions that should be declared as thrown on the abstract methods for creating the request body and parsing the response body.

### Testing

Check the commit history!! First, I added the new request class. Then I added tests for that. Then I added a few helper classes for the tests. Lastly, I refactored and extracted the common parts to the shared logic class.

Please, do check for public API breaking changes. There shouldn't be any, but is always good to have another pair of eyes :eyes:

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
