### PR TITLE
Add property owners and global to Client class

### DIFF
--- a/src/main/java/com/auth0/json/auth/CreatedUser.java
+++ b/src/main/java/com/auth0/json/auth/CreatedUser.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Class that holds the data of a newly created User. Obtained after a call to {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String)}
- * or {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String, String)}.
+ * Class that holds the data of a newly created User. Obtained after a call to {@link com.auth0.client.auth.AuthAPI#signUp(String, char[], String)}
+ * or {@link com.auth0.client.auth.AuthAPI#signUp(String, String, char[], String)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/auth0/json/auth/UserInfo.java
+++ b/src/main/java/com/auth0/json/auth/UserInfo.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 /**
  * Class that holds the Information related to a User's Access Token. Obtained after a call to {@link com.auth0.client.auth.AuthAPI#userInfo(String)},
- * {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String)} or {@link com.auth0.client.auth.AuthAPI#signUp(String, String, String, String)}.
+ * {@link com.auth0.client.auth.AuthAPI#signUp(String, char[], String)} or {@link com.auth0.client.auth.AuthAPI#signUp(String, String, char[], String)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -32,6 +32,8 @@ public class Client {
     private Boolean isFirstParty;
     @JsonProperty("oidc_conformant")
     private Boolean oidcConformant;
+    @JsonProperty("owners")
+    private List<String> owners;
     @JsonProperty("callbacks")
     private List<String> callbacks;
     @JsonProperty("allowed_origins")
@@ -236,6 +238,14 @@ public class Client {
     public void setOIDCConformant(Boolean oidcConformant) {
         this.oidcConformant = oidcConformant;
     }
+
+    /**
+     * Getter for the list of the owner of this client.
+     *
+     * @return the lisf of the owners.
+     */
+    @JsonProperty("owners")
+    public List<String> getOwners() { return owners; }
 
     /**
      * Getter for the list of allowed callback urls for the application.

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -36,6 +36,8 @@ public class Client {
     private List<String> owners;
     @JsonProperty("callbacks")
     private List<String> callbacks;
+    @JsonProperty("global")
+    private Boolean global;
     @JsonProperty("allowed_origins")
     private List<String> allowedOrigins;
     @JsonProperty("web_origins")
@@ -266,6 +268,13 @@ public class Client {
     public void setCallbacks(List<String> callbacks) {
         this.callbacks = callbacks;
     }
+
+    /**
+     * Whether this is your global 'All Applications' client representing legacy tenant settings (true) or a regular client (false).
+     *
+     * @return true if global client, false otherwise.
+     */
+    public Boolean isGlobal() { return global; }
 
     /**
      * Getter for the list of allowed origins for the application.

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -244,7 +244,7 @@ public class Client {
     /**
      * Getter for the list of the owner of this client.
      *
-     * @return the lisf of the owners.
+     * @return the list of the owners.
      */
     @JsonProperty("owners")
     public List<String> getOwners() { return owners; }

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ClientTest extends JsonTest<Client> {
 
-    private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"owners\":[\"mr|auth0|1234567890abcdf\"],\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
+    private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"owners\":[\"mr|auth0|1234567890abcdf\"],\"global\":true,\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
     private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
 
     @Test
@@ -133,6 +133,7 @@ public class ClientTest extends JsonTest<Client> {
 
         assertThat(client.getClientId(), is("clientId"));
         assertThat(client.isHerokuApp(), is(true));
+        assertThat(client.isGlobal(), is(true));
         assertThat(client.getOwners(), contains("mr|auth0|1234567890abcdf"));
         assertThat(client.getSigningKeys(), is(notNullValue()));
     }

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ClientTest extends JsonTest<Client> {
 
-    private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
+    private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"owners\":[\"mr|auth0|1234567890abcdf\"],\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
     private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
 
     @Test
@@ -133,6 +133,7 @@ public class ClientTest extends JsonTest<Client> {
 
         assertThat(client.getClientId(), is("clientId"));
         assertThat(client.isHerokuApp(), is(true));
+        assertThat(client.getOwners(), contains("mr|auth0|1234567890abcdf"));
         assertThat(client.getSigningKeys(), is(notNullValue()));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -18,11 +18,12 @@ public class UserTest extends JsonTest<User> {
     private static final String readOnlyJson = "{\"user_id\":\"user|123\",\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"last_password_reset\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[]}";
 
     @Test
-    public void shouldHaveEmptyValuesByDefault() throws Exception{
+    public void shouldHaveEmptyValuesByDefault() {
         User user = new User();
         assertThat(user.getValues(), is(notNullValue()));
 
-        User user2 = new User("my-connection");
+        User user2 = new User();
+        user2.setConnection("my-connection");
         assertThat(user2.getConnection(), is("my-connection"));
         assertThat(user2.getValues(), is(notNullValue()));
     }


### PR DESCRIPTION
### Changes

- Add a missing property `owners` to the Client object.
- Replace deprecated reference `AuthAPI#signUp(String, String, String)` by `AuthAPI#signUp(String, char[], String)}`
- Add a missing property `global` to the Client object.

### References

- N/A

### Testing

- [x] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors