### PR TITLE
Rename gradlew validation github action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   validation:
-    name: "Validation"
+    name: "validation/gradlew"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is so it shows a more descriptive text in the checks before it's run. Also, is how you see it on the branch protection settings.
 
![image](https://user-images.githubusercontent.com/3900123/93495024-0ea2be80-f8e4-11ea-94fd-3feee1f2ad95.png)
