### PR TITLE
Add refresh token configuration object to client

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -76,6 +76,8 @@ public class Client {
     private Map<String, Object> clientMetadata;
     @JsonProperty("mobile")
     private Mobile mobile;
+    @JsonProperty("refresh_token")
+    private RefreshToken refreshToken;
 
     /**
      * Creates a new Application instance setting the name property.
@@ -656,6 +658,24 @@ public class Client {
     @JsonProperty("mobile")
     public void setMobile(Mobile mobile) {
         this.mobile = mobile;
+    }
+
+    /**
+     * Getter for the configuration related to refresh tokens.
+     *
+     * @return the refresh token configuration.
+     */
+    public RefreshToken getRefreshToken() {
+        return refreshToken;
+    }
+
+    /**
+     * Setter for the configuration related to refresh tokens.
+     *
+     * @param refreshToken the refresh token configuration to set.
+     */
+    public void setRefreshToken(RefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }
 

--- a/src/main/java/com/auth0/json/mgmt/client/RefreshToken.java
+++ b/src/main/java/com/auth0/json/mgmt/client/RefreshToken.java
@@ -1,0 +1,176 @@
+package com.auth0.json.mgmt.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents the configuration of refresh tokens for a client.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RefreshToken {
+
+    @JsonProperty("rotation_type")
+    private String rotationType;
+    @JsonProperty("expiration_type")
+    private String expirationType;
+    @JsonProperty("leeway")
+    private Integer leeway;
+    @JsonProperty("token_lifetime")
+    private Integer tokenLifetime;
+    @JsonProperty("infinite_token_lifetime")
+    private Boolean infiniteTokenLifetime;
+    @JsonProperty("idle_token_lifetime")
+    private Integer idleTokenLifetime;
+    @JsonProperty("infinite_idle_token_lifetime")
+    private Boolean infiniteIdleTokenLifetime;
+
+    /**
+     * Getter for the rotation type of the refresh token.
+     *
+     * @return the rotation type.
+     */
+    @JsonProperty("rotation_type")
+    public String getRotationType() {
+        return rotationType;
+    }
+
+    /**
+     * Setter for the rotation type of the refresh token.
+     *
+     * @param rotationType the rotation type to set.
+     */
+    @JsonProperty("rotation_type")
+    public void setRotationType(String rotationType) {
+        this.rotationType = rotationType;
+    }
+
+    /**
+     * Getter for the expiration type of the refresh token.
+     *
+     * @return the expiration type.
+     */
+    @JsonProperty("expiration_type")
+    public String getExpirationType() {
+        return expirationType;
+    }
+
+    /**
+     * Setter for the expiration type of the refresh token.
+     *
+     * @param expirationType the expiration type to set.
+     */
+    @JsonProperty("expiration_type")
+    public void setExpirationType(String expirationType) {
+        this.expirationType = expirationType;
+    }
+
+    /**
+     * Getter for the period in seconds where the previous refresh token can be exchanged without
+     * triggering breach detection.
+     *
+     * @return the leeway in seconds.
+     */
+    @JsonProperty("leeway")
+    public Integer getLeeway() {
+        return leeway;
+    }
+
+    /**
+     * Setter for the period in seconds where the previous refresh token can be exchanged without
+     * triggering breach detection.
+     *
+     * @param leeway the leeway in seconds.
+     */
+    @JsonProperty("leeway")
+    public void setLeeway(Integer leeway) {
+        this.leeway = leeway;
+    }
+
+    /**
+     * Getter for the period in seconds for which refresh tokens will remain valid.
+     *
+     * @return a token's lifetime in seconds.
+     */
+    @JsonProperty("token_lifetime")
+    public Integer getTokenLifetime() {
+        return tokenLifetime;
+    }
+
+    /**
+     * Setter for the period in seconds for which refresh tokens will remain valid.
+     *
+     * @param tokenLifetime a token's lifetime in seconds.
+     */
+    @JsonProperty("token_lifetime")
+    public void setTokenLifetime(Integer tokenLifetime) {
+        this.tokenLifetime = tokenLifetime;
+    }
+
+    /**
+     * Getter for determining whether tokens have a set lifetime or not. This takes precedence over
+     * token_lifetime values.
+     *
+     * @return true if tokens do not have a set lifetime, false otherwise.
+     */
+    @JsonProperty("infinite_token_lifetime")
+    public Boolean getInfiniteTokenLifetime() {
+        return infiniteTokenLifetime;
+    }
+
+    /**
+     * Setter for determining whether tokens have a set lifetime or not. This takes precedence over
+     * token_lifetime values.
+     *
+     * @param infiniteTokenLifetime true if tokens do not have a set lifetime, false otherwise.
+     */
+    @JsonProperty("infinite_token_lifetime")
+    public void setInfiniteTokenLifetime(Boolean infiniteTokenLifetime) {
+        this.infiniteTokenLifetime = infiniteTokenLifetime;
+    }
+
+    /**
+     * Getter for the period in seconds for which refresh tokens will remain valid without use.
+     *
+     * @return a token's lifetime without use in seconds.
+     */
+    @JsonProperty("idle_token_lifetime")
+    public Integer getIdleTokenLifetime() {
+        return idleTokenLifetime;
+    }
+
+    /**
+     * Setter for the period in seconds for which refresh tokens will remain valid without use.
+     *
+     * @param idleTokenLifetime a token's lifetime without use in seconds.
+     */
+    @JsonProperty("idle_token_lifetime")
+    public void setIdleTokenLifetime(Integer idleTokenLifetime) {
+        this.idleTokenLifetime = idleTokenLifetime;
+    }
+
+    /**
+     * Getter for determining whether tokens expire without use or not. This takes precedence over
+     * idle_token_lifetime values.
+     *
+     * @return true if tokens do not expire from lack of use, false otherwise.
+     */
+    @JsonProperty("infinite_idle_token_lifetime")
+    public Boolean getInfiniteIdleTokenLifetime() {
+        return infiniteIdleTokenLifetime;
+    }
+
+    /**
+     * Setter for determining whether tokens expire without use or not. This takes precedence over
+     * idle_token_lifetime values.
+     *
+     * @param infiniteIdleTokenLifetime true if tokens do not expire from lack of use, false
+     *                                  otherwise.
+     */
+    @JsonProperty("infinite_idle_token_lifetime")
+    public void setInfiniteIdleTokenLifetime(Boolean infiniteIdleTokenLifetime) {
+        this.infiniteIdleTokenLifetime = infiniteIdleTokenLifetime;
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.*;
 public class ClientTest extends JsonTest<Client> {
 
     private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
-    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}}}";
+    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}},\"refresh_token\":{\"rotation_type\":\"non-rotating\"}}";
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -54,6 +54,8 @@ public class ClientTest extends JsonTest<Client> {
         client.setClientMetadata(metadata);
         Mobile mobile = new Mobile(new Android("pkg", Collections.singletonList("256")), new IOS("team", "id"));
         client.setMobile(mobile);
+        RefreshToken refreshToken = new RefreshToken();
+        client.setRefreshToken(refreshToken);
 
         String serialized = toJSON(client);
         assertThat(serialized, is(notNullValue()));
@@ -84,6 +86,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("token_endpoint_auth_method", "method"));
         assertThat(serialized, JsonMatcher.hasEntry("client_metadata", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("mobile", notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("refresh_token", notNullValue()));
     }
 
     @Test
@@ -124,6 +127,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getTokenEndpointAuthMethod(), is("method"));
         assertThat(client.getClientMetadata(), IsMapContaining.hasEntry("key", "value"));
         assertThat(client.getMobile(), is(notNullValue()));
+        assertThat(client.getRefreshToken(), is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/client/RefreshTokenTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/RefreshTokenTest.java
@@ -1,0 +1,50 @@
+package com.auth0.json.mgmt.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+public class RefreshTokenTest extends JsonTest<RefreshToken> {
+
+    private static final String json = "{\"rotation_type\":\"non-rotating\",\"expiration_type\":\"non-expiring\",\"leeway\":0,\"token_lifetime\":0,\"infinite_token_lifetime\":false,\"idle_token_lifetime\":0,\"infinite_idle_token_lifetime\":false}";
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setRotationType("non-rotating");
+        refreshToken.setExpirationType("non-expiring");
+        refreshToken.setLeeway(0);
+        refreshToken.setTokenLifetime(0);
+        refreshToken.setInfiniteTokenLifetime(false);
+        refreshToken.setIdleTokenLifetime(0);
+        refreshToken.setInfiniteIdleTokenLifetime(false);
+
+        String serialized = toJSON(refreshToken);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("rotation_type", "non-rotating"));
+        assertThat(serialized, JsonMatcher.hasEntry("expiration_type", "non-expiring"));
+        assertThat(serialized, JsonMatcher.hasEntry("leeway", 0));
+        assertThat(serialized, JsonMatcher.hasEntry("token_lifetime", 0));
+        assertThat(serialized, JsonMatcher.hasEntry("infinite_token_lifetime", false));
+        assertThat(serialized, JsonMatcher.hasEntry("idle_token_lifetime", 0));
+        assertThat(serialized, JsonMatcher.hasEntry("infinite_idle_token_lifetime", false));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        RefreshToken refreshToken = fromJSON(json, RefreshToken.class);
+
+        assertThat(refreshToken, is(notNullValue()));
+        assertThat(refreshToken.getRotationType(), is("non-rotating"));
+        assertThat(refreshToken.getExpirationType(), is("non-expiring"));
+        assertThat(refreshToken.getLeeway(), is(0));
+        assertThat(refreshToken.getTokenLifetime(), is(0));
+        assertThat(refreshToken.getInfiniteTokenLifetime(), is(false));
+        assertThat(refreshToken.getIdleTokenLifetime(), is(0));
+        assertThat(refreshToken.getInfiniteIdleTokenLifetime(), is(false));
+    }
+}


### PR DESCRIPTION
### Changes

Proposed solution to issue #318 

This PR includes a new object for managing the configuration of refresh tokens associated with a client, as well as the addition of the class (`RefreshToken`) as an instance variable on the `Client` class. The design is a 1-to-1 mapping of the refresh token configuration as defined in the [Auth0 Management API](https://auth0.com/docs/api/management/v2#!/Clients/get_clients).

I did not include enums for the `rotation_type` or `expiration_type` fields in the refresh token configuration like what was done in https://github.com/auth0/auth0.net/pull/451/ as the rest of the Java API relies on strings for all areas that would otherwise use enums.

This change is meant to allow for the use of documented API functionality which is currently unavailable in the SDK.

### References

* Relates to #318 
* Considered https://github.com/auth0/auth0.net/pull/451/ when planning the design

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
