### PR TITLE
Add support for Log Streams

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -1,0 +1,141 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.json.mgmt.logstreams.LogStream;
+import com.auth0.net.CustomRequest;
+import com.auth0.net.Request;
+import com.auth0.net.VoidRequest;
+import com.auth0.utils.Asserts;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+
+import java.util.List;
+
+/**
+ * Class that provides an implementation of the Log Streams methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Log_Streams
+ * <p>
+ * This class is not thread-safe.
+ *
+ * @see ManagementAPI
+ */
+public class LogStreamsEntity extends BaseManagementEntity {
+
+    private final static String LOG_STREAMS_PATH = "api/v2/log-streams";
+    private final static String AUTHORIZATION_HEADER = "Authorization";
+
+    LogStreamsEntity(OkHttpClient client, HttpUrl baseUrl, String apiToken) {
+        super(client, baseUrl, apiToken);
+    }
+
+    /**
+     * Creates a request to get all Log Streams.
+     * See the <a href="https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams">API Documentation for more information.</a>
+     *
+     * @return the request to execute.
+     */
+    public Request<List<LogStream>> list() {
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments(LOG_STREAMS_PATH)
+                .build()
+                .toString();
+
+        CustomRequest<List<LogStream>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<LogStream>>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Creates a request to get a single Log Stream by its ID.
+     * See the <a href="https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams_by_id">API Documentation for more information.</a>
+     *
+     * @param logStreamId The ID of the Log Stream to retrieve.
+     * @return the request to execute.
+     */
+    public Request<LogStream> get(String logStreamId) {
+        Asserts.assertNotNull(logStreamId, "logStreamId");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments(LOG_STREAMS_PATH)
+                .addPathSegment(logStreamId)
+                .build()
+                .toString();
+
+        CustomRequest<LogStream> request = new CustomRequest<>(client, url, "GET", new TypeReference<LogStream>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Creates a request to create a Log Stream.
+     * See the <a href="https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams">API Documentation for more information.</a>
+     *
+     * @param logStream The {@linkplain LogStream} to create.
+     * @return the request to execute.
+     */
+    public Request<LogStream> create(LogStream logStream) {
+        Asserts.assertNotNull(logStream, "logStream");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments(LOG_STREAMS_PATH)
+                .build()
+                .toString();
+
+        CustomRequest<LogStream> request = new CustomRequest<>(client, url, "POST", new TypeReference<LogStream>(){});
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(logStream);
+        return request;
+    }
+
+    /**
+     * Creates a request to update a Log Stream.
+     * See the <a href="https://auth0.com/docs/api/management/v2#!/Log_Streams/patch_log_streams_by_id">API Documentation for more information.</a>
+     *
+     * @param logStreamId The ID of the Log Stream to update.
+     * @param logStream   The {@linkplain LogStream} to update.
+     * @return the request to execute.
+     */
+    public Request<LogStream> update(String logStreamId, LogStream logStream) {
+        Asserts.assertNotNull(logStreamId, "logStreamId");
+        Asserts.assertNotNull(logStream, "logStream");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments(LOG_STREAMS_PATH)
+                .addPathSegment(logStreamId)
+                .build()
+                .toString();
+
+        CustomRequest<LogStream> request = new CustomRequest<>(client, url, "PATCH", new TypeReference<LogStream>(){
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(logStream);
+        return request;
+    }
+
+    /**
+     * Creates a request to delete a Log Stream.
+     * See the <a href="https://auth0.com/docs/api/management/v2#!/Log_Streams/delete_log_streams_by_id">API Documentation for more information.</a>
+     *
+     * @param logStreamId The ID of the Log Stream to delete.
+     * @return the request to execute.
+     */
+    public Request delete(String logStreamId) {
+        Asserts.assertNotNull(logStreamId, "logStreamId");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegments(LOG_STREAMS_PATH)
+                .addPathSegment(logStreamId)
+                .build()
+                .toString();
+
+        VoidRequest request = new VoidRequest(client, url, "DELETE");
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -77,7 +77,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
      * @return the request to execute.
      */
     public Request<LogStream> create(LogStream logStream) {
-        Asserts.assertNotNull(logStream, "logStream");
+        Asserts.assertNotNull(logStream, "log stream");
 
         String url = baseUrl
                 .newBuilder()
@@ -100,8 +100,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
      * @return the request to execute.
      */
     public Request<LogStream> update(String logStreamId, LogStream logStream) {
-        Asserts.assertNotNull(logStreamId, "logStreamId");
-        Asserts.assertNotNull(logStream, "logStream");
+        Asserts.assertNotNull(logStreamId, "log stream id");
+        Asserts.assertNotNull(logStream, "log stream");
 
         String url = baseUrl
                 .newBuilder()
@@ -125,7 +125,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
      * @return the request to execute.
      */
     public Request delete(String logStreamId) {
-        Asserts.assertNotNull(logStreamId, "logStreamId");
+        Asserts.assertNotNull(logStreamId, "log stream id");
 
         String url = baseUrl
                 .newBuilder()

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -54,7 +54,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
      * @return the request to execute.
      */
     public Request<LogStream> get(String logStreamId) {
-        Asserts.assertNotNull(logStreamId, "logStreamId");
+        Asserts.assertNotNull(logStreamId, "log stream id");
 
         String url = baseUrl
                 .newBuilder()

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -215,6 +215,15 @@ public class ManagementAPI {
     }
 
     /**
+     * Getter for the Log Streams entity.
+     *
+     * @return the Log Streams entity.
+     */
+    public LogStreamsEntity logStreams() {
+        return new LogStreamsEntity(client, baseUrl, apiToken);
+    }
+
+    /**
      * Getter for the Rules entity.
      *
      * @return the Rules entity.

--- a/src/main/java/com/auth0/json/mgmt/logstreams/LogStream.java
+++ b/src/main/java/com/auth0/json/mgmt/logstreams/LogStream.java
@@ -23,6 +23,23 @@ public class LogStream {
     private Map<String, Object> sink;
 
     /**
+     * Creates a new LogStream instance and sets the type.
+     *
+     * @param type The type of the Log Stream.
+     */
+    @JsonCreator
+    public LogStream(@JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    /**
+     * Creates a new LogStream instance.
+     */
+    public LogStream() {
+        this(null);
+    }
+
+    /**
      * Get the ID of this Log Stream.
      *
      * @return The ID of this Log Stream.

--- a/src/main/java/com/auth0/json/mgmt/logstreams/LogStream.java
+++ b/src/main/java/com/auth0/json/mgmt/logstreams/LogStream.java
@@ -23,7 +23,7 @@ public class LogStream {
     private Map<String, Object> sink;
 
     /**
-     * Creates a new LogStream instance and sets the type.
+     * Creates a new LogStream instance and sets the type, which cannot be changed once set.
      *
      * @param type The type of the Log Stream.
      */
@@ -33,7 +33,8 @@ public class LogStream {
     }
 
     /**
-     * Creates a new LogStream instance.
+     * Creates a new empty LogStream. Use this when you need to create an instance for use with an update request, as
+     * you cannot send the {@code type} field to the update API.
      */
     public LogStream() {
         this(null);
@@ -77,16 +78,6 @@ public class LogStream {
     @JsonProperty("type")
     public String getType() {
         return type;
-    }
-
-    /**
-     * Sets the type of this Log Stream.
-     *
-     * @param type The type to set.
-     */
-    @JsonProperty("type")
-    public void setType(String type) {
-        this.type = type;
     }
 
     /**

--- a/src/main/java/com/auth0/json/mgmt/logstreams/LogStream.java
+++ b/src/main/java/com/auth0/json/mgmt/logstreams/LogStream.java
@@ -1,0 +1,114 @@
+package com.auth0.json.mgmt.logstreams;
+
+import com.fasterxml.jackson.annotation.*;
+
+import java.util.Map;
+
+/**
+ * Represents an Auth0 Log Stream object. Related to the {@linkplain com.auth0.client.mgmt.LogStreamsEntity}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LogStream {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("sink")
+    private Map<String, Object> sink;
+
+    /**
+     * Get the ID of this Log Stream.
+     *
+     * @return The ID of this Log Stream.
+     */
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get the name of this Log Stream.
+     *
+     * @return The name of this Log Stream.
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of this Log Stream.
+     *
+     * @param name the name to set.
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the type of this Log Stream.
+     *
+     * @return The type of this Log Stream.
+     */
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the type of this Log Stream.
+     *
+     * @param type The type to set.
+     */
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Gets the status of this Log Stream.
+     *
+     * @return The status of this Log Stream.
+     */
+    @JsonProperty("status")
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * Sets the status of this Log Stream.
+     *
+     * @param status The status to set.
+     */
+    @JsonProperty("status")
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+     * Gets the sink of this Log Stream.
+     *
+     * @return the sink of this Log Stream.
+     */
+    @JsonProperty("sink")
+    public Map<String, Object> getSink() {
+        return sink;
+    }
+
+    /**
+     * Sets the sink of this Log Stream.
+     *
+     * @param sink A key-value map representing the sink to set.
+     */
+    @JsonProperty("sink")
+    public void setSink(Map<String, Object> sink) {
+        this.sink = sink;
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -42,6 +42,8 @@ public class MockServer {
     public static final String MGMT_LOG_EVENTS_LIST = "src/test/resources/mgmt/event_logs_list.json";
     public static final String MGMT_LOG_EVENTS_PAGED_LIST = "src/test/resources/mgmt/event_logs_paged_list.json";
     public static final String MGMT_LOG_EVENT = "src/test/resources/mgmt/event_log.json";
+    public static final String MGMT_LOG_STREAM = "src/test/resources/mgmt/log_stream.json";
+    public static final String MGMT_LOG_STREAMS_LIST = "src/test/resources/mgmt/log_streams_list.json";
     public static final String MGMT_RESOURCE_SERVERS_LIST = "src/test/resources/mgmt/resource_servers_list.json";
     public static final String MGMT_RESOURCE_SERVERS_PAGED_LIST = "src/test/resources/mgmt/resource_servers_paged_list.json";
     public static final String MGMT_RESOURCE_SERVER = "src/test/resources/mgmt/resource_server.json";

--- a/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
@@ -1,0 +1,182 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.client.MockServer;
+import com.auth0.json.mgmt.logstreams.LogStream;
+import com.auth0.net.Request;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.auth0.client.MockServer.*;
+import static com.auth0.client.RecordedRequestMatcher.hasHeader;
+import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class LogStreamsEntityTest extends BaseMgmtEntityTest {
+
+    @Test
+    public void shouldListLogStreams() throws Exception {
+        Request<List<LogStream>> request = api.logStreams().list();
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.MGMT_LOG_STREAMS_LIST, 200);
+        List<LogStream> response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/log-streams"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.size(), is(2));
+    }
+
+    @Test
+    public void shouldReturnEmptyLogStreams() throws Exception {
+        Request<List<LogStream>> request = api.logStreams().list();
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_EMPTY_LIST, 200);
+        List<LogStream> response = request.execute();
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response, empty());
+    }
+
+    @Test
+    public void shouldGetLogStream() throws Exception {
+        Request<LogStream> request = api.logStreams().get("123");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.MGMT_LOG_STREAM, 200);
+        LogStream response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/log-streams/123"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateLogStream() throws Exception {
+        Map<String, Object> sink = new HashMap<>();
+        sink.put("httpEndpoint", "https://me.org");
+        sink.put("httpAuthorization", "abc123");
+        sink.put("httpContentFormat", "JSONLINES");
+        sink.put("httpContentType", "application/json");
+        LogStream logStream = getLogStream("log stream", "http", sink);
+
+        Request<LogStream> request = api.logStreams().create(logStream);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT, 200);
+        LogStream response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/log-streams"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(3));
+        assertThat(body, hasEntry("name", "log stream"));
+        assertThat(body, hasEntry("type", "http"));
+        assertThat(body, hasEntry("sink", sink));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldUpdateLogStream() throws Exception {
+        Map<String, Object> sink = new HashMap<>();
+        sink.put("httpEndpoint", "https://me.org");
+        sink.put("httpAuthorization", "abc123");
+        sink.put("httpContentFormat", "JSONLINES");
+        sink.put("httpContentType", "application/json");
+        LogStream logStream = getLogStream("log stream", "http", sink);
+        logStream.setStatus("paused");
+
+        Request<LogStream> request = api.logStreams().update("123", logStream);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT, 200);
+        LogStream response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/log-streams/123"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(4));
+        assertThat(body, hasEntry("name", "log stream"));
+        assertThat(body, hasEntry("type", "http"));
+        assertThat(body, hasEntry("status", "paused"));
+        assertThat(body, hasEntry("sink", sink));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldDeleteLogStream() throws Exception {
+        Request request = api.logStreams().delete("1");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CONNECTION, 200);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/log-streams/1"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    @Test
+    public void shouldThrowOnGetLogStreamWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'logStreamId' cannot be null!");
+        api.logStreams().get(null);
+    }
+
+    @Test
+    public void shouldThrowOnDeleteLogStreamWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'logStreamId' cannot be null!");
+        api.logStreams().delete(null);
+    }
+
+    @Test
+    public void shouldThrowOnUpdateLogStreamWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'logStreamId' cannot be null!");
+        api.logStreams().update(null, new LogStream());
+    }
+
+    @Test
+    public void shouldThrowOnUpdateLogStreamWithNullLogStream() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'logStream' cannot be null!");
+        api.logStreams().update("123", null);
+    }
+
+    @Test
+    public void shouldThrowOnCreateLogStreamWithNullLogStream() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'logStream' cannot be null!");
+        api.logStreams().create(null);
+    }
+
+    private LogStream getLogStream(String name, String type, Map<String, Object> sink) {
+        LogStream logStream = new LogStream();
+        logStream.setName(name);
+        logStream.setType(type);
+        logStream.setSink(sink);
+        return logStream;
+    }
+}

--- a/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
@@ -105,7 +105,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldUpdateLogStream() throws Exception {
-        LogStream logStream = getLogStream("log stream", "http");
+        LogStream logStream = getLogStream("log stream", null);
         logStream.setStatus("paused");
 
         Request<LogStream> request = api.logStreams().update("123", logStream);
@@ -120,9 +120,8 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body.size(), is(4));
+        assertThat(body.size(), is(3));
         assertThat(body, hasEntry("name", "log stream"));
-        assertThat(body, hasEntry("type", "http"));
         assertThat(body, hasEntry("status", "paused"));
         assertThat(body, hasEntry("sink", logStream.getSink()));
 
@@ -184,9 +183,8 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
     }
 
     private LogStream getLogStream(String name, String type) {
-        LogStream logStream = new LogStream();
+        LogStream logStream = new LogStream(type);
         logStream.setName(name);
-        logStream.setType(type);
 
         Map<String, Object> sink = new HashMap<>();
         sink.put("httpEndpoint", "https://me.org");

--- a/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
@@ -32,7 +32,12 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.size(), is(2));
+        assertThat(response, hasSize(2));
+        assertThat(response, everyItem(hasProperty("id", is(notNullValue()))));
+        assertThat(response, everyItem(hasProperty("name", is(notNullValue()))));
+        assertThat(response, everyItem(hasProperty("type", is(notNullValue()))));
+        assertThat(response, everyItem(hasProperty("status", is(notNullValue()))));
+        assertThat(response, everyItem(hasProperty("sink", is(notNullValue()))));
     }
 
     @Test
@@ -61,21 +66,21 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         assertThat(response, is(notNullValue()));
+        assertThat(response, hasProperty("id", is(notNullValue())));
+        assertThat(response, hasProperty("name", is(notNullValue())));
+        assertThat(response, hasProperty("type", is(notNullValue())));
+        assertThat(response, hasProperty("status", is(notNullValue())));
+        assertThat(response, hasProperty("sink", is(notNullValue())));
     }
 
     @Test
     public void shouldCreateLogStream() throws Exception {
-        Map<String, Object> sink = new HashMap<>();
-        sink.put("httpEndpoint", "https://me.org");
-        sink.put("httpAuthorization", "abc123");
-        sink.put("httpContentFormat", "JSONLINES");
-        sink.put("httpContentType", "application/json");
-        LogStream logStream = getLogStream("log stream", "http", sink);
+        LogStream logStream = getLogStream("log stream", "http");
 
         Request<LogStream> request = api.logStreams().create(logStream);
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(MGMT_CLIENT, 200);
+        server.jsonResponse(MGMT_LOG_STREAM, 200);
         LogStream response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
@@ -87,25 +92,26 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(body.size(), is(3));
         assertThat(body, hasEntry("name", "log stream"));
         assertThat(body, hasEntry("type", "http"));
-        assertThat(body, hasEntry("sink", sink));
+        assertThat(body, hasEntry("sink", logStream.getSink()));
 
         assertThat(response, is(notNullValue()));
+        assertThat(response, hasProperty("id", is(notNullValue())));
+        assertThat(response, hasProperty("name", is(notNullValue())));
+        assertThat(response, hasProperty("type", is(notNullValue())));
+        assertThat(response, hasProperty("status", is(notNullValue())));
+        assertThat(response, hasProperty("sink", is(notNullValue())));
+
     }
 
     @Test
     public void shouldUpdateLogStream() throws Exception {
-        Map<String, Object> sink = new HashMap<>();
-        sink.put("httpEndpoint", "https://me.org");
-        sink.put("httpAuthorization", "abc123");
-        sink.put("httpContentFormat", "JSONLINES");
-        sink.put("httpContentType", "application/json");
-        LogStream logStream = getLogStream("log stream", "http", sink);
+        LogStream logStream = getLogStream("log stream", "http");
         logStream.setStatus("paused");
 
         Request<LogStream> request = api.logStreams().update("123", logStream);
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(MGMT_CLIENT, 200);
+        server.jsonResponse(MGMT_LOG_STREAM, 200);
         LogStream response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
@@ -118,9 +124,14 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(body, hasEntry("name", "log stream"));
         assertThat(body, hasEntry("type", "http"));
         assertThat(body, hasEntry("status", "paused"));
-        assertThat(body, hasEntry("sink", sink));
+        assertThat(body, hasEntry("sink", logStream.getSink()));
 
         assertThat(response, is(notNullValue()));
+        assertThat(response, hasProperty("id", is(notNullValue())));
+        assertThat(response, hasProperty("name", is(notNullValue())));
+        assertThat(response, hasProperty("type", is(notNullValue())));
+        assertThat(response, hasProperty("status", is(notNullValue())));
+        assertThat(response, hasProperty("sink", is(notNullValue())));
     }
 
     @Test
@@ -128,7 +139,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         Request request = api.logStreams().delete("1");
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(MGMT_CONNECTION, 200);
+        server.emptyResponse(204);
         request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
@@ -140,43 +151,50 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldThrowOnGetLogStreamWithNullId() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'logStreamId' cannot be null!");
+        exception.expectMessage("'log stream id' cannot be null!");
         api.logStreams().get(null);
     }
 
     @Test
     public void shouldThrowOnDeleteLogStreamWithNullId() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'logStreamId' cannot be null!");
+        exception.expectMessage("'log stream id' cannot be null!");
         api.logStreams().delete(null);
     }
 
     @Test
     public void shouldThrowOnUpdateLogStreamWithNullId() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'logStreamId' cannot be null!");
+        exception.expectMessage("'log stream id' cannot be null!");
         api.logStreams().update(null, new LogStream());
     }
 
     @Test
     public void shouldThrowOnUpdateLogStreamWithNullLogStream() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'logStream' cannot be null!");
+        exception.expectMessage("'log stream' cannot be null!");
         api.logStreams().update("123", null);
     }
 
     @Test
     public void shouldThrowOnCreateLogStreamWithNullLogStream() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'logStream' cannot be null!");
+        exception.expectMessage("'log stream' cannot be null!");
         api.logStreams().create(null);
     }
 
-    private LogStream getLogStream(String name, String type, Map<String, Object> sink) {
+    private LogStream getLogStream(String name, String type) {
         LogStream logStream = new LogStream();
         logStream.setName(name);
         logStream.setType(type);
+
+        Map<String, Object> sink = new HashMap<>();
+        sink.put("httpEndpoint", "https://me.org");
+        sink.put("httpAuthorization", "abc123");
+        sink.put("httpContentFormat", "JSONLINES");
+        sink.put("httpContentType", "application/json");
         logStream.setSink(sink);
+
         return logStream;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/logstreams/LogStreamsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/logstreams/LogStreamsTest.java
@@ -51,8 +51,7 @@ public class LogStreamsTest extends JsonTest<LogStream> {
 
     @Test
     public void shouldSerialize() throws Exception {
-        LogStream logStream = new LogStream();
-        logStream.setType("http");
+        LogStream logStream = new LogStream("http");
         logStream.setName("My Http Log Stream");
 
         Map<String, Object> sink = new HashMap<>();
@@ -71,8 +70,7 @@ public class LogStreamsTest extends JsonTest<LogStream> {
 
     @Test
     public void shouldSerializeWithDifferentObjectTypes() throws Exception {
-        LogStream logStream = new LogStream();
-        logStream.setType("http");
+        LogStream logStream = new LogStream("http");
         logStream.setName("My Log Stream");
 
         Map<String, Object> sink = new HashMap<>();
@@ -86,5 +84,15 @@ public class LogStreamsTest extends JsonTest<LogStream> {
         assertThat(serialized, JsonMatcher.hasEntry("name", "My Log Stream"));
         assertThat(serialized, JsonMatcher.hasEntry("type", "http"));
         assertThat(serialized, JsonMatcher.hasEntry("sink", sink));
+    }
+
+    @Test
+    public void shouldDeserializeReadOnlyData() throws Exception {
+        String readOnlyJson = "{\"id\":\"logStreamId\",\"type\":\"http\"}";
+
+        LogStream logStream = fromJSON(readOnlyJson, LogStream.class);
+        assertThat(logStream, is(notNullValue()));
+        assertThat(logStream.getId(), is("logStreamId"));
+        assertThat(logStream.getType(), is("http"));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/logstreams/LogStreamsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/logstreams/LogStreamsTest.java
@@ -1,0 +1,90 @@
+package com.auth0.json.mgmt.logstreams;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class LogStreamsTest extends JsonTest<LogStream> {
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        String httpSinkJson = "{\"id\": \"123\",\"name\": \"my http log stream\",\"type\": \"http\",\"status\":\"active\",\"sink\": {\"httpContentFormat\": \"JSONLINES\",\"httpContentType\": \"application/json\",\"httpEndpoint\": \"https://me.org\",\"httpAuthorization\": \"abc123\"}}";
+        LogStream logStream = fromJSON(httpSinkJson, LogStream.class);
+
+        assertThat(logStream, is(notNullValue()));
+        assertThat(logStream.getId(), is("123"));
+        assertThat(logStream.getName(), is("my http log stream"));
+        assertThat(logStream.getType(), is("http"));
+        assertThat(logStream.getStatus(), is("active"));
+        assertThat(logStream.getSink(), is(notNullValue()));
+        assertThat(logStream.getSink().size(), is(4));
+        assertThat(logStream.getSink(), hasEntry("httpContentFormat", "JSONLINES"));
+        assertThat(logStream.getSink(), hasEntry("httpContentType", "application/json"));
+        assertThat(logStream.getSink(), hasEntry("httpEndpoint", "https://me.org"));
+        assertThat(logStream.getSink(), hasEntry("httpAuthorization", "abc123"));
+    }
+
+    @Test
+    public void shouldDeserializeWithDifferentObjectTypes() throws Exception {
+        String json = "{\"id\": \"123\",\"name\": \"my http log stream\",\"type\": \"http\",\"status\":\"active\",\"sink\": {\"boolean\": true,\"array\": [\"one\",\"two\"],\"object\": {\"key1\":\"val1\",\"key2\":\"val2\"}}}";
+        LogStream logStream = fromJSON(json, LogStream.class);
+
+        assertThat(logStream, is(notNullValue()));
+        assertThat(logStream.getSink(), is(notNullValue()));
+        assertThat(logStream.getSink().size(), is(3));
+        assertThat(logStream.getSink(), hasEntry("boolean", true));
+        assertThat(logStream.getSink(), hasEntry("array", Arrays.asList("one","two")));
+
+        Map<String, Object> objectMap = new HashMap<>();
+        objectMap.put("key1", "val1");
+        objectMap.put("key2", "val2");
+        assertThat(logStream.getSink(), hasEntry("object", objectMap));
+    }
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        LogStream logStream = new LogStream();
+        logStream.setType("http");
+        logStream.setName("My Http Log Stream");
+
+        Map<String, Object> sink = new HashMap<>();
+        sink.put("httpContentFormat", "JSONLINES");
+        sink.put("httpContentType", "application/json");
+        sink.put("httpEndpoint", "https://me.org");
+        sink.put("httpAuthorization", "abc123");
+        logStream.setSink(sink);
+
+        String serialized = toJSON(logStream);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("name", "My Http Log Stream"));
+        assertThat(serialized, JsonMatcher.hasEntry("type", "http"));
+        assertThat(serialized, JsonMatcher.hasEntry("sink", sink));
+    }
+
+    @Test
+    public void shouldSerializeWithDifferentObjectTypes() throws Exception {
+        LogStream logStream = new LogStream();
+        logStream.setType("http");
+        logStream.setName("My Log Stream");
+
+        Map<String, Object> sink = new HashMap<>();
+        sink.put("boolean", true);
+        sink.put("array", Arrays.asList("one", 2));
+        sink.put("object", Collections.singletonMap("key", "val"));
+        logStream.setSink(sink);
+
+        String serialized = toJSON(logStream);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("name", "My Log Stream"));
+        assertThat(serialized, JsonMatcher.hasEntry("type", "http"));
+        assertThat(serialized, JsonMatcher.hasEntry("sink", sink));
+    }
+}

--- a/src/test/resources/mgmt/log_stream.json
+++ b/src/test/resources/mgmt/log_stream.json
@@ -1,0 +1,13 @@
+
+{
+  "id": "123",
+  "name": "log stream 1",
+  "status": "active",
+  "type": "http",
+  "sink": {
+    "httpContentFormat": "JSONLINES",
+    "httpContentType": "application/json",
+    "httpAuthorization": "abc123",
+    "httpEndpoint": "https//me.org"
+  }
+}

--- a/src/test/resources/mgmt/log_streams_list.json
+++ b/src/test/resources/mgmt/log_streams_list.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "123",
+    "name": "log stream 1",
+    "status": "active",
+    "type": "http",
+    "sink": {
+      "httpContentFormat": "JSONLINES",
+      "httpContentType": "application/json",
+      "httpAuthorization": "abc123",
+      "httpEndpoint": "https//me.org"
+    }
+  },
+  {
+    "id": "456",
+    "name": "log stream 2",
+    "status": "paused",
+    "type": "datadog",
+    "sink": {
+      "datadogRegion": "region",
+      "datadogApiKey": "abc123",
+      "httpAuthorization": "abc123",
+      "httpEndpoint": "https//me.org"
+    }
+  }
+]


### PR DESCRIPTION
### Changes

This PR adds support for the Log Streams APIs available in the Management API. A new entity, `LogStreamsEntity` is added along with the following public APIs:

- Create a Log Stream: ` public Request<LogStream> create(LogStream logStream)`
- List all Log Streams: `public Request<List<LogStream>> list()`
- Get a specific Log Stream: `public Request<LogStream> get(String logStreamId)`
- Update a Log Stream: `public Request<LogStream> update(String logStreamId, LogStream logStream)`
- Delete a Log Stream: `public Request delete(String logStreamId)`

A new domain model, `LogStream` is also included in this PR.

### References

- [Log Streaming feature documentation](https://auth0.com/docs/logs/export-log-events-with-log-streaming)
- [Log Streaming API documentation](https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams)

### Testing

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
