### PR TITLE
Fix OkHttp dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,17 +61,22 @@ test {
     }
 }
 
-dependencies {
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    implementation 'commons-codec:commons-codec:1.15'
-    implementation 'com.auth0:java-jwt:3.11.0'
+ext {
+    okhttpVersion = '4.9.0'
+    hamcrestVersion = '1.3'
+}
 
-    testImplementation 'org.bouncycastle:bcprov-jdk15on:1.65'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
-    testImplementation 'org.hamcrest:hamcrest-core:1.3'
-    testImplementation 'org.hamcrest:hamcrest-library:1.3'
-    testImplementation 'junit:junit:4.13.1'
+dependencies {
+    implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.11.3"
+    implementation "commons-codec:commons-codec:1.15"
+    implementation "com.auth0:java-jwt:3.11.0"
+
+    testImplementation "org.bouncycastle:bcprov-jdk15on:1.65"
+    testImplementation "org.mockito:mockito-core:2.28.2"
+    testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
+    testImplementation "org.hamcrest:hamcrest-core:${hamcrestVersion}"
+    testImplementation "org.hamcrest:hamcrest-library:${hamcrestVersion}"
+    testImplementation "junit:junit:4.13.1"
 }


### PR DESCRIPTION
### Changes

When we updated to OkHttp4, the logging interceptor version was missed. This change fixes that to use v4, as well as pulls out dependency versions into extension properties, for those that we have multiple dependencies on.

### References

- #324 

### Testing

I've verified that the logging works again with this update, but it does not resolve the issue reported in #324. Further discussion on possible causes of that can be found in the issue conversation. 

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
