### PR TITLE
Add rotating_refresh_token to devicecredential token types.

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/DeviceCredentials.java
+++ b/src/main/java/com/auth0/json/mgmt/DeviceCredentials.java
@@ -68,7 +68,7 @@ public class DeviceCredentials {
     }
 
     /**
-     * Getter for the type of credential.
+     * Getter for the type of credential. Either 'public_key', 'refresh_token' or 'rotating_refresh_token'.
      *
      * @return the type of credential.
      */
@@ -78,7 +78,7 @@ public class DeviceCredentials {
     }
 
     /**
-     * Setter for the type of credential. Either 'public_key' or 'refresh_token'.
+     * Setter for the type of credential. Either 'public_key', 'refresh_token' or 'rotating_refresh_token'.
      *
      * @param type the type of credential to set.
      */


### PR DESCRIPTION
Just doc comments for DeviceCredentials.Type missing the new `rotating_refresh_token` type.