### PR TITLE
Update dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,18 +63,18 @@ test {
 
 ext {
     okhttpVersion = '4.9.0'
-    hamcrestVersion = '1.3'
+    hamcrestVersion = '2.2'
 }
 
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.11.3"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
     implementation "commons-codec:commons-codec:1.15"
-    implementation "com.auth0:java-jwt:3.11.0"
+    implementation "com.auth0:java-jwt:3.12.1"
 
-    testImplementation "org.bouncycastle:bcprov-jdk15on:1.65"
-    testImplementation "org.mockito:mockito-core:2.28.2"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"
+    testImplementation "org.mockito:mockito-core:3.7.7"
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testImplementation "org.hamcrest:hamcrest-core:${hamcrestVersion}"
     testImplementation "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -700,10 +700,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -733,10 +733,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("scope", "profile photos contacts"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -787,10 +787,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("password", "p455w0rd"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -821,10 +821,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("audience", "https://myapi.auth0.com/users"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -849,10 +849,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("password", "password"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -911,10 +911,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("realm", "realm"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -945,10 +945,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("scope", "profile photos contacts"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -981,10 +981,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("audience", "https://myapi.auth0.com/users"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -1010,8 +1010,8 @@ public class AuthAPITest {
         assertThat(body, hasEntry("email", "user@domain.com"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getEmail(), not(isEmptyOrNullString()));
-        assertThat(response.getId(), not(isEmptyOrNullString()));
+        assertThat(response.getEmail(), not(emptyOrNullString()));
+        assertThat(response.getId(), not(emptyOrNullString()));
         assertThat(response.isEmailVerified(), is(notNullValue()));
     }
 
@@ -1061,8 +1061,8 @@ public class AuthAPITest {
         assertThat(authParamsSent, hasEntry("state", authParams.get("state")));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getEmail(), not(isEmptyOrNullString()));
-        assertThat(response.getId(), not(isEmptyOrNullString()));
+        assertThat(response.getEmail(), not(emptyOrNullString()));
+        assertThat(response.getId(), not(emptyOrNullString()));
         assertThat(response.isEmailVerified(), is(notNullValue()));
     }
 
@@ -1085,8 +1085,8 @@ public class AuthAPITest {
         assertThat(body, hasEntry("phone_number", "+16511234567"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getPhoneNumber(), not(isEmptyOrNullString()));
-        assertThat(response.getId(), not(isEmptyOrNullString()));
+        assertThat(response.getPhoneNumber(), not(emptyOrNullString()));
+        assertThat(response.getId(), not(emptyOrNullString()));
         assertThat(response.isPhoneVerified(), is(notNullValue()));
         assertThat(response.getRequestLanguage(), is(nullValue()));
     }
@@ -1114,8 +1114,8 @@ public class AuthAPITest {
         assertThat(body, hasEntry("phone_number", "+16511234567"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getPhoneNumber(), not(isEmptyOrNullString()));
-        assertThat(response.getId(), not(isEmptyOrNullString()));
+        assertThat(response.getPhoneNumber(), not(emptyOrNullString()));
+        assertThat(response.getId(), not(emptyOrNullString()));
         assertThat(response.isPhoneVerified(), is(notNullValue()));
         assertThat(response.getRequestLanguage(), is(nullValue()));
     }
@@ -1212,10 +1212,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("refresh_token", "ej2E8zNEzjrcSD2edjaE"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
@@ -1255,10 +1255,10 @@ public class AuthAPITest {
         assertThat(body, hasEntry("otp", "otp"));
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 }

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -159,10 +159,10 @@ public class CustomRequestTest {
         server.takeRequest();
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 

--- a/src/test/java/com/auth0/net/MultipartRequestTest.java
+++ b/src/test/java/com/auth0/net/MultipartRequestTest.java
@@ -179,10 +179,10 @@ public class MultipartRequestTest {
         server.takeRequest();
 
         assertThat(response, is(notNullValue()));
-        assertThat(response.getAccessToken(), not(isEmptyOrNullString()));
-        assertThat(response.getIdToken(), not(isEmptyOrNullString()));
-        assertThat(response.getRefreshToken(), not(isEmptyOrNullString()));
-        assertThat(response.getTokenType(), not(isEmptyOrNullString()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 


### PR DESCRIPTION
### Changes

Updates dependency versions.

The test changes are to replace the [now-deprecated](http://hamcrest.org/JavaHamcrest/javadoc/2.0.0.0/deprecated-list.html) method `isEmptyOrNullString` with `emptyOrNullString`

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
