### PR TITLE
Add support for MFA OTP exchange

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -860,7 +860,7 @@ public class AuthAPI {
      * @see <a href="https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-">Verify with one-time password (OTP) API documentation</a>
      */
     public AuthRequest exchangeMfaOtp(String mfaToken, char[] otp) {
-        Asserts.assertNotNull(mfaToken, "mfaToken");
+        Asserts.assertNotNull(mfaToken, "mfa token");
         Asserts.assertNotNull(otp, "otp");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -38,6 +38,7 @@ public class AuthAPI {
     private static final String KEY_REFRESH_TOKEN = "refresh_token";
     private static final String KEY_OTP = "otp";
     private static final String KEY_REALM = "realm";
+    private static final String KEY_MFA_TOKEN = "mfa_token";
 
     private static final String PATH_OAUTH = "oauth";
     private static final String PATH_TOKEN = "token";
@@ -833,6 +834,47 @@ public class AuthAPI {
         request.addParameter(KEY_CLIENT_SECRET, clientSecret);
         request.addParameter(KEY_CONNECTION, "sms");
         request.addParameter("phone_number", phoneNumber);
+        return request;
+    }
+
+    /**
+     * Creates a request to exchange the mfa token and one-time password (OTP) to authenticate a user with an MFA OTP Authenticator.
+     *
+     * <pre>
+     * {@code
+     * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
+     * try {
+     *      TokenHolder result = auth.exchangeMfaOtp("the-mfa-token”, new char[]{‘a','n','o','t',’p’})
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param mfaToken the mfa_token received from the mfa_required error that occurred during login. Must not be null.
+     * @param otp      the OTP Code provided by the user. Must not be null.
+     *
+     * @return a Request to configure and execute.
+     *
+     * @see <a href="https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-">Verify with one-time password (OTP) API documentation</a>
+     */
+    public AuthRequest exchangeMfaOtp(String mfaToken, char[] otp) {
+        Asserts.assertNotNull(mfaToken, "mfaToken");
+        Asserts.assertNotNull(otp, "otp");
+
+        String url = baseUrl
+                .newBuilder()
+                .addPathSegment(PATH_OAUTH)
+                .addPathSegment(PATH_TOKEN)
+                .build()
+                .toString();
+        TokenRequest request = new TokenRequest(client, url);
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        request.addParameter(KEY_CLIENT_SECRET, clientSecret);
+        request.addParameter(KEY_GRANT_TYPE, "http://auth0.com/oauth/grant-type/mfa-otp");
+        request.addParameter(KEY_MFA_TOKEN, mfaToken);
+        request.addParameter(KEY_OTP, otp);
         return request;
     }
 }

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1202,7 +1202,7 @@ public class AuthAPITest {
         assertThat(body, hasEntry("grant_type", (Object) "http://auth0.com/oauth/grant-type/mfa-otp"));
         assertThat(body, hasEntry("client_id", (Object) CLIENT_ID));
         assertThat(body, hasEntry("client_secret", (Object) CLIENT_SECRET));
-        assertThat(body, hasEntry("mfa_token", (Object) "mfaToken"));
+        assertThat(body, hasEntry("mfa_token", (Object) "mfa token"));
         assertThat(body, hasEntry("otp", (Object) "otp"));
 
         assertThat(response, is(notNullValue()));

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1175,7 +1175,7 @@ public class AuthAPITest {
     @Test
     public void shouldThrowWhenExchangeMfaOtpCalledWithNullMfaToken() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'mfaToken' cannot be null!");
+        exception.expectMessage("'mfa token' cannot be null!");
         api.exchangeMfaOtp(null, new char[]{'o','t','p'});
     }
 
@@ -1202,7 +1202,7 @@ public class AuthAPITest {
         assertThat(body, hasEntry("grant_type", (Object) "http://auth0.com/oauth/grant-type/mfa-otp"));
         assertThat(body, hasEntry("client_id", (Object) CLIENT_ID));
         assertThat(body, hasEntry("client_secret", (Object) CLIENT_SECRET));
-        assertThat(body, hasEntry("mfa_token", (Object) "mfa token"));
+        assertThat(body, hasEntry("mfa_token", (Object) "mfaToken"));
         assertThat(body, hasEntry("otp", (Object) "otp"));
 
         assertThat(response, is(notNullValue()));


### PR DESCRIPTION
### Changes

Fixes #280 and supersedes work started in #281.

Adds a new public API to exchange an MFA one-time password (OTP) for a set of tokens:

`public AuthRequest exchangeMfaOtp(String mfaToken, char[] otp)`

### References

- #280 
- #281 
- [API Docs](https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-)

### Testing

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
