### PR TITLE
Update to OkHttp 3.14.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,15 +60,15 @@ test {
 }
 
 dependencies {
-    implementation 'com.squareup.okhttp3:okhttp:3.9.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0.pr3'
     implementation 'commons-codec:commons-codec:1.13'
     implementation 'com.auth0:java-jwt:3.10.3'
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.65'
     testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.9.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.9'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'junit:junit:4.12'

--- a/src/test/java/com/auth0/client/RecordedRequestMatcher.java
+++ b/src/test/java/com/auth0/client/RecordedRequestMatcher.java
@@ -1,5 +1,6 @@
 package com.auth0.client;
 
+import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -71,21 +72,19 @@ public class RecordedRequestMatcher extends TypeSafeDiagnosingMatcher<RecordedRe
     }
 
     private boolean matchesQueryParameter(RecordedRequest item, Description mismatchDescription) {
-        String path = item.getPath();
-        boolean hasQuery = path.indexOf("?") > 0;
-        if (!hasQuery) {
+        HttpUrl requestUrl = item.getRequestUrl();
+        if (requestUrl.querySize() == 0) {
             mismatchDescription.appendText(" query was empty");
             return false;
         }
 
-        String query = path.substring(path.indexOf("?") + 1, path.length());
-        String[] parameters = query.split("&");
-        for (String p : parameters) {
-            if (p.equals(String.format("%s=%s", first, second))) {
-                return true;
-            }
+        String queryParamValue = requestUrl.queryParameter(first);
+        if (second.equals(queryParamValue)) {
+            return true;
         }
-        mismatchDescription.appendValueList("Query parameters were {", ", ", "}.", parameters);
+
+        mismatchDescription.appendValueList("Query parameters were {", ", ", "}.",
+                requestUrl.query().split("&"));
         return false;
     }
 

--- a/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
@@ -106,7 +106,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("q", "email%3A%5C*%40gmail.com"));
+        assertThat(recordedRequest, hasQueryParameter("q", "email:\\*@gmail.com"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(2));

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -194,7 +194,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
         assertThat(recordedRequest, not(hasQueryParameter("search_engine")));
-        assertThat(recordedRequest, hasQueryParameter("q", "email%3A%5C*%40gmail.com"));
+        assertThat(recordedRequest, hasQueryParameter("q", "email:\\*@gmail.com"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(2));


### PR DESCRIPTION
### Changes

* Updates to OkHttp 3.14.9, continuing the work started in #231.
* Updates `RecordedRequestMatcher.matchesQueryParameter` to use the `HttpUrl` and query methods instead of parsing the path manually. Also enables tests to expect the unencoded query parameter values.

### References

See the discussion on #231 for context and background regarding OkHttp changes to query parameter encoding (tl;dr - Since v3.10.0 more characters are being encoded).

### Testing

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
