### PR TITLE
Fix publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'com.auth0.gradle.oss-library.java'
-    id "com.jfrog.bintray" version "1.8.4"
+    id "com.jfrog.bintray" version "1.8.5"
 }
 
 repositories {
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = 'com.auth0'
-logger.lifecycle("Using version ${version} for ${name}")
+logger.lifecycle("Using version ${version} for ${name} group $group")
 
 oss {
     name 'auth0'
@@ -52,7 +52,7 @@ compileJava {
 
 compileTestJava {
     options.compilerArgs << "-Xlint:deprecation" << "-Werror"
-    }
+}
 
 test {
     testLogging {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         jcenter()
         maven {
@@ -8,7 +9,7 @@ pluginManagement {
         }
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.9.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.13.0'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         jcenter()
         maven {


### PR DESCRIPTION
### Changes

Upgrade to Gradle 6.7.1 to fix gradle toolchain in ubuntu
Fix publish artifacts using latest gralde auth0 plugin 

Requires publishing version 0.13.0 
https://github.com/auth0/oss-library-gradle-plugin/pull/23

### References

https://github.com/gradle/gradle/issues/15049
https://docs.gradle.org/6.7.1/release-notes.html

### Testing

Locally publish artifacts

