### PR TITLE
Add methods to determine cause of APIException

### DIFF
--- a/src/main/java/com/auth0/exception/APIException.java
+++ b/src/main/java/com/auth0/exception/APIException.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * Class that represents an Auth0 Server error captured from a http response. Provides different methods to get a clue of why the request failed.
+ * Represents an Auth0 Server error captured from an HTTP response. Provides different methods to determine why the request failed.
  * i.e.:
  * <pre>
  * {@code
@@ -79,6 +79,49 @@ public class APIException extends Auth0Exception {
      */
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * @return {@code true} when an MFA code is required to authenticate, {@code false} otherwise.
+     */
+    public boolean isMultifactorRequired() {
+        return "mfa_required".equals(error);
+    }
+
+    /**
+     * @return {@code true} when the username and/or password used for authentication are invalid, {@code false} otherwise.
+     */
+    public boolean isInvalidCredentials() {
+        return "invalid_user_password".equals(error) || "invalid_grant".equals(error) && "Wrong email or password.".equals(description);
+    }
+
+    /**
+     * @return {@code true} when MFA is required and the user is not enrolled, {@code false} otherwise.
+     */
+    public boolean isMultifactorEnrollRequired() {
+        return "unsupported_challenge_type".equals(error);
+    }
+
+    /**
+     * @return {@code true} when Bot Protection flags the request as suspicious, {@code false} otherwise.
+     */
+    public boolean isVerificationRequired() {
+        return "requires_verification".equals(error);
+    }
+
+    /**
+     * @return {@code true} when the MFA Token used on the login request is malformed or has expired, {@code false} otherwise.
+     */
+    public boolean isMultifactorTokenInvalid() {
+        return "expired_token".equals(error) && "mfa_token is expired".equals(description) ||
+                "invalid_grant".equals(error) && "Malformed mfa_token".equals(description);
+    }
+
+    /**
+     * @return {@code true} when authenticating with web-based authentiction and the resource server denied access per the OAuth 2 spec, {@code false} otherwise.
+     */
+    public boolean isAccessDenied() {
+        return "access_denied".equals(error);
     }
 
     private static String createMessage(String description, int statusCode) {

--- a/src/test/java/com/auth0/exception/APIExceptionTest.java
+++ b/src/test/java/com/auth0/exception/APIExceptionTest.java
@@ -22,30 +22,38 @@ public class APIExceptionTest {
     public void shouldBeMfaRequiredWithMfaTokenError() {
         values.put("error", "mfa_required");
         values.put("mfa_token", "some-mfa-token");
-        APIException apiException = new APIException(values, 403);
+        APIException apiException = new APIException(values, 42);
         assertThat(apiException.isMultifactorRequired(), is(true));
         assertThat(apiException.getValue("mfa_token"), is("some-mfa-token"));
     }
 
     @Test
-    public void shouldBeInvalidCredentialsError() {
+    public void shouldBeInvalidCredentialsErrorWhenInvalidGrant() {
         values.put("error", "invalid_grant");
         values.put("error_description", "Wrong email or password.");
-        APIException apiException = new APIException(values, 403);
+        APIException apiException = new APIException(values, 42);
+        assertThat(apiException.isInvalidCredentials(), is(true));
+    }
+
+    @Test
+    public void shouldBeInvalidCredentialsErrorWhenInvalidUserPassword() {
+        values.put("error", "invalid_user_password");
+        values.put("error_description", "Wrong email or password.");
+        APIException apiException = new APIException(values, 42);
         assertThat(apiException.isInvalidCredentials(), is(true));
     }
 
     @Test
     public void shouldBeAccessDeniedError() {
         values.put("error", "access_denied");
-        APIException apiException = new APIException(values, 401);
+        APIException apiException = new APIException(values, 42);
         assertThat(apiException.isAccessDenied(), is(true));
     }
 
     @Test
     public void shouldBeMfaEnrollementRequiredError() {
         values.put("error", "unsupported_challenge_type");
-        APIException apiException = new APIException(values, 403);
+        APIException apiException = new APIException(values, 42);
         assertThat(apiException.isMultifactorEnrollRequired(), is(true));
     }
 
@@ -53,7 +61,7 @@ public class APIExceptionTest {
     public void shouldBeMfaTokenInvalidErrorForMalformedToken() {
         values.put("error", "invalid_grant");
         values.put("error_description", "Malformed mfa_token");
-        APIException apiException = new APIException(values, 1);
+        APIException apiException = new APIException(values, 42);
         assertThat(apiException.isMultifactorTokenInvalid(), is(true));
     }
 
@@ -74,7 +82,7 @@ public class APIExceptionTest {
 
     @Test
     public void checkErrorTypesShouldHandleNullError() {
-        APIException apiException = new APIException(values, 403);
+        APIException apiException = new APIException(values, 42);
         assertThat(apiException.isAccessDenied(), is(false));
         assertThat(apiException.isInvalidCredentials(), is(false));
         assertThat(apiException.isMultifactorRequired(), is(false));

--- a/src/test/java/com/auth0/exception/APIExceptionTest.java
+++ b/src/test/java/com/auth0/exception/APIExceptionTest.java
@@ -44,6 +44,14 @@ public class APIExceptionTest {
     }
 
     @Test
+    public void shouldNotBeInvalidCredentialsErrorWhenWrongDescription() {
+        values.put("error", "invalid_grant");
+        values.put("error_description", "some message");
+        APIException apiException = new APIException(values, 42);
+        assertThat(apiException.isInvalidCredentials(), is(false));
+    }
+
+    @Test
     public void shouldBeAccessDeniedError() {
         values.put("error", "access_denied");
         APIException apiException = new APIException(values, 42);
@@ -71,6 +79,22 @@ public class APIExceptionTest {
         values.put("error_description", "mfa_token is expired");
         APIException apiException = new APIException(values, 1);
         assertThat(apiException.isMultifactorTokenInvalid(), is(true));
+    }
+
+    @Test
+    public void shouldNotBeMfaTokenInvalidErrorForExpiredTokenWhenWrongDescription() {
+        values.put("error", "expired_token");
+        values.put("error_description", "some message");
+        APIException apiException = new APIException(values, 1);
+        assertThat(apiException.isMultifactorTokenInvalid(), is(false));
+    }
+
+    @Test
+    public void shouldNotBeMfaTokenInvalidErrorForMalformedTokenWhenWrongDescription() {
+        values.put("error", "invalid_grant");
+        values.put("error_description", "some message");
+        APIException apiException = new APIException(values, 1);
+        assertThat(apiException.isMultifactorTokenInvalid(), is(false));
     }
 
     @Test

--- a/src/test/java/com/auth0/exception/APIExceptionTest.java
+++ b/src/test/java/com/auth0/exception/APIExceptionTest.java
@@ -1,0 +1,86 @@
+package com.auth0.exception;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class APIExceptionTest {
+
+    private Map<String, Object> values;
+
+    @Before
+    public void setUp() {
+        values = new HashMap<>();
+    }
+
+    @Test
+    public void shouldBeMfaRequiredWithMfaTokenError() {
+        values.put("error", "mfa_required");
+        values.put("mfa_token", "some-mfa-token");
+        APIException apiException = new APIException(values, 403);
+        assertThat(apiException.isMultifactorRequired(), is(true));
+        assertThat(apiException.getValue("mfa_token"), is("some-mfa-token"));
+    }
+
+    @Test
+    public void shouldBeInvalidCredentialsError() {
+        values.put("error", "invalid_grant");
+        values.put("error_description", "Wrong email or password.");
+        APIException apiException = new APIException(values, 403);
+        assertThat(apiException.isInvalidCredentials(), is(true));
+    }
+
+    @Test
+    public void shouldBeAccessDeniedError() {
+        values.put("error", "access_denied");
+        APIException apiException = new APIException(values, 401);
+        assertThat(apiException.isAccessDenied(), is(true));
+    }
+
+    @Test
+    public void shouldBeMfaEnrollementRequiredError() {
+        values.put("error", "unsupported_challenge_type");
+        APIException apiException = new APIException(values, 403);
+        assertThat(apiException.isMultifactorEnrollRequired(), is(true));
+    }
+
+    @Test
+    public void shouldBeMfaTokenInvalidErrorForMalformedToken() {
+        values.put("error", "invalid_grant");
+        values.put("error_description", "Malformed mfa_token");
+        APIException apiException = new APIException(values, 1);
+        assertThat(apiException.isMultifactorTokenInvalid(), is(true));
+    }
+
+    @Test
+    public void shouldBeMfaTokenInvalidErrorForExpiredToken() {
+        values.put("error", "expired_token");
+        values.put("error_description", "mfa_token is expired");
+        APIException apiException = new APIException(values, 1);
+        assertThat(apiException.isMultifactorTokenInvalid(), is(true));
+    }
+
+    @Test
+    public void shouldBeMfaEnrollementRequired() {
+        values.put("error", "unsupported_challenge_type");
+        APIException apiException = new APIException(values, 401);
+        assertThat(apiException.isMultifactorEnrollRequired(), is(true));
+    }
+
+    @Test
+    public void checkErrorTypesShouldHandleNullError() {
+        APIException apiException = new APIException(values, 403);
+        assertThat(apiException.isAccessDenied(), is(false));
+        assertThat(apiException.isInvalidCredentials(), is(false));
+        assertThat(apiException.isMultifactorRequired(), is(false));
+        assertThat(apiException.isMultifactorEnrollRequired(), is(false));
+        assertThat(apiException.isMultifactorTokenInvalid(), is(false));
+        assertThat(apiException.isVerificationRequired(), is(false));
+
+    }
+}


### PR DESCRIPTION
### Changes

Resolves #279.

Adds methods to `APIException` to help determine the cause of the underlying `APIException`, similar to how `Auth0.Android` [handles this](https://github.com/auth0/Auth0.Android/blob/master/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.java#L180-L205). Other methods can be added in the future as needed.


### References

- #279

### Testing

There is no existing test for `APIException`; this change adds a test class but only adds tests for the added functionality.

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
