### PR TITLE
Fix compile warnings in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.9.0'
     }
+
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:deprecation"
+        options.compilerArgs << "-Werror"
+    }
 }
 
 repositories {

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -31,7 +31,7 @@ import static com.auth0.client.UrlMatcher.isUrl;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AuthAPITest {
 
@@ -43,6 +43,8 @@ public class AuthAPITest {
 
     private MockServer server;
     private AuthAPI api;
+
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -477,6 +479,7 @@ public class AuthAPITest {
 
     //Sign Up
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnSignUpWithNullEmail() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -484,6 +487,7 @@ public class AuthAPITest {
         api.signUp(null, "p455w0rd", "my-connection");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnSignUpWithNullPasswordString() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -498,6 +502,7 @@ public class AuthAPITest {
         api.signUp("me@auth0.com", (char[]) null, "my-connection");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnSignUpWithNullConnection() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -505,6 +510,7 @@ public class AuthAPITest {
         api.signUp("me@auth0.com", "p455w0rd", null);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnUsernameSignUpWithNullEmail() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -512,6 +518,7 @@ public class AuthAPITest {
         api.signUp(null, "me", "p455w0rd", "my-connection");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnUsernameSignUpWithNullUsername() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -519,6 +526,7 @@ public class AuthAPITest {
         api.signUp("me@auth0.com", null, "p455w0rd", "my-connection");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnUsernameSignUpWithNullPasswordString() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -533,6 +541,7 @@ public class AuthAPITest {
         api.signUp("me@auth0.com", "me", (char[]) null, "my-connection");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnUsernameSignUpWithNullConnection() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -566,6 +575,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateSignUpRequestWithUsername() throws Exception {
+        @SuppressWarnings("deprecation")
         SignUpRequest request = api.signUp("me@auth0.com", "me", "p455w0rd", "db-connection");
         assertThat(request, is(notNullValue()));
 
@@ -592,7 +602,9 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateSignUpRequest() throws Exception {
+        @SuppressWarnings("deprecation")
         SignUpRequest request = api.signUp("me@auth0.com", "p455w0rd", "db-connection");
+
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
@@ -618,6 +630,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateSignUpRequestWithCustomParameters() throws Exception {
+        @SuppressWarnings("deprecation")
         SignUpRequest request = api.signUp("me@auth0.com", "p455w0rd", "db-connection");
         assertThat(request, is(notNullValue()));
         Map<String, String> customFields = new HashMap<>();
@@ -730,6 +743,7 @@ public class AuthAPITest {
 
     //Log In with Password grant
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnLogInWithPasswordWithNullUsername() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -737,6 +751,7 @@ public class AuthAPITest {
         api.login(null, "p455w0rd");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnLogInWithPasswordWithNullPassword() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -753,6 +768,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateLogInWithPasswordGrantRequest() throws Exception {
+        @SuppressWarnings("deprecation")
         AuthRequest request = api.login("me", "p455w0rd");
         assertThat(request, is(notNullValue()));
 
@@ -780,6 +796,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateLogInWithPasswordGrantRequestWithCustomParameters() throws Exception {
+        @SuppressWarnings("deprecation")
         AuthRequest request = api.login("me", "p455w0rd");
         assertThat(request, is(notNullValue()));
         request.setRealm("dbconnection");
@@ -814,6 +831,7 @@ public class AuthAPITest {
 
     //Log In with PasswordRealm grant
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnLogInWithPasswordRealmWithNullUsername() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -821,6 +839,7 @@ public class AuthAPITest {
         api.login(null, "p455w0rd", "realm");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnLogInWithPasswordRealmWithNullPasswordString() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -835,6 +854,7 @@ public class AuthAPITest {
         api.login("me", (char[]) null, "realm");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnLogInWithPasswordRealmWithNullRealm() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -844,6 +864,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateLogInWithPasswordRealmGrantRequest() throws Exception {
+        @SuppressWarnings("deprecation")
         AuthRequest request = api.login("me", "p455w0rd", "realm");
         assertThat(request, is(notNullValue()));
 
@@ -872,6 +893,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateLogInWithPasswordRealmGrantRequestWithCustomParameters() throws Exception {
+        @SuppressWarnings("deprecation")
         AuthRequest request = api.login("me", "p455w0rd", "realm");
         assertThat(request, is(notNullValue()));
         request.setAudience("https://myapi.auth0.com/users");

--- a/src/test/java/com/auth0/client/auth/AuthorizeUrlBuilderTest.java
+++ b/src/test/java/com/auth0/client/auth/AuthorizeUrlBuilderTest.java
@@ -18,6 +18,7 @@ public class AuthorizeUrlBuilderTest {
     private static final String CLIENT_ID = "clientId";
     private static final String REDIRECT_URI = "https://domain.auth0.com/callback";
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/src/test/java/com/auth0/client/auth/LogoutUrlBuilderTest.java
+++ b/src/test/java/com/auth0/client/auth/LogoutUrlBuilderTest.java
@@ -18,6 +18,7 @@ public class LogoutUrlBuilderTest {
     private static final String CLIENT_ID = "clientId";
     private static final String RETURN_TO_URL = "https://domain.auth0.com/callback";
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/src/test/java/com/auth0/client/mgmt/BaseMgmtEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/BaseMgmtEntityTest.java
@@ -12,6 +12,8 @@ public class BaseMgmtEntityTest {
 
     protected MockServer server;
     protected ManagementAPI api;
+
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/src/test/java/com/auth0/client/mgmt/BlacklistsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/BlacklistsEntityTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BlacklistsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
 
@@ -103,6 +103,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListClientGrants() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<ClientGrant>> request = api.clientGrants().list();
         assertThat(request, is(notNullValue()));
 
@@ -120,6 +121,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldReturnEmptyClientGrants() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<ClientGrant>> request = api.clientGrants().list();
         assertThat(request, is(notNullValue()));
 

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ClientsEntityTest extends BaseMgmtEntityTest {
 
@@ -123,6 +123,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListClients() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Client>> request = api.clients().list();
         assertThat(request, is(notNullValue()));
 
@@ -140,6 +141,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldReturnEmptyClients() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Client>> request = api.clients().list();
         assertThat(request, is(notNullValue()));
 

--- a/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
@@ -13,12 +13,13 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListConnections() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Connection>> request = api.connections().list(null);
         assertThat(request, is(notNullValue()));
 
@@ -37,6 +38,8 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldListConnectionsWithStrategy() throws Exception {
         ConnectionFilter filter = new ConnectionFilter().withStrategy("auth0");
+
+        @SuppressWarnings("deprecation")
         Request<List<Connection>> request = api.connections().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -56,6 +59,8 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldListConnectionsWithName() throws Exception {
         ConnectionFilter filter = new ConnectionFilter().withName("my-connection");
+
+        @SuppressWarnings("deprecation")
         Request<List<Connection>> request = api.connections().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -75,6 +80,8 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldListConnectionsWithFields() throws Exception {
         ConnectionFilter filter = new ConnectionFilter().withFields("some,random,fields", true);
+
+        @SuppressWarnings("deprecation")
         Request<List<Connection>> request = api.connections().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -112,6 +119,8 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldNotListConnectionsWithTotals() throws Exception {
         ConnectionFilter filter = new ConnectionFilter().withTotals(true);
+
+        @SuppressWarnings("deprecation")
         Request<List<Connection>> request = api.connections().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -174,6 +183,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldReturnEmptyConnections() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Connection>> request = api.connections().list(null);
         assertThat(request, is(notNullValue()));
 

--- a/src/test/java/com/auth0/client/mgmt/DeviceCredentialsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/DeviceCredentialsEntityTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
     @Test

--- a/src/test/java/com/auth0/client/mgmt/EmailProviderEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailProviderEntityTest.java
@@ -12,7 +12,7 @@ import static com.auth0.client.MockServer.MGMT_EMAIL_PROVIDER;
 import static com.auth0.client.MockServer.bodyFromRequest;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EmailProviderEntityTest extends BaseMgmtEntityTest {
     @Test

--- a/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
@@ -11,7 +11,7 @@ import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @SuppressWarnings("RedundantThrows")
 public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {

--- a/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GrantsEntityTest extends BaseMgmtEntityTest {
 
@@ -112,6 +112,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListGrants() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Grant>> request = api.grants().list("userId");
         assertThat(request, is(notNullValue()));
 
@@ -136,6 +137,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldThrowOnListGrantsWithNullUserId() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -145,6 +147,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldReturnEmptyGrants() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Grant>> request = api.grants().list("userId");
         assertThat(request, is(notNullValue()));
 

--- a/src/test/java/com/auth0/client/mgmt/GuardianEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GuardianEntityTest.java
@@ -12,7 +12,7 @@ import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GuardianEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LogEventsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
@@ -14,7 +14,7 @@ import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LogStreamsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -19,7 +19,7 @@ import java.net.Proxy;
 import static com.auth0.client.UrlMatcher.isUrl;
 import static okhttp3.logging.HttpLoggingInterceptor.Level;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ManagementAPITest {
 
@@ -28,6 +28,8 @@ public class ManagementAPITest {
 
     private MockServer server;
     private ManagementAPI api;
+
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ResourceServerEntityTest extends BaseMgmtEntityTest {
 
@@ -82,6 +82,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListResourceServers() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<ResourceServer>> request = api.resourceServers().list();
 
         assertThat(request, is(notNullValue()));

--- a/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.client.mgmt.filter.RolesFilter;

--- a/src/test/java/com/auth0/client/mgmt/RulesConfigsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesConfigsEntityTest.java
@@ -12,7 +12,7 @@ import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RulesConfigsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
@@ -13,12 +13,13 @@ import java.util.Map;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RulesEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldListRules() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Rule>> request = api.rules().list(null);
         assertThat(request, is(notNullValue()));
 
@@ -54,6 +55,8 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldListRulesWithEnabled() throws Exception {
         RulesFilter filter = new RulesFilter().withEnabled(true);
+
+        @SuppressWarnings("deprecation")
         Request<List<Rule>> request = api.rules().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -73,6 +76,8 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldListRulesWithFields() throws Exception {
         RulesFilter filter = new RulesFilter().withFields("some,random,fields", true);
+
+        @SuppressWarnings("deprecation")
         Request<List<Rule>> request = api.rules().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -93,6 +98,8 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldNotListRulesWithTotals() throws Exception {
         RulesFilter filter = new RulesFilter().withTotals(true);
+
+        @SuppressWarnings("deprecation")
         Request<List<Rule>> request = api.rules().list(filter);
         assertThat(request, is(notNullValue()));
 
@@ -154,6 +161,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldReturnEmptyRules() throws Exception {
+        @SuppressWarnings("deprecation")
         Request<List<Rule>> request = api.rules().list(null);
         assertThat(request, is(notNullValue()));
 

--- a/src/test/java/com/auth0/client/mgmt/StatsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/StatsEntityTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StatsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/TenantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/TenantsEntityTest.java
@@ -10,7 +10,7 @@ import static com.auth0.client.MockServer.MGMT_TENANT;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TenantsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/TicketsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/TicketsEntityTest.java
@@ -12,7 +12,7 @@ import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TicketsEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/UserBlocksEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UserBlocksEntityTest.java
@@ -9,7 +9,7 @@ import static com.auth0.client.MockServer.MGMT_USER_BLOCKS;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UserBlocksEntityTest extends BaseMgmtEntityTest {
 

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.auth0.client.mgmt.filter.FieldsFilter;
 import com.auth0.client.mgmt.filter.LogEventFilter;

--- a/src/test/java/com/auth0/client/mgmt/filter/ClientGrantsFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/ClientGrantsFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ClientGrantsFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/ConnectionFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/ConnectionFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConnectionFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/DeviceCredentialsFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/DeviceCredentialsFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DeviceCredentialsFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/FieldFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/FieldFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FieldFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/GrantsFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/GrantsFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GrantsFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/LogEventFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/LogEventFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LogEventFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/PageFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/PageFilterTest.java
@@ -2,7 +2,7 @@ package com.auth0.client.mgmt.filter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;

--- a/src/test/java/com/auth0/client/mgmt/filter/QueryFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/QueryFilterTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
@@ -18,6 +18,7 @@ import org.junit.rules.ExpectedException;
 
 public class QueryFilterTest {
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/src/test/java/com/auth0/client/mgmt/filter/ResourceServersFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/ResourceServersFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ResourceServersFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/RoleFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/RoleFilterTest.java
@@ -2,7 +2,7 @@ package com.auth0.client.mgmt.filter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;

--- a/src/test/java/com/auth0/client/mgmt/filter/RulesFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/RulesFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RulesFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/UserFilterTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UserFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/UsersExportFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/UsersExportFilterTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UsersExportFilterTest {
 

--- a/src/test/java/com/auth0/client/mgmt/filter/UsersImportOptionsTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/UsersImportOptionsTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UsersImportOptionsTest {
     private UsersImportOptions options;

--- a/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import static com.auth0.json.JsonMatcher.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ResourceServerTest extends JsonTest<ResourceServer> {
     private final static String RESOURCE_SERVER_JSON = "src/test/resources/mgmt/resource_server.json";

--- a/src/test/java/com/auth0/json/mgmt/ScopeTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ScopeTest.java
@@ -5,7 +5,7 @@ import com.auth0.json.JsonTest;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ScopeTest extends JsonTest<Scope> {
     private static final String SCOPE_JSON = "src/test/resources/mgmt/scope.json";

--- a/src/test/java/com/auth0/json/mgmt/guardian/SNSFactorProviderTest.java
+++ b/src/test/java/com/auth0/json/mgmt/guardian/SNSFactorProviderTest.java
@@ -12,6 +12,7 @@ public class SNSFactorProviderTest extends JsonTest<SNSFactorProvider> {
 
     private static final String json = "{\"aws_access_key_id\":\"akey\",\"aws_secret_access_key\":\"secretakey\",\"aws_region\":\"ar\",\"sns_apns_platform_application_arn\":\"arn1\",\"sns_gcm_platform_application_arn\":\"arn2\"}";
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSerializeWithDeprecatedSetters() throws Exception {
         SNSFactorProvider provider = new SNSFactorProvider();

--- a/src/test/java/com/auth0/json/mgmt/guardian/TwilioFactorProviderTest.java
+++ b/src/test/java/com/auth0/json/mgmt/guardian/TwilioFactorProviderTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.*;
 
 public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -25,6 +26,7 @@ public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
         new TwilioFactorProvider("+12356789", "messaging_service_sid", "atokEn", "id123");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldFailWhenSettingFromAndMessagingServiceSIDWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -35,6 +37,7 @@ public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
         provider.setMessagingServiceSID("id321");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldFailWhenSettingMessagingServiceSIDAndFromWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
@@ -45,6 +48,7 @@ public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
         provider.setFrom("+12356789");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSerializeWithDeprecatedSettersWithFrom() throws Exception {
         TwilioFactorProvider provider = new TwilioFactorProvider();
@@ -60,6 +64,7 @@ public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
         assertThat(serialized, not(containsString("\"messaging_service_sid\"")));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSerializeWithDeprecatedSettersWithMessagingServiceSID() throws Exception {
         TwilioFactorProvider provider = new TwilioFactorProvider();

--- a/src/test/java/com/auth0/json/mgmt/jobs/JobTest.java
+++ b/src/test/java/com/auth0/json/mgmt/jobs/JobTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JobTest extends JsonTest<Job> {
 

--- a/src/test/java/com/auth0/json/mgmt/jobs/UsersExportFieldTest.java
+++ b/src/test/java/com/auth0/json/mgmt/jobs/UsersExportFieldTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UsersExportFieldTest extends JsonTest<UsersExportField> {
 

--- a/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
@@ -12,6 +12,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
 
     private static final String readOnlyJson = "{\"ticket\":\"https://page.auth0.com/tickets/123\"}";
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSerialize() throws Exception {
         PasswordChangeTicket ticket = new PasswordChangeTicket("usr123");
@@ -33,7 +34,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(serialized, JsonMatcher.hasEntry("mark_email_as_verified", true));
     }
 
-    
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSerializeWithCustomizedConnection() throws Exception {
         PasswordChangeTicket ticket = new PasswordChangeTicket("user@emailprovider.com", "connid123");
@@ -61,6 +62,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(ticket.getTicket(), is("https://page.auth0.com/tickets/123"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldHandleNullPasswordString() throws Exception {
         PasswordChangeTicket ticket = new PasswordChangeTicket("userId");

--- a/src/test/java/com/auth0/json/mgmt/users/UserTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UserTest.java
@@ -27,6 +27,7 @@ public class UserTest extends JsonTest<User> {
         assertThat(user2.getValues(), is(notNullValue()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldSerialize() throws Exception {
         User user = new User("auth0");
@@ -119,6 +120,7 @@ public class UserTest extends JsonTest<User> {
         assertThat(user.getLoginsCount(), is(10));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldHandleNullPasswordString() {
         User user = new User();
@@ -135,6 +137,7 @@ public class UserTest extends JsonTest<User> {
         assertThat(user.getPassword(), is(nullValue()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldGetPasswordAsCharArray() {
         String password = "secret";

--- a/src/test/java/com/auth0/net/CreateUserRequestTest.java
+++ b/src/test/java/com/auth0/net/CreateUserRequestTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 import static com.auth0.client.MockServer.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CreateUserRequestTest {
 

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -32,6 +32,7 @@ public class CustomRequestTest {
     private MockServer server;
     private OkHttpClient client;
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
     private TypeReference<TokenHolder> tokenHolderType;
@@ -63,8 +64,8 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         TokenHolder execute = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertThat(recordedRequest.getMethod(), is("GET"));
-        Assert.assertThat(execute, is(notNullValue()));
+        assertThat(recordedRequest.getMethod(), is("GET"));
+        assertThat(execute, is(notNullValue()));
     }
 
     @Test
@@ -76,8 +77,8 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         TokenHolder execute = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertThat(recordedRequest.getMethod(), is("POST"));
-        Assert.assertThat(execute, is(notNullValue()));
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(execute, is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
@@ -46,8 +46,8 @@ public class EmptyBodyRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertThat(recordedRequest.getMethod(), is("POST"));
-        Assert.assertThat(recordedRequest.getBodySize(), is(0L));
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(recordedRequest.getBodySize(), is(0L));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class EmptyBodyRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertThat(recordedRequest.getMethod(), is("POST"));
-        Assert.assertThat(recordedRequest.getBodySize(), is(0L));
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(recordedRequest.getBodySize(), is(0L));
     }
 }

--- a/src/test/java/com/auth0/net/MultipartRequestTest.java
+++ b/src/test/java/com/auth0/net/MultipartRequestTest.java
@@ -37,6 +37,7 @@ public class MultipartRequestTest {
     private MockServer server;
     private OkHttpClient client;
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
     private TypeReference<TokenHolder> tokenHolderType;
@@ -76,8 +77,8 @@ public class MultipartRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         TokenHolder execute = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
-        Assert.assertThat(recordedRequest.getMethod(), is("POST"));
-        Assert.assertThat(execute, is(notNullValue()));
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(execute, is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/com/auth0/net/TelemetryInterceptorTest.java
+++ b/src/test/java/com/auth0/net/TelemetryInterceptorTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/auth0/net/TelemetryTest.java
+++ b/src/test/java/com/auth0/net/TelemetryTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TelemetryTest {
 

--- a/src/test/java/com/auth0/net/TokenRequestTest.java
+++ b/src/test/java/com/auth0/net/TokenRequestTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import static com.auth0.client.MockServer.AUTH_TOKENS;
 import static com.auth0.client.MockServer.bodyFromRequest;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TokenRequestTest {
 

--- a/src/test/java/com/auth0/net/VoidRequestTest.java
+++ b/src/test/java/com/auth0/net/VoidRequestTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 import static com.auth0.client.MockServer.AUTH_TOKENS;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VoidRequestTest {
     private OkHttpClient client;

--- a/src/test/java/com/auth0/utils/tokens/IdTokenVerifierTest.java
+++ b/src/test/java/com/auth0/utils/tokens/IdTokenVerifierTest.java
@@ -23,6 +23,7 @@ public class IdTokenVerifierTest {
     private final static Date DEFAULT_CLOCK = new Date(1567400400000L);
     private final static Integer DEFAULT_CLOCK_SKEW = 60;
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/src/test/java/com/auth0/utils/tokens/SignatureVerifierTest.java
+++ b/src/test/java/com/auth0/utils/tokens/SignatureVerifierTest.java
@@ -23,7 +23,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Scanner;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SignatureVerifierTest {
 
@@ -34,6 +34,7 @@ public class SignatureVerifierTest {
     private static final String RS_PUBLIC_KEY = "src/test/resources/keys/public-rsa.pem";
     private static final String RS_PUBLIC_KEY_BAD = "src/test/resources/keys/bad-public-rsa.pem";
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 


### PR DESCRIPTION
### Changes

ℹ️  **Test-only changes** ℹ️ 

The `compileTest` build target currently generates many compiler warnings, all of them related to the use of deprecated methods. While not serious in itself, having unresolved warnings can obfuscate future warnings that we need to address. 

The changes in this PR address the following:
* Change from the now [deprecated](https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertThat(java.lang.String,%20T,%20org.hamcrest.Matcher)) `org.junit.Assert.assertThat` to `org.hamcrest.MatcherAssert.assertThat`.
* Suppress warnings for tests that exercise our own deprecated methods
* Suppress warnings related to using the now [deprecated](https://junit.org/junit4/javadoc/4.13/org/junit/rules/ExpectedException.html#none()) `ExpectedException.none()` method. Time better spent changing to Junit5 exception assertion handling at some point.
* Updates the compiler arguments to list any deprecation warnings in all build types, and fail if there are warnings so we don't introduce new deprecation warnings

Suppressed warnings have been made with as minimal scope as possible, while avoiding adding unused variables simply to satisfy the allowed scope of `SuppressWarnings`.

### Testing

No additional tests added; all tests should pass as before.

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
