### PR TITLE
Use java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,15 @@
+plugins {
+    id 'java'
+    id 'jacoco'
+    id 'com.auth0.gradle.oss-library.java'
+    id "com.jfrog.bintray" version "1.8.4"
+}
+
+repositories {
+    jcenter()
+}
+
 group = 'com.auth0'
-
-apply plugin: 'com.auth0.gradle.oss-library.java'
-apply plugin: 'jacoco'
-
 logger.lifecycle("Using version ${version} for ${name}")
 
 oss {
@@ -39,24 +46,7 @@ compileJava {
 
 compileTestJava {
     options.compilerArgs << "-Xlint:deprecation" << "-Werror"
-}
-
-buildscript {
-    repositories {
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
     }
-    dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.9.0'
-    }
-}
-
-repositories {
-    jcenter()
-    mavenCentral()
-}
 
 test {
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,15 @@ jacocoTestReport {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 compileJava {
-    sourceCompatibility '1.7'
-    targetCompatibility '1.7'
+    sourceCompatibility '1.8'
+    targetCompatibility '1.8'
 
     options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked" << "-Werror"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        jcenter()
+        maven {
+            name "JCenter Gradle Plugins"
+            url "https://dl.bintray.com/gradle/gradle-plugins"
+        }
+    }
+    plugins {
+        id 'com.auth0.gradle.oss-library.java' version '0.9.0'
+    }
+}
+
 rootProject.name = 'auth0'


### PR DESCRIPTION
### Changes

Use gradle build scripts when gradle version > 5 
Use java 8

Gradle will use Java 8 using the toolchain support
https://docs.gradle.org/6.7/release-notes.html

### References

#314

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
