### PR TITLE
Update to OkHttp 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ test {
 }
 
 dependencies {
-    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
     implementation 'commons-codec:commons-codec:1.15'
@@ -70,7 +70,7 @@ dependencies {
 
     testImplementation 'org.bouncycastle:bcprov-jdk15on:1.65'
     testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.9'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'junit:junit:4.13.1'

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -47,7 +47,7 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
             return null;
         }
         byte[] jsonBody = mapper.writeValueAsBytes(body != null ? body : parameters);
-        return RequestBody.create(MediaType.parse(CONTENT_TYPE_APPLICATION_JSON), jsonBody);
+        return RequestBody.create(jsonBody, MediaType.parse(CONTENT_TYPE_APPLICATION_JSON));
     }
 
     @Override

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -19,7 +19,7 @@ public class EmptyBodyRequest<T> extends CustomRequest<T> {
 
     @Override
     protected RequestBody createRequestBody() {
-        return RequestBody.create(null, new byte[0]);
+        return RequestBody.create(new byte[0], null);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -79,7 +79,7 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
             throw new IllegalArgumentException("Failed to add part because the file specified cannot be found.");
         }
         bodyBuilder.addFormDataPart(name, file.getName(),
-                RequestBody.create(MediaType.parse(mediaType), file));
+                RequestBody.create(file, MediaType.parse(mediaType)));
         partsCount++;
         return this;
     }


### PR DESCRIPTION
### Changes

Updates the OkHttp dependency to version 4.

Details on the changes contained in version 4 can be found [here](https://square.github.io/okhttp/upgrading_to_okhttp_4/) (impacts are intentionally small). 

I did change three usages of `RequestBody.create` to reverse the parameter order to resolve deprecation warnings, as [documented by OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/main/kotlin/okhttp3/RequestBody.kt#L180).  

### References

- https://square.github.io/okhttp/upgrading_to_okhttp_4/

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
