### PR TITLE
Update README for Spring Boot dependency collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,41 @@ implementation 'com.auth0:auth0:1.27.0'
 
 The Auth0 Authentication API and User's Management API are available for Android in the `auth0.android` library. Check https://github.com/auth0/auth0.android for more information.
 
+### Using with Spring Dependency Management
+
+This library use OkHttp version 4 as the networking client used to make requests to the Auth0 Authentication and Management APIs. If you are using Spring's depdendency management, you may encounter `java.lang.NoSuchMethodError` errors when making requests, related to Spring's dependency management using OkHttp 3. To resolve this issue, you can override Spring's dependency on OkHttp:
+
+Maven ([more information](https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/)):
+```xml
+<dependencyManagement>
+		<dependencies>
+			<!--  Needed to avoid conflict with OkHttp being used in auth0-java and okhttp3 being used by spring -->
+			<dependency>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>okhttp</artifactId>
+				<version>4.9.0</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+```
+
+Gradle ([more information](https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/)):
+```java
+plugins {
+  ...
+  // spring dependency plugin will define okhttp3, which will have issues with okhttp4 in auth0-java
+  id "io.spring.dependency-management" version "1.0.10.RELEASE"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "com.squareup.okhttp3:okhttp-bom:4.9.0"
+    }
+}
+```
+
+More information can be found in this [Github issue](https://github.com/auth0/auth0-java/issues/324).
+
 ## Auth API
 
 The implementation is based on the [Authentication API Docs](https://auth0.com/docs/api/authentication).


### PR DESCRIPTION
### Changes

Spring's dependency management defines okhttp v3 as part of its exported BOM, which collides with okhttp v4 used by this library. This results in `java.lang.NoSuchMethodError` when making requests, as reported in #324. Unfortunately we cannot control how Spring exports its dependencies, so this PR updates the README to include the workaround of specifying okhttp v4 in the spring dependency management configuration.

### References

- [Spring Boot maven plugin docs](https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/)
- [Spring Boot gradle dependency plugin docs](https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/)
- #324 

### Testing

Solution tested by creating both a maven and gradle project using the spring boot plugins. Without the bom override, `NoSuchMethodError` observed when making requests. With the bom override, the error is resolved.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
