### PR TITLE
Add support for async requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ implementation 'com.auth0:auth0:1.26.0'
 
 The Auth0 Authentication API and User's Management API are available for Android in the `auth0.android` library. Check https://github.com/auth0/auth0.android for more information.
 
-
 ## Auth API
 
 The implementation is based on the [Authentication API Docs](https://auth0.com/docs/api/authentication).
@@ -569,6 +568,10 @@ try {
     // request error
 }
 ```
+
+## Asynchronous requests
+
+Requests can be executed asynchronously, using the `executeAsync()` method, which returns a `CompletableFuture<T>`. 
 
 ## API Clients Recommendations
 The SDK implements a custom networking stack on top of the **OkHttp** library. The [official recommendation](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#okhttpclients-should-be-shared) from Square is to re-use as much as possible these clients. However, it's not possible to pass an existing `OkHttpClient` instance to our `AuthAPI` and `ManagementAPI` clients. 

--- a/src/main/java/com/auth0/net/BaseRequest.java
+++ b/src/main/java/com/auth0/net/BaseRequest.java
@@ -1,10 +1,14 @@
 package com.auth0.net;
 
 import com.auth0.exception.Auth0Exception;
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class BaseRequest<T> implements Request<T> {
 
@@ -34,5 +38,37 @@ public abstract class BaseRequest<T> implements Request<T> {
         } catch (IOException e) {
             throw new Auth0Exception("Failed to execute request", e);
         }
+    }
+
+    @Override
+    public CompletableFuture<T> executeAsync() {
+        final CompletableFuture<T> future = new CompletableFuture<T>();
+
+        okhttp3.Request request;
+        try {
+            request = createRequest();
+        } catch (Auth0Exception e) {
+            future.completeExceptionally(e);
+            return future;
+        }
+
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                future.completeExceptionally(new Auth0Exception("Failed to execute request", e));
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
+                try {
+                    T parsedResponse = parseResponse(response);
+                    future.complete(parsedResponse);
+                } catch (Auth0Exception e) {
+                    future.completeExceptionally(e);
+                }
+            }
+        });
+
+        return future;
     }
 }

--- a/src/main/java/com/auth0/net/Request.java
+++ b/src/main/java/com/auth0/net/Request.java
@@ -3,6 +3,8 @@ package com.auth0.net;
 import com.auth0.exception.APIException;
 import com.auth0.exception.Auth0Exception;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Class that represents an HTTP Request that can be executed.
  *
@@ -11,11 +13,27 @@ import com.auth0.exception.Auth0Exception;
 public interface Request<T> {
 
     /**
-     * Executes this request.
+     * Executes this request synchronously.
      *
      * @return the response body JSON decoded as T
      * @throws APIException   if the request was executed but the response wasn't successful.
      * @throws Auth0Exception if the request couldn't be created or executed successfully.
      */
     T execute() throws Auth0Exception;
+
+    /**
+     * Executes this request asynchronously.
+     *
+     * @apiNote This method was added after the interface was released in version 1.0.
+     *          It is defined as a default method for compatibility reasons.
+     *          From version 2.0 on, the method will be abstract and all implementations of this interface
+     *          will have to provide their own implementation.
+     *
+     * @implSpec The default implementation throws an {@linkplain UnsupportedOperationException}.
+     *
+     * @return a {@linkplain CompletableFuture} representing the specified request.
+     */
+    default CompletableFuture<T> executeAsync() {
+        throw new UnsupportedOperationException("executeAsync");
+    }
 }

--- a/src/test/java/com/auth0/net/RequestTest.java
+++ b/src/test/java/com/auth0/net/RequestTest.java
@@ -1,0 +1,20 @@
+package com.auth0.net;
+
+import com.auth0.exception.Auth0Exception;
+import org.junit.Test;
+import static org.junit.Assert.assertThrows;
+
+public class RequestTest {
+
+    @Test
+    public void defaultImplementationShouldThrow() {
+        assertThrows("executeAsync",
+            UnsupportedOperationException.class,
+            new Request<String>() {
+                @Override
+                public String execute() throws Auth0Exception {
+                    return null;
+                }
+            }::executeAsync);
+    }
+}


### PR DESCRIPTION
### Changes

Fixes #315 

This change adds the ability to execute a request asynchronously, through the addition of a new default method on the `Request` interface:

```java
default CompletableFuture<T> executeAsync()
```

The default interface implementation throws an `UnsupportedOperationException`. The implementation in `BaseRequest` returns a [CompletableFuture](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html). An example usage:

```java
api.users().list(null).executeAsync().whenComplete((usersPage, ex) -> {
    if (ex != null) {
        System.out.println("Exception occurred: " + ex.getMessage());
    } else {
        System.out.println("Users list size: " + usersPage.getItems().size());
    }
}).get();
```

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
