### PR TITLE
Update Gradle OSS Plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.15.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.14.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.15.0'
     }
 }
 


### PR DESCRIPTION
### Changes

Updates to version `0.15.1` of the OSS plugin, which supports publishing directly to Sonatype instead of Bintray.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
