### PR TITLE
Add unchecked warnings failures for src

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ jacocoTestReport {
 compileJava {
     sourceCompatibility '1.7'
     targetCompatibility '1.7'
+
+    options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked" << "-Werror"
+}
+
+compileTestJava {
+    options.compilerArgs << "-Xlint:deprecation" << "-Werror"
 }
 
 buildscript {
@@ -44,11 +50,6 @@ buildscript {
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.9.0'
-    }
-
-    tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:deprecation"
-        options.compilerArgs << "-Werror"
     }
 }
 

--- a/src/main/java/com/auth0/exception/APIException.java
+++ b/src/main/java/com/auth0/exception/APIException.java
@@ -136,7 +136,8 @@ public class APIException extends Auth0Exception {
             Object description = values.get("description");
             if (description instanceof String) {
                 return (String) description;
-            } else {
+            } else if (description instanceof Map){
+                @SuppressWarnings("unchecked")
                 PasswordStrengthErrorParser policy = new PasswordStrengthErrorParser((Map<String, Object>) description);
                 return policy.getDescription();
             }

--- a/src/test/java/com/auth0/exception/APIExceptionTest.java
+++ b/src/test/java/com/auth0/exception/APIExceptionTest.java
@@ -3,6 +3,7 @@ package com.auth0.exception;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,16 +14,85 @@ public class APIExceptionTest {
 
     private Map<String, Object> values;
 
+    private final static int ERROR_CODE = 42;
+    private final static String EXPECTED_ERROR_MESSAGE_PREFIX = "Request failed with status code " + ERROR_CODE + ": ";
+
     @Before
     public void setUp() {
         values = new HashMap<>();
     }
 
     @Test
+    public void shouldGetMessageFromErrorDescription() {
+        values.put("error_description", "some error description");
+        values.put("description", "some description");
+        values.put("message", "some message");
+        values.put("error", "some error");
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "some error description"));
+    }
+
+    @Test
+    public void shouldGetMessageFromDescriptionAsString() {
+        values.put("message", "some message");
+        values.put("error", "some error");
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "some message"));
+    }
+
+    @Test
+    public void shouldGetMessageFromDescriptionAsMap() {
+        Map<String, Object> rules = new HashMap<>();
+        rules.put("verified", false);
+        rules.put("code", "lengthAtLeast");
+        rules.put("format", Collections.singletonList(8));
+        rules.put("message", "some password length message");
+
+        Map<String, Object> passwordStrengthError = new HashMap<>();
+        passwordStrengthError.put("rules", Collections.singletonList(rules));
+
+        values.put("description", passwordStrengthError);
+        values.put("message", "some message");
+        values.put("error", "some error");
+
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "some password length message"));
+    }
+
+    @Test
+    public void shouldGetDefaultMessageWhenDescriptionNotMapOrString() {
+        values.put("description", Collections.singletonList("some description"));
+
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "Unknown exception"));
+    }
+
+    @Test
+    public void shouldGetMessageFromMessage() {
+        values.put("message", "some message");
+        values.put("error", "some error");
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "some message"));
+    }
+
+    @Test
+    public void shouldGetMessageFromError() {
+        values.put("error", "some error");
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "some error"));
+    }
+
+    @Test
+    public void shouldGetDefaultMessage() {
+        APIException apiException = new APIException(values, ERROR_CODE);
+        assertThat(apiException.getMessage(), is(EXPECTED_ERROR_MESSAGE_PREFIX + "Unknown exception"));
+    }
+
+    @Test
     public void shouldBeMfaRequiredWithMfaTokenError() {
         values.put("error", "mfa_required");
         values.put("mfa_token", "some-mfa-token");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorRequired(), is(true));
         assertThat(apiException.getValue("mfa_token"), is("some-mfa-token"));
     }
@@ -31,7 +101,7 @@ public class APIExceptionTest {
     public void shouldBeInvalidCredentialsErrorWhenInvalidGrant() {
         values.put("error", "invalid_grant");
         values.put("error_description", "Wrong email or password.");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isInvalidCredentials(), is(true));
     }
 
@@ -39,7 +109,7 @@ public class APIExceptionTest {
     public void shouldBeInvalidCredentialsErrorWhenInvalidUserPassword() {
         values.put("error", "invalid_user_password");
         values.put("error_description", "Wrong email or password.");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isInvalidCredentials(), is(true));
     }
 
@@ -47,21 +117,21 @@ public class APIExceptionTest {
     public void shouldNotBeInvalidCredentialsErrorWhenWrongDescription() {
         values.put("error", "invalid_grant");
         values.put("error_description", "some message");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isInvalidCredentials(), is(false));
     }
 
     @Test
     public void shouldBeAccessDeniedError() {
         values.put("error", "access_denied");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isAccessDenied(), is(true));
     }
 
     @Test
     public void shouldBeMfaEnrollementRequiredError() {
         values.put("error", "unsupported_challenge_type");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorEnrollRequired(), is(true));
     }
 
@@ -69,7 +139,7 @@ public class APIExceptionTest {
     public void shouldBeMfaTokenInvalidErrorForMalformedToken() {
         values.put("error", "invalid_grant");
         values.put("error_description", "Malformed mfa_token");
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorTokenInvalid(), is(true));
     }
 
@@ -77,7 +147,7 @@ public class APIExceptionTest {
     public void shouldBeMfaTokenInvalidErrorForExpiredToken() {
         values.put("error", "expired_token");
         values.put("error_description", "mfa_token is expired");
-        APIException apiException = new APIException(values, 1);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorTokenInvalid(), is(true));
     }
 
@@ -85,7 +155,7 @@ public class APIExceptionTest {
     public void shouldNotBeMfaTokenInvalidErrorForExpiredTokenWhenWrongDescription() {
         values.put("error", "expired_token");
         values.put("error_description", "some message");
-        APIException apiException = new APIException(values, 1);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorTokenInvalid(), is(false));
     }
 
@@ -93,20 +163,20 @@ public class APIExceptionTest {
     public void shouldNotBeMfaTokenInvalidErrorForMalformedTokenWhenWrongDescription() {
         values.put("error", "invalid_grant");
         values.put("error_description", "some message");
-        APIException apiException = new APIException(values, 1);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorTokenInvalid(), is(false));
     }
 
     @Test
     public void shouldBeMfaEnrollementRequired() {
         values.put("error", "unsupported_challenge_type");
-        APIException apiException = new APIException(values, 401);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isMultifactorEnrollRequired(), is(true));
     }
 
     @Test
     public void checkErrorTypesShouldHandleNullError() {
-        APIException apiException = new APIException(values, 42);
+        APIException apiException = new APIException(values, ERROR_CODE);
         assertThat(apiException.isAccessDenied(), is(false));
         assertThat(apiException.isInvalidCredentials(), is(false));
         assertThat(apiException.isMultifactorRequired(), is(false));


### PR DESCRIPTION
### Changes

_This is primarily a tech debt and future preparedness PR_

`APIException` currently performs an unsafe (in compiler terms) cast of the error description to a `Map<String, Object>`. Functionally, this shouldn't be an issue since a `ClassCastException` would only come from a change in the error schema, which shouldn't happen.

However, it does cause an unchecked cast warning, which we should typically not have or suppress as needed. This change does the following:
- Updates `APIException` to only create a `PasswordStrengthErrorParser` if the error description is a map (currently it would fail with a runtime exception if not a string)
- Suppresses the unchecked exception when casting the error description to `Map<String, Object>`
- Adds tests to cover this change and the `obtainExceptionMessage` behavior in general
- Moves the compiler options to `compileJava` and `compileTestJava`
- Adds the `-Xlint:unchecked` compiler flag for src (not for tests)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [X] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
