### PR TITLE
#269 : Missing Management API Functionality for Linking User Accounts…

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -338,12 +338,12 @@ public class UsersEntity extends BaseManagementEntity {
     }
 
     /**
-     * Links two User's Identities via token using the link_with parameter.
-     * A token with scope update:users is needed or update:current_user_identities if access token is for same user.
+     * A token with scope update:current_user_identities is needed.
+     * It only works for the user the access token represents.
      * See https://auth0.com/docs/api/management/v2#!/Users/post_identities
      *
-     * @param primaryUserId   the primary identity's user id
-     * @param secondaryIdToken the user identity token (JWT)
+     * @param primaryUserId the primary identity's user id associated with the access token this client was configured with.
+     * @param secondaryIdToken the user ID token representing the identity to link with the current user
      * @return a Request to execute.
      */
     public Request<List<Identity>> linkIdentity(String primaryUserId, String secondaryIdToken) {

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -338,6 +338,35 @@ public class UsersEntity extends BaseManagementEntity {
     }
 
     /**
+     * Links two User's Identities via token using the link_with parameter.
+     * A token with scope update:users is needed or update:current_user_identities if access token is for same user.
+     * See https://auth0.com/docs/api/management/v2#!/Users/post_identities
+     *
+     * @param primaryUserId   the primary identity's user id
+     * @param secondaryIdToken the user identity token (JWT)
+     * @return a Request to execute.
+     */
+    public Request<List<Identity>> linkIdentity(String primaryUserId, String secondaryIdToken) {
+        Asserts.assertNotNull(primaryUserId, "primary user id");
+        Asserts.assertNotNull(secondaryIdToken, "secondary id token");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments("api/v2/users")
+                .addPathSegment(primaryUserId)
+                .addPathSegment("identities")
+                .build()
+                .toString();
+
+        CustomRequest<List<Identity>> request = new CustomRequest<>(client, url, "POST", new TypeReference<List<Identity>>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.addParameter("link_with", secondaryIdToken);
+
+        return request;
+    }
+
+    /**
      * Un-links two User's Identities.
      * A token with scope update:users is needed.
      * See https://auth0.com/docs/api/management/v2#!/Users/delete_provider_by_user_id

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -585,7 +585,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     public void shouldThrowOnLinkUserIdentityWithNullUserId() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'primary user id' cannot be null!");
-        api.users().linkIdentity("1", null);
+        api.users().linkIdentity(null, "2");
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -582,6 +582,13 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldThrowOnLinkUserIdentityWithNullUserId() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'primary user id' cannot be null!");
+        api.users().linkIdentity("1", null);
+    }
+
+    @Test
     public void shouldThrowOnLinkUserIdentityWithNullProvider() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'provider' cannot be null!");

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -575,6 +575,13 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldThrowOnLinkUserIdentityWithNullSecondaryToken() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'secondary id token' cannot be null!");
+        api.users().linkIdentity("1", null);
+    }
+
+    @Test
     public void shouldThrowOnLinkUserIdentityWithNullProvider() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'provider' cannot be null!");
@@ -598,6 +605,26 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(body.size(), is(2));
         assertThat(body, hasEntry("provider", (Object) "auth0"));
         assertThat(body, hasEntry("user_id", (Object) "2"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldLinkUserIdentityBySecondaryIdToken() throws Exception {
+        Request<List<Identity>> request = api.users().linkIdentity("1", "2");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_IDENTITIES_LIST, 200);
+        List<Identity> response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/identities"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(1));
+        assertThat(body, hasEntry("link_with", (Object) "2"));
 
         assertThat(response, is(notNullValue()));
     }


### PR DESCRIPTION
### Changes

The Java Auth0 API is missing the ability to link accounts using the "link_with" body parameter option. This is useful for when the client sends the secondary ID token to link with.

Override the linkIdentity method in UsersEntity.java to support the ability to supply a ID token instead of a connection and provider string. 

### References

https://github.com/auth0/auth0-java/issues/269
See: https://auth0.com/docs/api/management/v2#!/Users/post_identities

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ X] This change adds test coverage
- [ X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ X] All existing and new tests complete without errors
