### PR TITLE
Add display_name property to Connection

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/Connection.java
@@ -83,7 +83,7 @@ public class Connection {
     }
 
     /**
-     * Getter for the connection name, used in the new universal login experience.
+     * Getter for the connection display name, used in the new universal login experience.
      *
      * @return the connection display name.
      */
@@ -93,7 +93,7 @@ public class Connection {
     }
 
     /**
-     * Setter for the connection name, used in the new universal login experience.
+     * Setter for the connection display name, used in the new universal login experience.
      *
      * @param displayName the connection display name to set.
      */

--- a/src/main/java/com/auth0/json/mgmt/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/Connection.java
@@ -18,6 +18,8 @@ public class Connection {
 
     @JsonProperty("name")
     private String name;
+    @JsonProperty("display_name")
+    private String displayName;
     @JsonProperty("options")
     private Map<String, Object> options;
     @JsonProperty("id")
@@ -61,7 +63,7 @@ public class Connection {
     }
 
     /**
-     * Getter for the connection options.
+     * Setter for the connection options.
      *
      * @param options the connection options.
      */
@@ -78,6 +80,26 @@ public class Connection {
     @JsonProperty("id")
     public String getId() {
         return id;
+    }
+
+    /**
+     * Getter for the connection name, used in the new universal login experience.
+     *
+     * @return the connection display name.
+     */
+    @JsonProperty("display_name")
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Setter for the connection name, used in the new universal login experience.
+     *
+     * @param displayName the connection display name to set.
+     */
+    @JsonProperty("display_name")
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 
     /**
@@ -109,7 +131,7 @@ public class Connection {
     public void setEnabledClients(List<String> enabledClients) {
         this.enabledClients = enabledClients;
     }
-    
+
     /**
      * Getter for the ad/ldap connection's ticket url.
      *
@@ -122,21 +144,21 @@ public class Connection {
 
     /**
      * Getter for the metadata of this connection.
-     * 
+     *
      * @return the map of metadata key-values.
      */
     @JsonProperty("metadata")
     public Map<String, String> getMetadata() {
-    	return metadata;
+        return metadata;
     }
-    
+
     /**
      * Setter for the metadata of this connection.
-     * 
+     *
      * @param metadata the map of metadata key-values.
      */
     @JsonProperty("metadata")
     public void setMetadata(Map<String, String> metadata) {
-    	this.metadata = metadata;
+        this.metadata = metadata;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/ConnectionTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ConnectionTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ConnectionTest extends JsonTest<Connection> {
 
-    private static final String json = "{\"name\": \"my-connection\",\"strategy\": \"auth0\",\"options\": {},\"enabled_clients\": [\"client1\",\"client2\"],\"metadata\": {\"key\": \"value\"}}";
+    private static final String json = "{\"name\": \"my-connection\",\"display_name\": \"My cool connection!\",\"strategy\": \"auth0\",\"options\": {},\"enabled_clients\": [\"client1\",\"client2\"],\"metadata\": {\"key\": \"value\"}}";
     private static final String readOnlyJson = "{\"id\":\"connectionId\"}";
 
     private static final String jsonAd = "{\"name\":\"my-ad-connection\",\"strategy\":\"ad\",\"provisioning_ticket_url\":\"https://demo.auth0.com/p/ad/ddQTRlVt\",\"options\":{},\"enabled_clients\":[\"client1\",\"client2\"]}";
@@ -20,6 +20,7 @@ public class ConnectionTest extends JsonTest<Connection> {
     @Test
     public void shouldSerialize() throws Exception {
         Connection connection = new Connection("my-connection", "auth0");
+        connection.setDisplayName("COOL!");
         connection.setOptions(new HashMap<String, Object>());
         connection.setEnabledClients(Arrays.asList("client1", "client2"));
         connection.setMetadata(new HashMap<String, String>());
@@ -27,6 +28,7 @@ public class ConnectionTest extends JsonTest<Connection> {
         String serialized = toJSON(connection);
         assertThat(serialized, is(notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("name", "my-connection"));
+        assertThat(serialized, JsonMatcher.hasEntry("display_name", "COOL!"));
         assertThat(serialized, JsonMatcher.hasEntry("strategy", "auth0"));
         assertThat(serialized, JsonMatcher.hasEntry("options", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("enabled_clients", Arrays.asList("client1", "client2")));
@@ -40,6 +42,7 @@ public class ConnectionTest extends JsonTest<Connection> {
 
         assertThat(connection, is(notNullValue()));
         assertThat(connection.getName(), is("my-connection"));
+        assertThat(connection.getDisplayName(), is("My cool connection!"));
         assertThat(connection.getOptions(), is(notNullValue()));
         assertThat(connection.getStrategy(), is("auth0"));
         assertThat(connection.getEnabledClients(), contains("client1", "client2"));


### PR DESCRIPTION
### Changes

Adds the missing `display_name` property to the Connection class.

### References

* Closes https://github.com/auth0/auth0-java/issues/252.
* Resolves `SDK-1624`

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
