### PR TITLE
Fix JavaDoc tags for Java8

### DIFF
--- a/src/main/java/com/auth0/net/Request.java
+++ b/src/main/java/com/auth0/net/Request.java
@@ -24,12 +24,12 @@ public interface Request<T> {
     /**
      * Executes this request asynchronously.
      *
-     * @apiNote This method was added after the interface was released in version 1.0.
-     *          It is defined as a default method for compatibility reasons.
-     *          From version 2.0 on, the method will be abstract and all implementations of this interface
-     *          will have to provide their own implementation.
+     * Note: This method was added after the interface was released in version 1.0.
+     * It is defined as a default method for compatibility reasons.
+     * From version 2.0 on, the method will be abstract and all implementations of this interface
+     * will have to provide their own implementation.
      *
-     * @implSpec The default implementation throws an {@linkplain UnsupportedOperationException}.
+     * The default implementation throws an {@linkplain UnsupportedOperationException}.
      *
      * @return a {@linkplain CompletableFuture} representing the specified request.
      */


### PR DESCRIPTION
### Changes

In #328, we added the JavaDoc tags `@apiNote` and `@implSpec`. These are not available in Java8 (they are in Java9). Removing the tags to fix JavaDoc generation.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
