### PR TITLE
Add support for java Proxy with basic auth

### DIFF
--- a/src/main/java/com/auth0/client/ClientOptions.java
+++ b/src/main/java/com/auth0/client/ClientOptions.java
@@ -1,0 +1,27 @@
+package com.auth0.client;
+
+/**
+ * Class holder of additional options to set to the API client instance.
+ */
+public class ClientOptions {
+
+    private ProxyOptions proxyOptions;
+
+    /**
+     * Getter for the Proxy configuration options
+     *
+     * @return the Proxy configuration options if set, null otherwise.
+     */
+    public ProxyOptions getProxyOptions() {
+        return proxyOptions;
+    }
+
+    /**
+     * Setter for the Proxy configuration options
+     *
+     * @param proxyOptions the Proxy configuration options
+     */
+    public void setProxyOptions(ProxyOptions proxyOptions) {
+        this.proxyOptions = proxyOptions;
+    }
+}

--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -3,7 +3,7 @@ package com.auth0.client;
 /**
  * Class holder of additional options to set to the API client instance.
  */
-public class ClientOptions {
+public class HttpOptions {
 
     private ProxyOptions proxyOptions;
 

--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -1,7 +1,7 @@
 package com.auth0.client;
 
 /**
- * Class holder of additional options to set to the API client instance.
+ * Used to configure additional configuration options when customizing the API client instance.
  */
 public class HttpOptions {
 

--- a/src/main/java/com/auth0/client/ProxyOptions.java
+++ b/src/main/java/com/auth0/client/ProxyOptions.java
@@ -1,0 +1,56 @@
+package com.auth0.client;
+
+import com.auth0.utils.Asserts;
+import okhttp3.Credentials;
+
+import java.net.Proxy;
+
+/**
+ * Holder class for Java Proxy related settings.
+ */
+public class ProxyOptions {
+
+    private final Proxy proxy;
+    private String basicAuth;
+
+    /**
+     * Builds a new instance using the given Proxy.
+     * The Proxy will not have authentication unless {@link #setBasicAuthentication(String, char[])} is set.
+     *
+     * @param proxy the Proxy to use.
+     */
+    public ProxyOptions(Proxy proxy) {
+        Asserts.assertNotNull(proxy, "proxy");
+        this.proxy = proxy;
+    }
+
+    /**
+     * Setter that builds the authentication value to use for this Proxy.
+     *
+     * @param username the username to use.
+     * @param password the password to use.
+     */
+    public void setBasicAuthentication(String username, char[] password) {
+        Asserts.assertNotNull(proxy, "username");
+        Asserts.assertNotNull(proxy, "password");
+        this.basicAuth = Credentials.basic(username, new String(password));
+    }
+
+    /**
+     * Getter of the Proxy instance to set
+     *
+     * @return the Proxy instance to set
+     */
+    public Proxy getProxy() {
+        return proxy;
+    }
+
+    /**
+     * Getter of the authentication value to use for this Proxy.
+     *
+     * @return the authentication value to use for this Proxy, or null if unset.
+     */
+    public String getBasicAuthentication() {
+        return basicAuth;
+    }
+}

--- a/src/main/java/com/auth0/client/ProxyOptions.java
+++ b/src/main/java/com/auth0/client/ProxyOptions.java
@@ -6,7 +6,7 @@ import okhttp3.Credentials;
 import java.net.Proxy;
 
 /**
- * Holder class for Java Proxy related settings.
+ * Used to configure Java Proxy-related configurations.
  */
 public class ProxyOptions {
 

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1,6 +1,6 @@
 package com.auth0.client.auth;
 
-import com.auth0.client.ClientOptions;
+import com.auth0.client.HttpOptions;
 import com.auth0.client.ProxyOptions;
 import com.auth0.json.auth.UserInfo;
 import com.auth0.net.Request;
@@ -51,7 +51,7 @@ public class AuthAPI {
      * @param clientSecret the application's client secret.
      * @param options      configuration options for this client instance.
      */
-    public AuthAPI(String domain, String clientId, String clientSecret, ClientOptions options) {
+    public AuthAPI(String domain, String clientId, String clientSecret, HttpOptions options) {
         Asserts.assertNotNull(domain, "domain");
         Asserts.assertNotNull(clientId, "client id");
         Asserts.assertNotNull(clientSecret, "client secret");
@@ -78,7 +78,7 @@ public class AuthAPI {
      * @param clientSecret the application's client secret.
      */
     public AuthAPI(String domain, String clientId, String clientSecret) {
-        this(domain, clientId, clientSecret, new ClientOptions());
+        this(domain, clientId, clientSecret, new HttpOptions());
     }
 
     /**
@@ -88,7 +88,7 @@ public class AuthAPI {
      * @param options the options to set to the client.
      * @return a new networking client instance configured as requested.
      */
-    private OkHttpClient buildNetworkingClient(ClientOptions options) {
+    private OkHttpClient buildNetworkingClient(HttpOptions options) {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
         final ProxyOptions proxyOptions = options.getProxyOptions();
         if (proxyOptions != null) {

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -44,12 +44,15 @@ public class AuthAPI {
     private final HttpLoggingInterceptor logging;
 
     /**
-     * Create a new instance with the given tenant's domain, application's client id and client secret. These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
+     * Create a new instance with the given tenant's domain, application's client id and client secret.
+     * These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
+     * In addition, accepts an {@link HttpOptions} that will be used to configure the networking client.
      *
      * @param domain       tenant's domain.
      * @param clientId     the application's client id.
      * @param clientSecret the application's client secret.
      * @param options      configuration options for this client instance.
+     * @see #AuthAPI(String, String, String)
      */
     public AuthAPI(String domain, String clientId, String clientSecret, HttpOptions options) {
         Asserts.assertNotNull(domain, "domain");
@@ -71,7 +74,8 @@ public class AuthAPI {
     }
 
     /**
-     * Create a new instance with the given tenant's domain, application's client id and client secret. These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
+     * Create a new instance with the given tenant's domain, application's client id and client secret.
+     * These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
      *
      * @param domain       tenant's domain.
      * @param clientId     the application's client id.

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -26,11 +26,14 @@ public class ManagementAPI {
 
     /**
      * Create an instance with the given tenant's domain and API token.
-     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens to learn how to obtain a token.
+     * In addition, accepts an {@link HttpOptions} that will be used to configure the networking client.
+     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens
+     * to learn how to obtain a token.
      *
      * @param domain   the tenant's domain.
      * @param apiToken the token to authenticate the calls with.
      * @param options  configuration options for this client instance.
+     * @see #ManagementAPI(String, String)
      */
     public ManagementAPI(String domain, String apiToken, HttpOptions options) {
         Asserts.assertNotNull(domain, "domain");
@@ -50,7 +53,8 @@ public class ManagementAPI {
 
     /**
      * Create an instance with the given tenant's domain and API token.
-     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens to learn how to obtain a token.
+     * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens
+     * to learn how to obtain a token.
      *
      * @param domain   the tenant's domain.
      * @param apiToken the token to authenticate the calls with.

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -1,6 +1,6 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.client.ClientOptions;
+import com.auth0.client.HttpOptions;
 import com.auth0.client.ProxyOptions;
 import com.auth0.net.Telemetry;
 import com.auth0.net.TelemetryInterceptor;
@@ -32,7 +32,7 @@ public class ManagementAPI {
      * @param apiToken the token to authenticate the calls with.
      * @param options  configuration options for this client instance.
      */
-    public ManagementAPI(String domain, String apiToken, ClientOptions options) {
+    public ManagementAPI(String domain, String apiToken, HttpOptions options) {
         Asserts.assertNotNull(domain, "domain");
         Asserts.assertNotNull(apiToken, "api token");
 
@@ -56,7 +56,7 @@ public class ManagementAPI {
      * @param apiToken the token to authenticate the calls with.
      */
     public ManagementAPI(String domain, String apiToken) {
-        this(domain, apiToken, new ClientOptions());
+        this(domain, apiToken, new HttpOptions());
     }
 
     /**
@@ -66,7 +66,7 @@ public class ManagementAPI {
      * @param options the options to set to the client.
      * @return a new networking client instance configured as requested.
      */
-    private OkHttpClient buildNetworkingClient(ClientOptions options) {
+    private OkHttpClient buildNetworkingClient(HttpOptions options) {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
         final ProxyOptions proxyOptions = options.getProxyOptions();
         if (proxyOptions != null) {

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1,14 +1,17 @@
 package com.auth0.client.auth;
 
+import com.auth0.client.ClientOptions;
 import com.auth0.client.MockServer;
+import com.auth0.client.ProxyOptions;
 import com.auth0.exception.APIException;
 import com.auth0.json.auth.CreatedUser;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.json.auth.UserInfo;
+import com.auth0.net.Request;
 import com.auth0.net.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import okhttp3.Interceptor;
+import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -20,6 +23,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.io.FileReader;
+import java.net.Proxy;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +106,123 @@ public class AuthAPITest {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'client secret' cannot be null!");
         new AuthAPI(DOMAIN, CLIENT_ID, null);
+    }
+
+    @Test
+    public void shouldNotUseProxyByDefault() throws Exception {
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+        assertThat(api.getClient().proxy(), is(nullValue()));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request nonAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .build();
+        okhttp3.Response nonAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(nonAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, nonAuthenticatedResponse);
+        assertThat(processedRequest, is(nullValue()));
+    }
+
+    @Test
+    public void shouldUseProxy() throws Exception {
+        Proxy proxy = Mockito.mock(Proxy.class);
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        ClientOptions clientOptions = new ClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, clientOptions);
+        assertThat(api.getClient().proxy(), is(proxy));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request nonAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .build();
+        okhttp3.Response nonAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(nonAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, nonAuthenticatedResponse);
+
+        assertThat(processedRequest, is(nullValue()));
+    }
+
+    @Test
+    public void shouldUseProxyWithAuthentication() throws Exception {
+        Proxy proxy = Mockito.mock(Proxy.class);
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
+        assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
+        ClientOptions clientOptions = new ClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, clientOptions);
+        assertThat(api.getClient().proxy(), is(proxy));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request nonAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .build();
+        okhttp3.Response nonAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(nonAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, nonAuthenticatedResponse);
+
+        assertThat(processedRequest, is(notNullValue()));
+        assertThat(processedRequest.url(), is(HttpUrl.parse("https://test.com/app")));
+        assertThat(processedRequest.header("Proxy-Authorization"), is(proxyOptions.getBasicAuthentication()));
+        assertThat(processedRequest.header("some-header"), is("some-value"));
+    }
+
+    @Test
+    public void proxyShouldNotProcessAlreadyAuthenticatedRequest() throws Exception {
+        Proxy proxy = Mockito.mock(Proxy.class);
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
+        assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
+        ClientOptions clientOptions = new ClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, clientOptions);
+        assertThat(api.getClient().proxy(), is(proxy));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request alreadyAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .header("Proxy-Authorization", "pre-existing-value")
+                .build();
+        okhttp3.Response alreadyAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(alreadyAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, alreadyAuthenticatedResponse);
+        assertThat(processedRequest, is(nullValue()));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1,6 +1,6 @@
 package com.auth0.client.auth;
 
-import com.auth0.client.ClientOptions;
+import com.auth0.client.HttpOptions;
 import com.auth0.client.MockServer;
 import com.auth0.client.ProxyOptions;
 import com.auth0.exception.APIException;
@@ -135,10 +135,10 @@ public class AuthAPITest {
     public void shouldUseProxy() throws Exception {
         Proxy proxy = Mockito.mock(Proxy.class);
         ProxyOptions proxyOptions = new ProxyOptions(proxy);
-        ClientOptions clientOptions = new ClientOptions();
-        clientOptions.setProxyOptions(proxyOptions);
+        HttpOptions httpOptions = new HttpOptions();
+        httpOptions.setProxyOptions(proxyOptions);
 
-        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, clientOptions);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, httpOptions);
         assertThat(api.getClient().proxy(), is(proxy));
         Authenticator authenticator = api.getClient().proxyAuthenticator();
         assertThat(authenticator, is(notNullValue()));
@@ -166,10 +166,10 @@ public class AuthAPITest {
         ProxyOptions proxyOptions = new ProxyOptions(proxy);
         proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
         assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
-        ClientOptions clientOptions = new ClientOptions();
-        clientOptions.setProxyOptions(proxyOptions);
+        HttpOptions httpOptions = new HttpOptions();
+        httpOptions.setProxyOptions(proxyOptions);
 
-        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, clientOptions);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, httpOptions);
         assertThat(api.getClient().proxy(), is(proxy));
         Authenticator authenticator = api.getClient().proxyAuthenticator();
         assertThat(authenticator, is(notNullValue()));
@@ -200,10 +200,10 @@ public class AuthAPITest {
         ProxyOptions proxyOptions = new ProxyOptions(proxy);
         proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
         assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
-        ClientOptions clientOptions = new ClientOptions();
-        clientOptions.setProxyOptions(proxyOptions);
+        HttpOptions httpOptions = new HttpOptions();
+        httpOptions.setProxyOptions(proxyOptions);
 
-        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, clientOptions);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, httpOptions);
         assertThat(api.getClient().proxy(), is(proxy));
         Authenticator authenticator = api.getClient().proxyAuthenticator();
         assertThat(authenticator, is(notNullValue()));

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -1,9 +1,12 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.client.ClientOptions;
 import com.auth0.client.MockServer;
+import com.auth0.client.ProxyOptions;
+import com.auth0.client.auth.AuthAPI;
 import com.auth0.net.Telemetry;
 import com.auth0.net.TelemetryInterceptor;
-import okhttp3.Interceptor;
+import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.junit.After;
 import org.junit.Before;
@@ -11,6 +14,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+
+import java.net.Proxy;
 
 import static com.auth0.client.UrlMatcher.isUrl;
 import static okhttp3.logging.HttpLoggingInterceptor.Level;
@@ -131,6 +136,123 @@ public class ManagementAPITest {
         assertThat(api.tickets().apiToken, is("new token"));
         assertThat(api.userBlocks().apiToken, is("new token"));
         assertThat(api.users().apiToken, is("new token"));
+    }
+
+    @Test
+    public void shouldNotUseProxyByDefault() throws Exception {
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
+        assertThat(api.getClient().proxy(), is(nullValue()));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request nonAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .build();
+        okhttp3.Response nonAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(nonAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, nonAuthenticatedResponse);
+        assertThat(processedRequest, is(nullValue()));
+    }
+
+    @Test
+    public void shouldUseProxy() throws Exception {
+        Proxy proxy = Mockito.mock(Proxy.class);
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        ClientOptions clientOptions = new ClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, clientOptions);
+        assertThat(api.getClient().proxy(), is(proxy));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request nonAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .build();
+        okhttp3.Response nonAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(nonAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, nonAuthenticatedResponse);
+
+        assertThat(processedRequest, is(nullValue()));
+    }
+
+    @Test
+    public void shouldUseProxyWithAuthentication() throws Exception {
+        Proxy proxy = Mockito.mock(Proxy.class);
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
+        assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
+        ClientOptions clientOptions = new ClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, clientOptions);
+        assertThat(api.getClient().proxy(), is(proxy));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request nonAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .build();
+        okhttp3.Response nonAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(nonAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, nonAuthenticatedResponse);
+
+        assertThat(processedRequest, is(notNullValue()));
+        assertThat(processedRequest.url(), is(HttpUrl.parse("https://test.com/app")));
+        assertThat(processedRequest.header("Proxy-Authorization"), is(proxyOptions.getBasicAuthentication()));
+        assertThat(processedRequest.header("some-header"), is("some-value"));
+    }
+
+    @Test
+    public void proxyShouldNotProcessAlreadyAuthenticatedRequest() throws Exception {
+        Proxy proxy = Mockito.mock(Proxy.class);
+        ProxyOptions proxyOptions = new ProxyOptions(proxy);
+        proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
+        assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
+        ClientOptions clientOptions = new ClientOptions();
+        clientOptions.setProxyOptions(proxyOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, clientOptions);
+        assertThat(api.getClient().proxy(), is(proxy));
+        Authenticator authenticator = api.getClient().proxyAuthenticator();
+        assertThat(authenticator, is(notNullValue()));
+
+        Route route = Mockito.mock(Route.class);
+        okhttp3.Request alreadyAuthenticatedRequest = new okhttp3.Request.Builder()
+                .url("https://test.com/app")
+                .addHeader("some-header", "some-value")
+                .header("Proxy-Authorization", "pre-existing-value")
+                .build();
+        okhttp3.Response alreadyAuthenticatedResponse = new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("OK")
+                .request(alreadyAuthenticatedRequest)
+                .build();
+
+        okhttp3.Request processedRequest = authenticator.authenticate(route, alreadyAuthenticatedResponse);
+        assertThat(processedRequest, is(nullValue()));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -1,9 +1,8 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.client.ClientOptions;
+import com.auth0.client.HttpOptions;
 import com.auth0.client.MockServer;
 import com.auth0.client.ProxyOptions;
-import com.auth0.client.auth.AuthAPI;
 import com.auth0.net.Telemetry;
 import com.auth0.net.TelemetryInterceptor;
 import okhttp3.*;
@@ -165,10 +164,10 @@ public class ManagementAPITest {
     public void shouldUseProxy() throws Exception {
         Proxy proxy = Mockito.mock(Proxy.class);
         ProxyOptions proxyOptions = new ProxyOptions(proxy);
-        ClientOptions clientOptions = new ClientOptions();
-        clientOptions.setProxyOptions(proxyOptions);
+        HttpOptions httpOptions = new HttpOptions();
+        httpOptions.setProxyOptions(proxyOptions);
 
-        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, clientOptions);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, httpOptions);
         assertThat(api.getClient().proxy(), is(proxy));
         Authenticator authenticator = api.getClient().proxyAuthenticator();
         assertThat(authenticator, is(notNullValue()));
@@ -196,10 +195,10 @@ public class ManagementAPITest {
         ProxyOptions proxyOptions = new ProxyOptions(proxy);
         proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
         assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
-        ClientOptions clientOptions = new ClientOptions();
-        clientOptions.setProxyOptions(proxyOptions);
+        HttpOptions httpOptions = new HttpOptions();
+        httpOptions.setProxyOptions(proxyOptions);
 
-        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, clientOptions);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, httpOptions);
         assertThat(api.getClient().proxy(), is(proxy));
         Authenticator authenticator = api.getClient().proxyAuthenticator();
         assertThat(authenticator, is(notNullValue()));
@@ -230,10 +229,10 @@ public class ManagementAPITest {
         ProxyOptions proxyOptions = new ProxyOptions(proxy);
         proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray());
         assertThat(proxyOptions.getBasicAuthentication(), is("Basic am9obmRvZTpwc3N3ZA=="));
-        ClientOptions clientOptions = new ClientOptions();
-        clientOptions.setProxyOptions(proxyOptions);
+        HttpOptions httpOptions = new HttpOptions();
+        httpOptions.setProxyOptions(proxyOptions);
 
-        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, clientOptions);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, httpOptions);
         assertThat(api.getClient().proxy(), is(proxy));
         Authenticator authenticator = api.getClient().proxyAuthenticator();
         assertThat(authenticator, is(notNullValue()));


### PR DESCRIPTION
### Changes
This PR adds a new constructor for both `AuthAPI` and `ManagementAPI` classes that accepts a set of `ClientOptions` (final name can still change). 

The idea is that from now on, every new property that we want to configure in the OkHttpClient comes through this options object. This way, we reduce the exposure of third-party classes in our public API.

For now, this Options object accepts a `ProxyOptions` object (final name also subject to change), that will hold the **Proxy** instance and any basic authentication, if required.

#### Usage

```java
Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 9090));
ProxyOptions proxyOptions = new ProxyOptions(proxy);
//proxyOptions.setBasicAuthentication("johndoe", "psswd".toCharArray()); //- Optional
HttpOptions httpOptions = new HttpOptions();
httpOptions.setProxyOptions(proxyOptions);

AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, httpOptions);
```
#### Local environment setup

In order to test the SDK with a Proxy, I've followed these steps to set up a local proxy:
1. Download [proxyman](https://proxyman.io/) or any other proxy that supports authentication.
2. Enable the Proxy. Browser requests should be blocked for now.
3. Whitelist the proxy certificate in the keychain and trust it. Proxyman offers a helper tool to do this for you when provided with the root password. Browser requests should start coming through the proxy now.
4. Whitelist the proxy certificate in the JVM and trust it. I've achieved this with the following command:

```
sudo keytool -keystore ${JAVA_HOME}/jre/lib/security/cacerts -storepass changeit -import -trustcacerts -v -alias {alias}CA -file {certificate}.pem
```

Create a class or test to try the code snippet in the section above. Requests made by classes, like tests, should now come through. 

### References

The feature was originally requested here https://github.com/auth0/auth0-java/issues/91

### Testing

- [x] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
