### PR TITLE
Use Standard Jackson Date serialization

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/DailyStats.java
+++ b/src/main/java/com/auth0/json/mgmt/DailyStats.java
@@ -17,7 +17,7 @@ public class DailyStats {
 
     @JsonProperty("logins")
     private Integer logins;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("date")
     private Date date;
 
@@ -36,7 +36,7 @@ public class DailyStats {
      *
      * @return the date to which the stats belong
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("date")
     public Date getDate() {
         return date;

--- a/src/main/java/com/auth0/json/mgmt/guardian/Enrollment.java
+++ b/src/main/java/com/auth0/json/mgmt/guardian/Enrollment.java
@@ -29,10 +29,10 @@ public class Enrollment {
     private String phoneNumber;
     @JsonProperty("auth_method")
     private String authMethod;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("enrolled_at")
     private Date enrolledAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("last_auth")
     private Date lastAuth;
 
@@ -111,7 +111,7 @@ public class Enrollment {
      *
      * @return the enrolled at.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("enrolled_at")
     public Date getEnrolledAt() {
         return enrolledAt;
@@ -122,7 +122,7 @@ public class Enrollment {
      *
      * @return the last authentication.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("last_auth")
     public Date getLastAuth() {
         return lastAuth;

--- a/src/main/java/com/auth0/json/mgmt/jobs/Job.java
+++ b/src/main/java/com/auth0/json/mgmt/jobs/Job.java
@@ -16,7 +16,7 @@ public class Job {
     private String status;
     @JsonProperty("type")
     private String type;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("created_at")
     private Date createdAt;
     @JsonProperty("id")
@@ -55,7 +55,7 @@ public class Job {
         return type;
     }
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("created_at")
     public Date getCreatedAt() {
         return createdAt;

--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
@@ -18,7 +18,7 @@ public class LogEvent {
 
     @JsonProperty("_id")
     private String id;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("date")
     private Date date;
     @JsonProperty("type")
@@ -51,7 +51,7 @@ public class LogEvent {
      *
      * @return the date.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("date")
     public Date getDate() {
         return date;

--- a/src/main/java/com/auth0/json/mgmt/users/User.java
+++ b/src/main/java/com/auth0/json/mgmt/users/User.java
@@ -50,10 +50,10 @@ public class User implements Serializable {
     private String givenName;
     @JsonProperty("family_name")
     private String familyName;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("created_at")
     private Date createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("updated_at")
     private Date updatedAt;
     @JsonProperty("identities")
@@ -66,10 +66,10 @@ public class User implements Serializable {
     private List<String> multifactor;
     @JsonProperty("last_ip")
     private String lastIp;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("last_login")
     private Date lastLogin;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("last_password_reset")
     private Date lastPasswordReset;
     @JsonProperty("logins_count")
@@ -348,7 +348,7 @@ public class User implements Serializable {
      *
      * @return the created at.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("created_at")
     public Date getCreatedAt() {
         return createdAt;
@@ -359,7 +359,7 @@ public class User implements Serializable {
      *
      * @return the updated at.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("updated_at")
     public Date getUpdatedAt() {
         return updatedAt;
@@ -440,7 +440,7 @@ public class User implements Serializable {
      *
      * @return the last login.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("last_login")
     public Date getLastLogin() {
         return lastLogin;
@@ -451,7 +451,7 @@ public class User implements Serializable {
      *
      * @return the last password reset.
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("last_password_reset")
     public Date getLastPasswordReset() {
         return lastPasswordReset;

--- a/src/test/java/com/auth0/json/JsonTest.java
+++ b/src/test/java/com/auth0/json/JsonTest.java
@@ -11,10 +11,9 @@ import java.util.TimeZone;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 public class JsonTest<T> {
-
-    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     private ObjectMapper mapper;
 
@@ -38,9 +37,9 @@ public class JsonTest<T> {
         return new String(Files.readAllBytes(Paths.get(path)));
     }
 
-    protected Date parseJSONDate(String dateString) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT);
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return sdf.parse(dateString);
+    protected Date parseJSONDate(String dateString) throws ParseException, JsonProcessingException {
+        // StdDateFormat is the DateFormat Jackson uses by default for date fields (uses UTC timezone by default)
+        // https://fasterxml.github.io/jackson-databind/javadoc/2.9/com/fasterxml/jackson/databind/util/StdDateFormat.html
+        return new StdDateFormat().parse(dateString);
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 public class UserTest extends JsonTest<User> {
 
     private static final String json = "{\"user_id\":\"user|123\",\"connection\":\"auth0\",\"client_id\":\"client123\",\"password\":\"pwd\",\"verify_password\":true,\"username\":\"usr\",\"email\":\"me@auth0.com\",\"email_verified\":true,\"verify_email\":true,\"phone_number\":\"1234567890\",\"phone_verified\":true,\"verify_phone_number\":true,\"picture\":\"https://pic.ture/12\",\"name\":\"John\",\"nickname\":\"Johny\",\"given_name\":\"John\",\"family_name\":\"Walker\",\"app_metadata\":{},\"user_metadata\":{},\"blocked\":true,\"context\":\"extra information\"}";
-    private static final String readOnlyJson = "{\"user_id\":\"user|123\",\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"last_password_reset\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[]}";
+    private static final String readOnlyJson = "{\"user_id\":\"user|123\",\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"last_password_reset\":\"2016-02-23T19:57:29Z\",\"logins_count\":10,\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[]}";
 
     @Test
     public void shouldHaveEmptyValuesByDefault() throws Exception{
@@ -113,7 +113,7 @@ public class UserTest extends JsonTest<User> {
         assertThat(user.getCreatedAt(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
         assertThat(user.getUpdatedAt(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
         assertThat(user.getLastLogin(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
-        assertThat(user.getLastPasswordReset(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
+        assertThat(user.getLastPasswordReset(), is(parseJSONDate("2016-02-23T19:57:29.000Z")));
         assertThat(user.getIdentities(), is(notNullValue()));
         assertThat(user.getLastIP(), is("10.0.0.1"));
         assertThat(user.getLoginsCount(), is(10));

--- a/src/test/resources/mgmt/user.json
+++ b/src/test/resources/mgmt/user.json
@@ -7,6 +7,7 @@
   "user_id": "usr_5457edea1b8f33391a000004",
   "created_at": "",
   "updated_at": "",
+  "last_password_reset": "2019-08-14T19:35:00Z",
   "identities": [
     {
       "provider": "facebook",


### PR DESCRIPTION
### Changes

Remove our custom date serialization/deserialization patterns, as it is not strictly ISO-8601 compliant. We've seen failures on deserialization when the milliseconds field (which are optional in ISO-8601) are not sent, for example.

Instead, we can use the standard Jackson date serialization and deserialization, which uses ISO-8601 format.

### References

- [StdDateFormat](https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/util/StdDateFormat.java) (default date format used for serialization and deserialization)
- [W3C Date/Time Formats](w3.org/TR/NOTE-datetime)

### Testing

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
