### PR TITLE
Add missing "sources" property to the Permission

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -8,7 +8,6 @@ import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.client.mgmt.filter.UserFilter;
 import com.auth0.json.mgmt.Permission;
 import com.auth0.json.mgmt.PermissionsPage;
-import com.auth0.json.mgmt.Role;
 import com.auth0.json.mgmt.RolesPage;
 import com.auth0.json.mgmt.guardian.Enrollment;
 import com.auth0.json.mgmt.logevents.LogEventsPage;

--- a/src/main/java/com/auth0/json/mgmt/Permission.java
+++ b/src/main/java/com/auth0/json/mgmt/Permission.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 /**
  * Class that represents an Auth0 Permission object. Related to the {@link com.auth0.client.mgmt.RolesEntity} entity.
  */
@@ -12,96 +14,109 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Permission {
 
-  @JsonProperty("permission_name")
-  private String name;
+    @JsonProperty("permission_name")
+    private String name;
 
-  @JsonProperty("description")
-  private String description;
+    @JsonProperty("description")
+    private String description;
 
-  @JsonProperty("resource_server_identifier")
-  private String resourceServerId;
+    @JsonProperty("resource_server_identifier")
+    private String resourceServerId;
 
-  @JsonProperty("resource_server_name")
-  private String resourceServerName;
+    @JsonProperty("resource_server_name")
+    private String resourceServerName;
 
-  /**
-   * Getter for the role's name.
-   *
-   * @return the name of the role.
-   */
-  @JsonProperty("permission_name")
-  public String getName() {
-    return name;
-  }
+    @JsonProperty("sources")
+    private List<PermissionSource> sources;
 
-  /**
-   * Setter for the role's name.
-   *
-   * @param name the name of the role to set.
-   */
-  @JsonProperty("permission_name")
-  public void setName(String name) {
-    this.name = name;
-  }
+    /**
+     * Getter for the role's name.
+     *
+     * @return the name of the role.
+     */
+    @JsonProperty("permission_name")
+    public String getName() {
+        return name;
+    }
 
-  /**
-   * The getter for the role's description.
-   *
-   * @return the description of the role.
-   */
-  @JsonProperty("description")
-  public String getDescription() {
-    return description;
-  }
+    /**
+     * Setter for the role's name.
+     *
+     * @param name the name of the role to set.
+     */
+    @JsonProperty("permission_name")
+    public void setName(String name) {
+        this.name = name;
+    }
 
-  /**
-   * Setter for the role's description.
-   *
-   * @param description the description of the role to set.
-   */
-  @JsonProperty("description")
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    /**
+     * The getter for the role's description.
+     *
+     * @return the description of the role.
+     */
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
 
-  /**
-   * Getter for the permissions's resource server identifier.
-   *
-   * @return the resource server identifier of the permission.
-   */
-  @JsonProperty("resource_server_identifier")
-  public String getResourceServerId() {
-    return resourceServerId;
-  }
+    /**
+     * Setter for the role's description.
+     *
+     * @param description the description of the role to set.
+     */
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-  /**
-   * Setter for the permissions's resource server identifier.
-   *
-   * @param resourceServerId the resource server identifier of the permission to set.
-   */
-  @JsonProperty("resource_server_identifier")
-  public void setResourceServerId(String resourceServerId) {
-    this.resourceServerId = resourceServerId;
-  }
+    /**
+     * Getter for the permissions's resource server identifier.
+     *
+     * @return the resource server identifier of the permission.
+     */
+    @JsonProperty("resource_server_identifier")
+    public String getResourceServerId() {
+        return resourceServerId;
+    }
 
-  /**
-   * Getter for the permissions's resource server name.
-   *
-   * @return the resource server name of the permission.
-   */
-  @JsonProperty("resource_server_name")
-  public String getResourceServerName() {
-    return resourceServerName;
-  }
+    /**
+     * Setter for the permissions's resource server identifier.
+     *
+     * @param resourceServerId the resource server identifier of the permission to set.
+     */
+    @JsonProperty("resource_server_identifier")
+    public void setResourceServerId(String resourceServerId) {
+        this.resourceServerId = resourceServerId;
+    }
 
-  /**
-   * Setter for the permissions's resource server name.
-   *
-   * @param resourceServerName the resource server name of the permission to set.
-   */
-  @JsonProperty("resource_server_name")
-  public void setResourceServerName(String resourceServerName) {
-    this.resourceServerName = resourceServerName;
-  }
+    /**
+     * Getter for the permissions's resource server name.
+     *
+     * @return the resource server name of the permission.
+     */
+    @JsonProperty("resource_server_name")
+    public String getResourceServerName() {
+        return resourceServerName;
+    }
+
+    /**
+     * Setter for the permissions's resource server name.
+     *
+     * @param resourceServerName the resource server name of the permission to set.
+     */
+    @JsonProperty("resource_server_name")
+    public void setResourceServerName(String resourceServerName) {
+        this.resourceServerName = resourceServerName;
+    }
+
+    /**
+     * Getter for the permission's sources.
+     *
+     * @return the permission sources.
+     */
+    @JsonProperty("sources")
+    public List<PermissionSource> getSources() {
+        return sources;
+    }
 
 }

--- a/src/main/java/com/auth0/json/mgmt/PermissionSource.java
+++ b/src/main/java/com/auth0/json/mgmt/PermissionSource.java
@@ -1,0 +1,54 @@
+package com.auth0.json.mgmt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents an Auth0 Permission's Soruce object. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
+ */
+@SuppressWarnings("unused")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PermissionSource {
+
+    @JsonProperty("source_type")
+    private String type;
+
+    @JsonProperty("source_name")
+    private String name;
+
+    @JsonProperty("source_id")
+    private String id;
+
+    /**
+     * Getter for the source's name.
+     *
+     * @return the name of the source.
+     */
+    @JsonProperty("source_name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Getter for the source's type.
+     *
+     * @return the type of the source.
+     */
+    @JsonProperty("source_type")
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Getter for the source's id.
+     *
+     * @return the id of the source.
+     */
+    @JsonProperty("source_id")
+    public String getId() {
+        return id;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/PermissionSource.java
+++ b/src/main/java/com/auth0/json/mgmt/PermissionSource.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Class that represents an Auth0 Permission's Soruce object. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
+ * Class that represents an Auth0 Permission's Source object. Related to the {@link com.auth0.client.mgmt.UsersEntity} entity.
  */
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
@@ -28,7 +28,6 @@ import com.auth0.json.mgmt.Permission;
 import com.auth0.json.mgmt.PermissionsPage;
 import com.auth0.json.mgmt.Role;
 import com.auth0.json.mgmt.RolesPage;
-import com.auth0.json.mgmt.users.User;
 import com.auth0.json.mgmt.users.UsersPage;
 import com.auth0.net.Request;
 import java.util.ArrayList;

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -32,7 +32,6 @@ import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.client.mgmt.filter.UserFilter;
 import com.auth0.json.mgmt.Permission;
 import com.auth0.json.mgmt.PermissionsPage;
-import com.auth0.json.mgmt.Role;
 import com.auth0.json.mgmt.RolesPage;
 import com.auth0.json.mgmt.guardian.Enrollment;
 import com.auth0.json.mgmt.logevents.LogEvent;

--- a/src/test/java/com/auth0/json/mgmt/permissions/PermissionSourceTest.java
+++ b/src/test/java/com/auth0/json/mgmt/permissions/PermissionSourceTest.java
@@ -1,0 +1,25 @@
+package com.auth0.json.mgmt.permissions;
+
+import com.auth0.json.JsonTest;
+import com.auth0.json.mgmt.PermissionSource;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class PermissionSourceTest extends JsonTest<PermissionSource> {
+
+    private static final String json = "{\"source_name\":\"sName\",\"source_id\":\"sId\",\"source_type\":\"sType\"}";
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        PermissionSource permission = fromJSON(json, PermissionSource.class);
+
+        assertThat(permission, is(notNullValue()));
+        assertThat(permission.getName(), is("sName"));
+        assertThat(permission.getId(), is("sId"));
+        assertThat(permission.getType(), is("sType"));
+    }
+
+}

--- a/src/test/java/com/auth0/json/mgmt/permissions/PermissionTest.java
+++ b/src/test/java/com/auth0/json/mgmt/permissions/PermissionTest.java
@@ -1,0 +1,49 @@
+package com.auth0.json.mgmt.permissions;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import com.auth0.json.mgmt.Permission;
+import com.auth0.json.mgmt.PermissionSource;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PermissionTest extends JsonTest<Permission> {
+
+    private static final String json = "{\"permission_name\":\"pName\",\"description\":\"pDesc\",\"resource_server_name\":\"resName\",\"resource_server_identifier\":\"resId\",\"sources\":[{\"source_id\":\"srcId\",\"source_name\":\"srcName\",\"source_type\":\"srcType\"}]}";
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        Permission permission = new Permission();
+        permission.setDescription("pDesc");
+        permission.setName("pName");
+        permission.setResourceServerId("resServerId");
+        permission.setResourceServerName("resServerName");
+
+        String serialized = toJSON(permission);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("description", "pDesc"));
+        assertThat(serialized, JsonMatcher.hasEntry("permission_name", "pName"));
+        assertThat(serialized, JsonMatcher.hasEntry("resource_server_identifier", "resServerId"));
+        assertThat(serialized, JsonMatcher.hasEntry("resource_server_name", "resServerName"));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        Permission permission = fromJSON(json, Permission.class);
+
+        assertThat(permission, is(notNullValue()));
+        assertThat(permission.getDescription(), is("pDesc"));
+        assertThat(permission.getName(), is("pName"));
+        assertThat(permission.getResourceServerId(), is("resId"));
+        assertThat(permission.getResourceServerName(), is("resName"));
+        assertThat(permission.getSources(), hasSize(1));
+
+        PermissionSource includedSource = permission.getSources().get(0);
+        assertThat(includedSource.getId(), is("srcId"));
+        assertThat(includedSource.getName(), is("srcName"));
+        assertThat(includedSource.getType(), is("srcType"));
+    }
+
+}

--- a/src/test/java/com/auth0/json/mgmt/permissions/PermissionsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/permissions/PermissionsPageTest.java
@@ -1,0 +1,40 @@
+package com.auth0.json.mgmt.permissions;
+
+import com.auth0.json.JsonTest;
+import com.auth0.json.mgmt.PermissionsPage;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PermissionsPageTest extends JsonTest<PermissionsPage> {
+    private static final String jsonWithTotals = "{\"start\":0,\"length\":10,\"total\":14,\"limit\":50,\"permissions\":[{\"permission_name\":\"pName\",\"description\":\"pDesc\",\"resource_server_name\":\"resName\",\"resource_server_identifier\":\"resId\",\"sources\":[]}]}";
+    private static final String jsonWithoutTotals = "[{\"permission_name\":\"pName\",\"description\":\"pDesc\",\"resource_server_name\":\"resName\",\"resource_server_identifier\":\"resId\",\"sources\":[]}]";
+
+    @Test
+    public void shouldDeserializeWithoutTotals() throws Exception {
+        PermissionsPage page = fromJSON(jsonWithoutTotals, PermissionsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(1));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        PermissionsPage page = fromJSON(jsonWithTotals, PermissionsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getLength(), is(10));
+        assertThat(page.getTotal(), is(14));
+        assertThat(page.getLimit(), is(50));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(1));
+    }
+
+}


### PR DESCRIPTION
### Changes

Adds a missing property to the Permission object. Mostly boilerplate code.

### References

Closes https://github.com/auth0/auth0-java/issues/246

### Testing
I've added missing tests for the `Permission` and its page object as well.
 
- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
