### PR TITLE
Added support for `auth0-forwarded-for` header to the AuthApi.login methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,28 @@ try {
     // request error
 }
 ```
+**NOTE:** 
+
+In order to avoid issues with anomaly detection for both the `Log In with Password` and `Log In with Password Realm` calls, as described here [Docs](https://auth0.com/docs/authorization/avoid-common-issues-with-resource-owner-password-flow-and-anomaly-detection#send-the-user-s-ip-address-from-your-server), it is possible to supply the `auth0-forwarded-for` header and value.
+
+`AuthRequest login(String emailOrUsername, String password, CustomHeaderOptions options)`
+
+`AuthRequest login(String emailOrUsername, String password, String realm, CustomHeaderOptions options)`
+
+Example:
+```java
+CustomHeaderOptions headers = new CustomHeaderOptions().withAuth0ForwardedForHeader("127.0.0.1");
+AuthRequest request = auth.login("me@domain.com", "password123", headers)
+    .setAudience("https://api.me.auth0.com/users")
+    .setScope("openid contacts");
+try {
+    TokenHolder holder = request.execute();
+} catch (APIException exception) {
+    // api error
+} catch (Auth0Exception exception) {
+    // request error
+}
+```
 
 ### Request Token for Audience - /oauth/token
 

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -508,8 +508,9 @@ public class AuthAPI {
      * <pre>
      * {@code
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * CustomHeaderOptions headers = new CustomHeaderOptions().withAuth0ForwardedForHeader("127.0.0.1");
      * try {
-     *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t})
+     *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t}, headers)
      *          .setScope("openid email nickname")
      *          .execute();
      * } catch (Auth0Exception e) {
@@ -622,8 +623,9 @@ public class AuthAPI {
      * <pre>
      * {@code
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * CustomHeaderOptions headers = new CustomHeaderOptions().withAuth0ForwardedForHeader("127.0.0.1");
      * try {
-     *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t'}, "my-realm")
+     *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t'}, "my-realm", headers)
      *          .setAudience("https://myapi.me.auth0.com/users")
      *          .execute();
      * } catch (Auth0Exception e) {

--- a/src/main/java/com/auth0/client/auth/options/CustomHeaderOptions.java
+++ b/src/main/java/com/auth0/client/auth/options/CustomHeaderOptions.java
@@ -6,6 +6,8 @@ import java.util.Map;
 /**
  * Class used to supply custom headers to those request which require them.
  * <p>
+ * Currently supports the following headers: auth0-forwarded-for
+ * <p>
  * This class is not thread-safe.
  *
  * @see <a href="https://auth0.com/docs/authorization/avoid-common-issues-with-resource-owner-password-flow-and-anomaly-detection#send-the-user-s-ip-address-from-your-server"> Auth0 Anomaly Detection Common Issues</a>

--- a/src/main/java/com/auth0/client/auth/options/CustomHeaderOptions.java
+++ b/src/main/java/com/auth0/client/auth/options/CustomHeaderOptions.java
@@ -1,0 +1,33 @@
+package com.auth0.client.auth.options;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class used to supply custom headers to those request which require them.
+ * <p>
+ * This class is not thread-safe.
+ *
+ * @see <a href="https://auth0.com/docs/authorization/avoid-common-issues-with-resource-owner-password-flow-and-anomaly-detection#send-the-user-s-ip-address-from-your-server"> Auth0 Anomaly Detection Common Issues</a>
+ */
+public class CustomHeaderOptions
+{
+    protected final Map<String, String> parameters = new HashMap<>();
+
+    public static final String AUTH0_FORWARDED_FOR_HEADER = "auth0-forwarded-for";
+
+    /**
+     * Include the `auth-forwarded-for` header
+     *
+     * @param forwardedForValue the ip address to pass through in the header value.
+     * @return this customHeaderOptions instance
+     */
+    public CustomHeaderOptions withAuth0ForwardedForHeader(String forwardedForValue) {
+        parameters.put(AUTH0_FORWARDED_FOR_HEADER, forwardedForValue);
+        return this;
+    }
+
+    public Map<String, String> getAsMap() {
+        return parameters;
+    }
+}

--- a/src/main/java/com/auth0/client/auth/options/CustomHeaderOptions.java
+++ b/src/main/java/com/auth0/client/auth/options/CustomHeaderOptions.java
@@ -19,7 +19,7 @@ public class CustomHeaderOptions
     public static final String AUTH0_FORWARDED_FOR_HEADER = "auth0-forwarded-for";
 
     /**
-     * Include the `auth-forwarded-for` header
+     * Include the `auth0-forwarded-for` header
      *
      * @param forwardedForValue the ip address to pass through in the header value.
      * @return this customHeaderOptions instance

--- a/src/test/java/com/auth0/client/auth/options/CustomHeaderOptionsTest.java
+++ b/src/test/java/com/auth0/client/auth/options/CustomHeaderOptionsTest.java
@@ -1,0 +1,24 @@
+package com.auth0.client.auth.options;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class CustomHeaderOptionsTest
+{
+    @Test
+    public void shouldGetNewInstance() {
+        CustomHeaderOptions instance = new CustomHeaderOptions();
+        assertThat(instance, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetNewInstanceWithAuth0ForwardedForValueSet() {
+        CustomHeaderOptions instance = new CustomHeaderOptions().withAuth0ForwardedForHeader("127.0.0.1");
+        assertThat(instance, is(notNullValue()));
+        assertThat(instance.getAsMap().containsKey(CustomHeaderOptions.AUTH0_FORWARDED_FOR_HEADER), is(true));
+        assertThat(instance.getAsMap().get(CustomHeaderOptions.AUTH0_FORWARDED_FOR_HEADER), is("127.0.0.1"));
+    }
+
+}


### PR DESCRIPTION
### Changes

This PR adds support for the `auth0-forwarded-for` header to the `AuthAPI.login` calls. 
This was added in order to avoid the common issue with anomaly dection described here: https://auth0.com/docs/authorization/avoid-common-issues-with-resource-owner-password-flow-and-anomaly-detection#send-the-user-s-ip-address-from-your-server

A new entity, `CustomHeaderOptions` is added along with the following updates to the `AuthAPI` class to use that new entity:

- `AuthAPI.login(String emailOrUsername, char[] password, CustomHeaderOptions options)` method added
- `AuthAPI.login(String emailOrUsername, char[] password, String realm, CustomHeaderOptions options)` method added
- Tests were updated, README.md was updated.

### References

The `auth0-forwarded-for` header is required in some instances, as described here: 
https://auth0.com/docs/authorization/avoid-common-issues-with-resource-owner-password-flow-and-anomaly-detection#send-the-user-s-ip-address-from-your-server


### Testing

Unit tests were updated, and example provided in README.

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
