### PR TITLE
Add support for identity field for email verification jobs and tickets

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -59,7 +59,10 @@ public class JobsEntity extends BaseManagementEntity {
      *
      * @param userId   The user_id of the user to whom the email will be sent.
      * @param clientId The id of the client, if not provided the global one will be used.
+     *
      * @return a Request to execute.
+     *
+     * @see JobsEntity#sendVerificationEmail(String, String, EmailVerificationIdentity)
      */
     public Request<Job> sendVerificationEmail(String userId, String clientId) {
         return sendVerificationEmail(userId, clientId, null);
@@ -74,6 +77,8 @@ public class JobsEntity extends BaseManagementEntity {
      * @param emailVerificationIdentity The identity of the user. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
      *
      * @return a Request to execute.
+     *
+     * @see JobsEntity#sendVerificationEmail(String, String)
      */
     public Request<Job> sendVerificationEmail(String userId, String clientId, EmailVerificationIdentity emailVerificationIdentity) {
         Asserts.assertNotNull(userId, "user id");

--- a/src/main/java/com/auth0/json/mgmt/EmailVerificationIdentity.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailVerificationIdentity.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class EmailVerificationIdentity implements Serializable {
+public class EmailVerificationIdentity {
 
     @JsonProperty("provider")
     private String provider;

--- a/src/main/java/com/auth0/json/mgmt/EmailVerificationIdentity.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailVerificationIdentity.java
@@ -1,0 +1,36 @@
+package com.auth0.json.mgmt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+
+/**
+ * Represents the identity object that can be sent on requests to create an email verification ticket or job.
+ * Related to {@link com.auth0.client.mgmt.JobsEntity} and {@link com.auth0.client.mgmt.TicketsEntity}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmailVerificationIdentity implements Serializable {
+
+    @JsonProperty("provider")
+    private String provider;
+    @JsonProperty("user_id")
+    private String userId;
+
+    public EmailVerificationIdentity(String provider, String userId) {
+        this.provider = provider;
+        this.userId = userId;
+    }
+
+    @JsonProperty("provider")
+    public String getProvider() {
+        return this.provider;
+    }
+
+    @JsonProperty("user_id")
+    public String getUserId() {
+        return this.userId;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/EmailVerificationIdentity.java
+++ b/src/main/java/com/auth0/json/mgmt/EmailVerificationIdentity.java
@@ -19,16 +19,32 @@ public class EmailVerificationIdentity implements Serializable {
     @JsonProperty("user_id")
     private String userId;
 
+    /**
+     * Create a new instance.
+     *
+     * @param provider The identity provider name (e.g. {@code "google-oauth2"}).
+     * @param userId The user ID of the identity to be verified.
+     */
     public EmailVerificationIdentity(String provider, String userId) {
         this.provider = provider;
         this.userId = userId;
     }
 
+    /**
+     * Get the identity provider name.
+     *
+     * @return The identity provider name.
+     */
     @JsonProperty("provider")
     public String getProvider() {
         return this.provider;
     }
 
+    /**
+     * Get the user ID.
+     *
+     * @return the User ID.
+     */
     @JsonProperty("user_id")
     public String getUserId() {
         return this.userId;

--- a/src/main/java/com/auth0/json/mgmt/tickets/EmailVerificationTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/EmailVerificationTicket.java
@@ -1,6 +1,7 @@
 
 package com.auth0.json.mgmt.tickets;
 
+import com.auth0.json.mgmt.EmailVerificationIdentity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -22,6 +23,8 @@ public class EmailVerificationTicket {
     private Integer ttlSec;
     @JsonProperty("ticket")
     private String ticket;
+    @JsonProperty("identity")
+    private EmailVerificationIdentity identity;
 
     @JsonCreator
     public EmailVerificationTicket(@JsonProperty("user_id") String userId) {
@@ -56,6 +59,17 @@ public class EmailVerificationTicket {
     @JsonProperty("ttl_sec")
     public void setTTLSeconds(Integer seconds) {
         this.ttlSec = seconds;
+    }
+
+    /**
+     * Sets the identity. Needed to verify primary identities when using social, enterprise, or passwordless connections.
+     * It is also required to verify secondary identities.
+     *
+     * @param identity the identity.
+     */
+    @JsonProperty("identity")
+    public void setIdentity(EmailVerificationIdentity identity) {
+        this.identity = identity;
     }
 
     /**

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -250,8 +250,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldThrowOnSendUserVerificationEmailWithNullIdentityUserId() {
         exception.expect(IllegalArgumentException.class);
-        // don't be too specific in testing the order we null-check provider and user-id
-        exception.expectMessage("'identity ");
+        exception.expectMessage("'identity user id' cannot be null!");
         api.jobs().sendVerificationEmail("google-oauth2|1234", null, new EmailVerificationIdentity("google-oauth2", null));
     }
 

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -166,8 +166,8 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
-    public void shouldSendUserAVerificationEmail() throws Exception {
-        Request<Job> request = api.jobs().sendVerificationEmail("google-oauth2|1234", null);
+    public void shouldSendUserAVerificationEmailWithNullClientIdAndEmailVerification() throws Exception {
+        Request<Job> request = api.jobs().sendVerificationEmail("google-oauth2|1234", null, null);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_VERIFICATION_EMAIL, 200);
@@ -204,13 +204,6 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(body, hasEntry("client_id", "AaiyAPdpYdesoKnqjj8HJqRn4T5titww"));
 
         assertThat(response, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldThrowOnSendUserVerificationEmailWithNullUserId() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'user id' cannot be null!");
-        api.jobs().sendVerificationEmail(null, null);
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/tickets/EmailVerificationTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/EmailVerificationTicketTest.java
@@ -2,7 +2,11 @@ package com.auth0.json.mgmt.tickets;
 
 import com.auth0.json.JsonMatcher;
 import com.auth0.json.JsonTest;
+import com.auth0.json.mgmt.EmailVerificationIdentity;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -23,6 +27,26 @@ public class EmailVerificationTicketTest extends JsonTest<EmailVerificationTicke
         assertThat(serialized, JsonMatcher.hasEntry("user_id", "usr123"));
         assertThat(serialized, JsonMatcher.hasEntry("result_url", "https://page.auth0.com/result"));
         assertThat(serialized, JsonMatcher.hasEntry("ttl_sec", 36000));
+    }
+
+    @Test
+    public void shouldSerializeWithIdentity() throws Exception {
+        EmailVerificationTicket ticket = new EmailVerificationTicket("usr123");
+        ticket.setResultUrl("https://page.auth0.com/result");
+        ticket.setTTLSeconds(36000);
+        EmailVerificationIdentity identity = new EmailVerificationIdentity("some-provider", "some-user-id");
+        ticket.setIdentity(identity);
+
+        String serialized = toJSON(ticket);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("user_id", "usr123"));
+        assertThat(serialized, JsonMatcher.hasEntry("result_url", "https://page.auth0.com/result"));
+        assertThat(serialized, JsonMatcher.hasEntry("ttl_sec", 36000));
+
+        Map<String, String> identityMap = new HashMap<>();
+        identityMap.put("provider", "some-provider");
+        identityMap.put("user_id", "some-user-id");
+        assertThat(serialized, JsonMatcher.hasEntry("identity", identityMap));
     }
 
     @Test


### PR DESCRIPTION
### Changes

Adds support for specifying the (optional) `identity` object when creating email verification tickets or jobs. This is needed when verifying emails when the primary is social, enterprise, or passwordless. Also needed to verify secondary identities.

### References

- https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
- https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email

### Testing

In addition to unit tests, I've also verified the changes manually using a real tenant and users.

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
