### PR TITLE
Add Organizations Management API Support [SDK-2437]

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -81,18 +81,38 @@ public class JobsEntity extends BaseManagementEntity {
      * @see JobsEntity#sendVerificationEmail(String, String)
      */
     public Request<Job> sendVerificationEmail(String userId, String clientId, EmailVerificationIdentity emailVerificationIdentity) {
+        return sendVerificationEmail(userId, clientId, emailVerificationIdentity, null);
+    }
+
+    /**
+     * Sends an Email Verification. A token with scope update:users is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email.
+     *
+     * @param userId   The user_id of the user to whom the email will be sent.
+     * @param clientId The id of the client, if not provided the global one will be used.
+     * @param emailVerificationIdentity The identity of the user. Required to verify primary identities when using social, enterprise, or passwordless connections. It is also required to verify secondary identities.
+     * @param orgId The organization ID. If provided, the organization_id and organization_name will be included as query arguments in the link back to the application.
+     *
+     * @return a Request to execute.
+     *
+     * @see JobsEntity#sendVerificationEmail(String, String)
+     */
+    public Request<Job> sendVerificationEmail(String userId, String clientId, EmailVerificationIdentity emailVerificationIdentity, String orgId) {
         Asserts.assertNotNull(userId, "user id");
 
         String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/jobs/verification-email")
-                .build()
-                .toString();
+            .newBuilder()
+            .addPathSegments("api/v2/jobs/verification-email")
+            .build()
+            .toString();
 
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("user_id", userId);
         if (clientId != null && !clientId.isEmpty()) {
             requestBody.put("client_id", clientId);
+        }
+        if (orgId != null && !orgId.isEmpty()) {
+            requestBody.put("organization_id", orgId);
         }
         if (emailVerificationIdentity != null) {
             Asserts.assertNotNull(emailVerificationIdentity.getProvider(), "identity provider");

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -348,4 +348,13 @@ public class ManagementAPI {
     public RolesEntity roles() {
         return new RolesEntity(client, baseUrl, apiToken);
     }
+
+    /**
+     * Getter for the Organizations entity.
+     *
+     * @return the Organizations entity.
+     */
+    public OrganizationsEntity organizations() {
+        return new OrganizationsEntity(client, baseUrl, apiToken);
+    }
 }

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -1,0 +1,562 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.client.mgmt.filter.BaseFilter;
+import com.auth0.client.mgmt.filter.FieldsFilter;
+import com.auth0.client.mgmt.filter.InvitationsFilter;
+import com.auth0.client.mgmt.filter.PageFilter;
+import com.auth0.json.mgmt.RolesPage;
+import com.auth0.json.mgmt.organizations.*;
+import com.auth0.net.CustomRequest;
+import com.auth0.net.Request;
+import com.auth0.net.VoidRequest;
+import com.auth0.utils.Asserts;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+
+import java.util.Map;
+
+/**
+ * Class that provides an implementation of the Organization endpoints of the Management API.
+ * <p>
+ * This class is not thread-safe.
+ *
+ * @see ManagementAPI
+ */
+public class OrganizationsEntity extends BaseManagementEntity {
+
+    private final static String ORGS_PATH = "api/v2/organizations";
+    private final static String AUTHORIZATION_HEADER = "Authorization";
+
+    OrganizationsEntity(OkHttpClient client, HttpUrl baseUrl, String apiToken) {
+        super(client, baseUrl, apiToken);
+    }
+
+    // Organizations Entity
+
+    /**
+     * Get all organizations. A token with read:organizations scope is required.
+     *
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<OrganizationsPage> list(PageFilter filter) {
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH);
+
+        applyFilter(filter, builder);
+
+        String url = builder.build().toString();
+        CustomRequest<OrganizationsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<OrganizationsPage>() {
+        });
+
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Get an organization. A token with read:organizations scope is required.
+     *
+     * @param orgId the ID of the organization to retrieve
+     * @return a Request to execute
+     */
+    public Request<Organization> get(String orgId) {
+        Asserts.assertNotNull(orgId, "organization ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .build()
+            .toString();
+
+        CustomRequest<Organization> request = new CustomRequest<>(client, url, "GET", new TypeReference<Organization>() {
+        });
+
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Get an organization. A token with read:organizations scope is required.
+     *
+     * @param orgName the name of the organization to retrieve
+     * @return a Request to execute
+     */
+    public Request<Organization> getByName(String orgName) {
+        Asserts.assertNotNull(orgName, "organization name");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment("name")
+            .addPathSegment(orgName)
+            .build()
+            .toString();
+
+        CustomRequest<Organization> request = new CustomRequest<>(client, url, "GET", new TypeReference<Organization>() {
+        });
+
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Create an organization. A token with create:organizations scope is required.
+     *
+     * @param organization the organization to create
+     * @return a Request to execute
+     */
+    public Request<Organization> create(Organization organization) {
+        Asserts.assertNotNull(organization, "organization");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .build()
+            .toString();
+
+        CustomRequest<Organization> request = new CustomRequest<>(client, url, "POST", new TypeReference<Organization>() {
+        });
+
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(organization);
+        return request;
+    }
+
+    /**
+     * Update an organization. A token with update:organizations scope is required.
+     *
+     * @param orgId the ID of the organization to update
+     * @param organization the updated organization
+     * @return a Request to execute
+     */
+    public Request<Organization> update(String orgId, Organization organization) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(organization, "organization");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .build()
+            .toString();
+
+        CustomRequest<Organization> request = new CustomRequest<>(client, url, "PATCH", new TypeReference<Organization>() {
+        });
+
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(organization);
+        return request;
+    }
+
+    /**
+     * Delete an organization. A token with delete:organizations scope is required.
+     *
+     * @param orgId the ID of the organization to delete
+     * @return a Request to execute
+     */
+    public Request delete(String orgId) {
+        Asserts.assertNotNull(orgId, "organization ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .build()
+            .toString();
+
+        VoidRequest voidRequest = new VoidRequest(client, url, "DELETE");
+        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return voidRequest;
+    }
+
+    // Organization members
+
+    /**
+     * Get the members of an organization. A token with read:organization_members scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<MembersPage> getMembers(String orgId, PageFilter filter) {
+        Asserts.assertNotNull(orgId, "organization ID");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("members");
+
+        applyFilter(filter, builder);
+
+        String url = builder.build().toString();
+        CustomRequest<MembersPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<MembersPage>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Add members to an organization. A token with create:organization_members scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param members The members to add
+     * @return a Request to execute
+     */
+    public Request addMembers(String orgId, Members members) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(members, "members");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("members")
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, url, "POST");
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(members);
+        return request;
+    }
+
+    /**
+     * Delete members from an organization. A token with delete:organization_members scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param members The members to remove
+     * @return a Request to execute
+     */
+    public Request deleteMembers(String orgId, Members members) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(members, "members");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("members")
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, url, "DELETE");
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(members);
+        return request;
+    }
+
+    // Organization connections
+
+    /**
+     * Get the connections of an organization. A token with read:organization_connections scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<EnabledConnectionsPage> getConnections(String orgId, PageFilter filter) {
+        Asserts.assertNotNull(orgId, "organization ID");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("enabled_connections");
+
+        applyFilter(filter, builder);
+
+        String url = builder.build().toString();
+        CustomRequest<EnabledConnectionsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<EnabledConnectionsPage>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Add a connection to an organization. A token with create:organization_connections scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param connection The connection to add
+     * @return a Request to execute
+     */
+    public Request<EnabledConnection> addConnection(String  orgId, EnabledConnection connection) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(connection, "connection");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("enabled_connections")
+            .build()
+            .toString();
+
+        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, url, "POST", new TypeReference<EnabledConnection>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(connection);
+        return request;
+    }
+
+    /**
+     * Delete a connection from an organization. A token with delete:organization_connections scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param connectionId the ID of the connection to delete
+     * @return a Request to execute
+     */
+    public Request deleteConnection(String  orgId, String connectionId) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(connectionId, "connection ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("enabled_connections")
+            .addPathSegment(connectionId)
+            .build()
+            .toString();
+
+        VoidRequest voidRequest = new VoidRequest(client, url, "DELETE");
+        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return voidRequest;
+    }
+
+    /**
+     * Update a connection of an organization. A token with update:organization_connections scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param connectionId the ID of the connection to update
+     * @param connection the connection to update
+     * @return a Request to execute
+     */
+    public Request<EnabledConnection> updateConnection(String orgId, String connectionId, EnabledConnection connection) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(connectionId, "connection ID");
+        Asserts.assertNotNull(connection, "connection");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("enabled_connections")
+            .addPathSegment(connectionId)
+            .build()
+            .toString();
+
+        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, url, "PATCH", new TypeReference<EnabledConnection>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(connection);
+        return request;
+    }
+
+    // Org roles
+
+    /**
+     * Get the roles for a member of an organization. A token with read:organization_members scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param userId the ID of the user
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<RolesPage> getRoles(String orgId, String userId, PageFilter filter) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(userId, "user ID");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("members")
+            .addPathSegment(userId)
+            .addPathSegment("roles");
+
+        applyFilter(filter, builder);
+
+        String url = builder.build().toString();
+        CustomRequest<RolesPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<RolesPage>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Add roles for a member of an organization. A token with create:organization_member_roles scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param userId the ID of the user
+     * @param roles the roles to add
+     * @return a Request to execute
+     */
+    public Request addRoles(String orgId, String userId, Roles roles) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(userId, "user ID");
+        Asserts.assertNotNull(roles, "roles");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("members")
+            .addPathSegment(userId)
+            .addPathSegment("roles")
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, url, "POST");
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(roles);
+        return request;
+    }
+
+    /**
+     * Delete roles from a member of an organization. A token with delete:organization_member_roles scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param userId the ID of the user
+     * @param roles the roles to delete
+     * @return a Request to execute
+     */
+    public Request deleteRoles(String orgId, String userId, Roles roles) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(userId, "user ID");
+        Asserts.assertNotNull(roles, "roles");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("members")
+            .addPathSegment(userId)
+            .addPathSegment("roles")
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, url, "DELETE");
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(roles);
+        return request;
+    }
+
+    // Organization invitations
+
+    /**
+     * Create an invitation. A token with create:organization_invitations scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param invitation the invitation to create
+     * @return a Request to execute
+     */
+    public Request<Invitation> createInvitation(String orgId, Invitation invitation) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(invitation, "invitation");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("invitations")
+            .build()
+            .toString();
+
+        CustomRequest<Invitation> request = new CustomRequest<>(client, url, "POST", new TypeReference<Invitation>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        request.setBody(invitation);
+        return request;
+
+    }
+
+    /**
+     * Get an invitation. A token with read:organization_invitations scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param invitationId the ID of the invitation
+     * @param filter an optional result filter
+     * @return a Request to execute
+     */
+    public Request<Invitation> getInvitation(String orgId, String invitationId, FieldsFilter filter) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(invitationId, "invitation ID");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("invitations")
+            .addPathSegment(invitationId);
+
+        applyFilter(filter, builder);
+
+        String url = builder.build().toString();
+        CustomRequest<Invitation> request = new CustomRequest<>(client, url, "GET", new TypeReference<Invitation>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Gets all invitations for an organization. A token with read:organization_invitations scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param filter an optional result filter
+     * @return a Request to execute
+     */
+    public Request<InvitationsPage> getInvitations(String orgId, InvitationsFilter filter) {
+        Asserts.assertNotNull(orgId, "organization ID");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("invitations");
+
+        applyFilter(filter, builder);
+
+        String url = builder.build().toString();
+        CustomRequest<InvitationsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<InvitationsPage>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Delete an invitation. A token with delete:organization_invitations scope is required.
+     *
+     * @param orgId the ID of the organization
+     * @param invitationId the ID of the invitation to delete
+     * @return a Request to execute
+     */
+    public Request deleteInvitation(String orgId, String invitationId) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(invitationId, "invitation ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("invitations")
+            .addPathSegment(invitationId)
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, url, "DELETE");
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    private void applyFilter(BaseFilter filter, HttpUrl.Builder builder) {
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -9,6 +9,7 @@ import com.auth0.json.mgmt.PermissionsPage;
 import com.auth0.json.mgmt.RolesPage;
 import com.auth0.json.mgmt.guardian.Enrollment;
 import com.auth0.json.mgmt.logevents.LogEventsPage;
+import com.auth0.json.mgmt.organizations.OrganizationsPage;
 import com.auth0.json.mgmt.users.Identity;
 import com.auth0.json.mgmt.users.RecoveryCode;
 import com.auth0.json.mgmt.users.User;
@@ -572,6 +573,35 @@ public class UsersEntity extends BaseManagementEntity {
                 .toString();
         VoidRequest request = new VoidRequest(this.client, url, "POST");
         request.setBody(body);
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Get the organizations a user belongs to.
+     * A token with read:users and read:organizations is required.
+     *
+     * @param userId the user ID
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<OrganizationsPage> getOrganizations(String userId, PageFilter filter) {
+        Asserts.assertNotNull(userId, "user ID");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegment("organizations");
+
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+        String url = builder.build().toString();
+        CustomRequest<OrganizationsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<OrganizationsPage>() {
+        });
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/filter/InvitationsFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/InvitationsFilter.java
@@ -1,0 +1,58 @@
+package com.auth0.client.mgmt.filter;
+
+/**
+ * Class used to filter the results received when fetching invitations. Related to the {@linkplain com.auth0.client.mgmt.OrganizationsEntity}.
+ * <p>
+ * This class is not thread-safe.
+ */
+public class InvitationsFilter extends BaseFilter {
+
+    /**
+     * Filter by page
+     *
+     * @param pageNumber    the page number to retrieve.
+     * @param amountPerPage the amount of items per page to retrieve.
+     * @return this filter instance
+     */
+    public InvitationsFilter withPage(int pageNumber, int amountPerPage) {
+        parameters.put("page", pageNumber);
+        parameters.put("per_page", amountPerPage);
+        return this;
+    }
+
+    /**
+     * Include the query summary
+     *
+     * @param includeTotals whether to include or not the query summary.
+     * @return this filter instance
+     */
+    public InvitationsFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+    /**
+     * Only retrieve certain fields from the item.
+     *
+     * @param fields        a list of comma separated fields to retrieve.
+     * @param includeFields whether to include or exclude in the response the fields that were given.
+     * @return this filter instance
+     */
+    public InvitationsFilter withFields(String fields, boolean includeFields) {
+        parameters.put("fields", fields);
+        parameters.put("include_fields", includeFields);
+        return this;
+    }
+
+    /**
+     * Sort the query
+     *
+     * @param sort the field to use for sorting. Use 'field:order' where order is 1 for ascending and -1 for descending.
+     * @return this filter instance
+     */
+    public InvitationsFilter withSort(String sort) {
+        parameters.put("sort", sort);
+        return this;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -78,6 +78,10 @@ public class Client {
     private Mobile mobile;
     @JsonProperty("refresh_token")
     private RefreshToken refreshToken;
+    @JsonProperty("organization_usage")
+    private String organizationUsage;
+    @JsonProperty("organization_require_behavior")
+    private String organizationRequireBehavior;
 
     /**
      * Creates a new Application instance setting the name property.
@@ -676,6 +680,37 @@ public class Client {
      */
     public void setRefreshToken(RefreshToken refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    /**
+     * @return the organization usage value
+     */
+    public String getOrganizationUsage() {
+        return organizationUsage;
+    }
+
+    /**
+     * Sets the value of the organization_usage field
+     *
+     * @param organizationUsage the organization_usage value
+     */
+    public void setOrganizationUsage(String organizationUsage) {
+        this.organizationUsage = organizationUsage;
+    }
+
+    /**
+     * @return the organization require behavior value
+     */
+    public String getOrganizationRequireBehavior() {
+        return organizationRequireBehavior;
+    }
+
+    /**
+     * Sets the value of the organization_require_behavior field
+     * @param organizationRequireBehavior the organization_require_behavior value
+     */
+    public void setOrganizationRequireBehavior(String organizationRequireBehavior) {
+        this.organizationRequireBehavior = organizationRequireBehavior;
     }
 }
 

--- a/src/main/java/com/auth0/json/mgmt/organizations/Branding.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Branding.java
@@ -1,0 +1,51 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the branding object of an {@linkplain Organization}.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Branding {
+
+    @JsonProperty("logo_url")
+    private String logoUrl;
+    @JsonProperty("colors")
+    private Colors colors;
+
+    /**
+     * @return the value of the logo URL
+     */
+    public String getLogoUrl() {
+        return logoUrl;
+    }
+
+    /**
+     * Sets the value of the logo URL to display on the login page
+     *
+     * @param logoUrl the logo URL to display on the login page. Must be an HTTPS URL or null.
+     */
+    public void setLogoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+    }
+
+    /**
+     * @return the {@linkplain Colors} for this Branding instance.
+     */
+    public Colors getColors() {
+        return colors;
+    }
+
+    /**
+     * Sets the value of the {@linkplain Colors} for this Branding instance.
+     *
+     * @param colors the colors associated with this Branding instance.
+     */
+    public void setColors(Colors colors) {
+        this.colors = colors;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Colors.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Colors.java
@@ -1,0 +1,64 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the colors object of a {@linkplain Branding}.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Colors {
+
+    @JsonProperty("primary")
+    private String primary;
+    @JsonProperty("page_background")
+    private String pageBackground;
+
+    public Colors() {}
+
+    /**
+     * Create a new instance.
+     *
+     * @param primary the HEX color for primary elements.
+     * @param pageBackground the HEX color for background.
+     */
+    public Colors(@JsonProperty("primary") String primary, @JsonProperty("page_background") String pageBackground) {
+        this.primary = primary;
+        this.pageBackground = pageBackground;
+    }
+
+    /**
+     * @return the primary color value.
+     */
+    public String getPrimary() {
+        return primary;
+    }
+
+    /**
+     * Sets the color for primary elements.
+     *
+     * @param primary the HEX color for primary elements.
+     */
+    public void setPrimary(String primary) {
+        this.primary = primary;
+    }
+
+    /**
+     * @return the background color value.
+     */
+    public String getPageBackground() {
+        return pageBackground;
+    }
+
+    /**
+     * Sets the color for the background.
+     *
+     * @param pageBackground the HEX color for the background.
+     */
+    public void setPageBackground(String pageBackground) {
+        this.pageBackground = pageBackground;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Connection.java
@@ -1,0 +1,51 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the Connection object of an {@linkplain EnabledConnection}.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Connection {
+
+    @JsonProperty("name")
+    private String  name;
+    @JsonProperty("strategy")
+    private String strategy;
+
+    /**
+     * @return the name of the connection.
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Sets the name of the connection.
+     *
+     * @param name the name of the connection.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the strategy of the connection
+     */
+    public String getStrategy() {
+        return this.strategy;
+    }
+
+    /**
+     * Sets the strategy of this connection.
+     *
+     * @param strategy the strategy of the connection.
+     */
+    public void setStrategy(String strategy) {
+        this.strategy = strategy;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/ConnectionsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/ConnectionsPageDeserializer.java
@@ -1,0 +1,24 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.PageDeserializer;
+
+import java.util.List;
+
+/**
+ * Parses a paged response into its {@linkplain EnabledConnectionsPage} representation.
+ */
+public class ConnectionsPageDeserializer  extends PageDeserializer<EnabledConnectionsPage, EnabledConnection> {
+    protected ConnectionsPageDeserializer() {
+        super(EnabledConnection.class, "enabled_connections");
+    }
+
+    @Override
+    protected EnabledConnectionsPage createPage(List<EnabledConnection> items) {
+        return new EnabledConnectionsPage(items);
+    }
+
+    @Override
+    protected EnabledConnectionsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<EnabledConnection> items) {
+        return new EnabledConnectionsPage(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/EnabledConnection.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/EnabledConnection.java
@@ -1,0 +1,80 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the enabled connection object for an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EnabledConnection {
+
+    @JsonProperty("connection")
+    private Connection connection;
+    @JsonProperty("assign_membership_on_login")
+    private boolean assignMembershipOnLogin;
+    @JsonProperty("connection_id")
+    private String connectionId;
+
+    public EnabledConnection() {}
+
+    /**
+     * Create a new instance.
+     *
+     * @param connectionId the ID of the connection
+     */
+    public EnabledConnection(@JsonProperty("connection_id") String connectionId) {
+        this.connectionId = connectionId;
+    }
+
+    /**
+     * @return the value of the {@linkplain Connection}.
+     */
+    public Connection getConnection() {
+        return connection;
+    }
+
+    /**
+     * Sets the value of the {@linkplain Connection}.
+     *
+     * @param connection the {@linkplain Connection} to set.
+     */
+    public void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * @return whether users will automatically granted membership in the organization when logging in.
+     */
+    public boolean isAssignMembershipOnLogin() {
+        return assignMembershipOnLogin;
+    }
+
+    /**
+     * Sets whether users will be automatically granted membership in the organization when logging in.
+     *
+     * @param assignMembershipOnLogin {@code true} to grant membership in the organization automatically when logging in, {@code false} to require membership to be granted prior to logging with this connection.
+     */
+    public void setAssignMembershipOnLogin(boolean assignMembershipOnLogin) {
+        this.assignMembershipOnLogin = assignMembershipOnLogin;
+    }
+
+    /**
+     * @return the value of the connection ID.
+     */
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    /**
+     * Sets the connection ID.
+     *
+     * @param connectionId the connection ID.
+     */
+    public void setConnectionId(String connectionId) {
+        this.connectionId = connectionId;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/EnabledConnectionsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/EnabledConnectionsPage.java
@@ -1,0 +1,27 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.Page;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Represents a page of the enabled connections for an organization.
+ * @see EnabledConnection
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = ConnectionsPageDeserializer.class)
+public class EnabledConnectionsPage extends Page<EnabledConnection> {
+
+    public EnabledConnectionsPage(List<EnabledConnection> items) {
+        super(items);
+    }
+
+    public EnabledConnectionsPage(Integer start, Integer length, Integer total, Integer limit, List<EnabledConnection> items) {
+        super(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
@@ -1,0 +1,222 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.*;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Represents the Invitation object for an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Invitation {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("inviter")
+    private Inviter inviter;
+    @JsonProperty("invitee")
+    private Invitee invitee;
+    @JsonProperty("ttl_sec")
+    private Integer ttlInSeconds;
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("connection_id")
+    private String connectionId;
+    @JsonProperty("app_metadata")
+    private Map<String, Object> appMetadata;
+    @JsonProperty("user_metadata")
+    private Map<String, Object> userMetadata;
+    @JsonProperty("send_invitation_email")
+    private Boolean sendInvitationEmail;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @JsonProperty("created_at")
+    private Date createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @JsonProperty("expires_at")
+    private Date expiresAt;
+    @JsonProperty("ticket_id")
+    private String ticketId;
+    @JsonProperty("invitation_url")
+    private String invitationUrl;
+    @JsonProperty("organization_id")
+    private String organizationId;
+    @JsonProperty("roles")
+    private Roles roles;
+
+    /**
+     * Create a new instance.
+     *
+     * @param inviter the {@linkplain Inviter} of this invitation.
+     * @param invitee the {@linkplain Invitee} of this invitation.
+     * @param clientId The id of the connection the invitee will authenticate with.\
+     */
+    @JsonCreator
+    public Invitation(@JsonProperty("inviter") Inviter inviter, @JsonProperty("invitee") Invitee invitee, @JsonProperty("client_id") String clientId) {
+        this.inviter = inviter;
+        this.invitee = invitee;
+        this.clientId = clientId;
+    }
+
+    /**
+     * @return the ID of this invitation.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return the {@linkplain Inviter} of this invitation.
+     */
+    public Inviter getInviter() {
+        return inviter;
+    }
+
+    /**
+     * @return the {@linkplain Invitee} of this invitation.
+     */
+    public Invitee getInvitee() {
+        return invitee;
+    }
+
+    /**
+     * @return the number of seconds before this invitation expires.
+     */
+    public Integer getTtlInSeconds() {
+        return ttlInSeconds;
+    }
+
+    /**
+     * Sets the number of seconds before this invitation expires.
+     * If unspecified or set to 0, this value defaults to 604800 seconds (7 days). Max value: 2592000 seconds (30 days).
+     *
+     * @param ttlInSeconds the number of seconds before this invitation expires.
+     */
+    public void setTtlInSeconds(Integer ttlInSeconds) {
+        this.ttlInSeconds = ttlInSeconds;
+    }
+
+    /**
+     * @return the client ID of this invitation.
+     */
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * @return the connection ID of this invitation.
+     */
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    /**
+     * Sets the ID of the connection for the inviter to authenticate with.
+     *
+     * @param connectionId the ID of the connection.
+     */
+    public void setConnectionId(String connectionId) {
+        this.connectionId = connectionId;
+    }
+
+    /**
+     * @return the app metadata of this invitation.
+     */
+    public Map<String, Object> getAppMetadata() {
+        return appMetadata;
+    }
+
+    /**
+     * Sets the app metadata associated with this invitation.
+     *
+     * @param appMetadata the app metadata.
+     */
+    public void setAppMetadata(Map<String, Object> appMetadata) {
+        this.appMetadata = appMetadata;
+    }
+
+    /**
+     * @return the user metadata of this invitation.
+     */
+    public Map<String, Object> getUserMetadata() {
+        return userMetadata;
+    }
+
+    /**
+     * Sets the user metadata associated with this invitation.
+     *
+     * @param userMetadata the user metadata.
+     */
+    public void setUserMetadata(Map<String, Object> userMetadata) {
+        this.userMetadata = userMetadata;
+    }
+
+    /**
+     * @return whether the user will receive an invitation email (true) or no email (false).
+     */
+    public Boolean isSendInvitationEmail() {
+        return sendInvitationEmail;
+    }
+
+    /**
+     * Whether the user will receive an invitation email (true) or no email (false). If not specified, default value is true.
+     *
+     * @param sendInvitationEmail whether to send the user an invitation email or not.
+     */
+    public void setSendInvitationEmail(Boolean sendInvitationEmail) {
+        this.sendInvitationEmail = sendInvitationEmail;
+    }
+
+    /**
+     * @return the date this invitation was created at.
+     */
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * @return the date this invitation expires.
+     */
+    public Date getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
+     * @return the ID of the invitation ticket.
+     */
+    public String getTicketId() {
+        return ticketId;
+    }
+
+    /**
+     * @return the roles associated with the user invited.
+     */
+    public Roles getRoles() {
+        return roles;
+    }
+
+    /**
+     * Sets the roles to be associated with the user invited.
+     *
+     * @param roles the {@linkplain Roles} to associated with the user invited.
+     */
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    /**
+     * @return the invitation url to be send to the invitee.
+     */
+    public String getInvitationUrl() {
+        return invitationUrl;
+    }
+
+    /**
+     * @return the ID of the organization for this invitation.
+     */
+    public String getOrganizationId() {
+        return organizationId;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/InvitationsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/InvitationsPage.java
@@ -1,0 +1,27 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.Page;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Represents a page of Invitations.
+ * @see Invitation
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = InvitationsPageDeserializer.class)
+public class InvitationsPage extends Page<Invitation> {
+
+    public InvitationsPage(List<Invitation> items) {
+        super(items);
+    }
+
+    public InvitationsPage(Integer start, Integer length, Integer total, Integer limit, List<Invitation> items) {
+        super(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/InvitationsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/InvitationsPageDeserializer.java
@@ -1,0 +1,25 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.PageDeserializer;
+
+import java.util.List;
+
+/**
+ * Parses a paged response into its {@linkplain InvitationsPage} representation.
+ */
+public class InvitationsPageDeserializer extends PageDeserializer<InvitationsPage, Invitation> {
+
+    protected InvitationsPageDeserializer() {
+        super(Invitation.class, "invitations");
+    }
+
+    @Override
+    protected InvitationsPage createPage(List<Invitation> items) {
+        return new InvitationsPage(items);
+    }
+
+    @Override
+    protected InvitationsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Invitation> items) {
+        return new InvitationsPage(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Invitee.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Invitee.java
@@ -1,0 +1,34 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the Invitee object for an Invitation.
+ * @see Invitation
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Invitee {
+
+    @JsonProperty("email")
+    private String email;
+
+    /**
+     * Create a new instance.
+     *
+     * @param email the email of the Invitee.
+     */
+    public Invitee(@JsonProperty("email") String email) {
+        this.email = email;
+    }
+
+    /**
+     * @return the email of this Invitee.
+     */
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Inviter.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Inviter.java
@@ -1,0 +1,34 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the Inviter object for an Invitation.
+ * @see Invitation
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Inviter {
+
+    @JsonProperty("name")
+    private String name;
+
+    /**
+     * Create a new instance.
+     *
+     * @param name the name of the Inviter.
+     */
+    public Inviter(@JsonProperty("name") String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the name of this Inviter.
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Member.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Member.java
@@ -1,0 +1,78 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the member of an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Member {
+
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("email")
+    private String email;
+    @JsonProperty("picture")
+    private String picture;
+    @JsonProperty("name")
+    private String name;
+
+    /**
+     * @return the user ID of this Member.
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     * @return the user ID of this Member.
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Sets the email of this Member.
+     *
+     * @param email the email of this Member.
+     */
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+     * @return the URL for this Member's picture.
+     */
+    public String getPicture() {
+        return picture;
+    }
+
+    /**
+     * Sets the URL for this Member's picture.
+     *
+     * @param picture the URL of this Member's picture.
+     */
+    public void setPicture(String picture) {
+        this.picture = picture;
+    }
+
+    /**
+     * @return the name of this Member.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of this Member.
+     *
+     * @param name the name of this Member.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Members.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Members.java
@@ -1,0 +1,38 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the request body when adding or deleting members from an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Members {
+
+    @JsonProperty("members")
+    private List<String> members;
+
+    /**
+     * Create a new instance.
+     *
+     * @param members a list of {@linkplain Member}
+     */
+    @JsonCreator
+    public Members(@JsonProperty("members") List<String> members) {
+        this.members = members;
+    }
+
+    /**
+     * @return the list of members.
+     */
+    public List<String> getMembers() {
+        return members;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/MembersPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/MembersPage.java
@@ -1,0 +1,26 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.Page;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Represents a page of Members of an organization.
+ * @see Member
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = MembersPageDeserializer.class)
+public class MembersPage extends Page<Member> {
+    public MembersPage(List<Member> items) {
+        super(items);
+    }
+
+    public MembersPage(Integer start, Integer length, Integer total, Integer limit, List<Member> items) {
+        super(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/MembersPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/MembersPageDeserializer.java
@@ -1,0 +1,25 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.PageDeserializer;
+
+import java.util.List;
+
+/**
+ * Parses a paged response into its {@linkplain MembersPage} representation.
+ */
+public class MembersPageDeserializer extends PageDeserializer<MembersPage, Member> {
+
+    protected MembersPageDeserializer() {
+        super(Member.class, "members");
+    }
+
+    @Override
+    protected MembersPage createPage(List<Member> items) {
+        return new MembersPage(items);
+    }
+
+    @Override
+    protected MembersPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Member> items) {
+        return new MembersPage(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Organization.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Organization.java
@@ -1,0 +1,111 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Represents the organization object.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Organization {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("display_name")
+    private String displayName;
+    @JsonProperty("metadata")
+    private Map<String, Object> metadata;
+    @JsonProperty("branding")
+    private Branding branding;
+
+    public Organization() {}
+
+    /**
+     * Create a new instance.
+     *
+     * @param name the name of this organization.
+     */
+    @JsonCreator
+    public Organization(@JsonProperty("name") String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the ID of this organization.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return the name of this Organization.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of this Organization.
+     *
+     * @param name the name of the Organization.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the display name of this Organization.
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Sets the display name of this Organization.
+     *
+     * @param displayName the display name of this Organization.
+     */
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * @return the {@linkplain Branding} of this Organization.
+     */
+    public Branding getBranding() {
+        return branding;
+    }
+
+    /**
+     * Sets the {@linkplain Branding} of this Organization.
+     *
+     * @param branding the {@linkplain Branding} of this Organization.
+     */
+    public void setBranding(Branding branding) {
+        this.branding = branding;
+    }
+
+    /**
+     * @return the metadata of this Organization.
+     */
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Sets the metadata of this Organization.
+     *
+     * @param metadata the metadata of this Organization.
+     */
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPage.java
@@ -1,0 +1,26 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.Page;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Represents a page of an Organization.
+ * @see Organization
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = OrganizationsPageDeserializer.class)
+public class OrganizationsPage extends Page<Organization> {
+    public OrganizationsPage(List<Organization> items) {
+        super(items);
+    }
+
+    public OrganizationsPage(Integer start, Integer length, Integer total, Integer limit, List<Organization> items) {
+        super(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPageDeserializer.java
@@ -1,0 +1,26 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.PageDeserializer;
+import com.auth0.json.mgmt.logevents.LogEvent;
+
+import java.util.List;
+
+/**
+ * Parses a paged response into its {@linkplain OrganizationsPage} representation.
+ */
+public class OrganizationsPageDeserializer extends PageDeserializer<OrganizationsPage, Organization> {
+
+    protected OrganizationsPageDeserializer() {
+        super(Organization.class, "organizations");
+    }
+
+    @Override
+    protected OrganizationsPage createPage(List<Organization> items) {
+        return new OrganizationsPage(items);
+    }
+
+    @Override
+    protected OrganizationsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Organization> items) {
+        return new OrganizationsPage(start, length, total, limit, items);
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Roles.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Roles.java
@@ -1,0 +1,36 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the request body when adding or deleting roles from a member of an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Roles {
+
+    @JsonProperty("roles")
+    private List<String> roles;
+
+    /**
+     * Create a new instance.
+     *
+     * @param roles the list of Role IDs to associate with the member.
+     */
+    public Roles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    /**
+     * @return the list of Role IDs associated with the member.
+     */
+    public List<String> getRoles() {
+        return roles;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -30,6 +30,8 @@ public class PasswordChangeTicket {
     private String ticket;
     @JsonProperty("mark_email_as_verified")
     private Boolean markEmailAsVerified;
+    @JsonProperty("organization_id")
+    private String orgId;
 
     @JsonCreator
     public PasswordChangeTicket(@JsonProperty("user_id") String userId) {
@@ -117,6 +119,26 @@ public class PasswordChangeTicket {
     @JsonProperty("mark_email_as_verified")
     public void setMarkEmailAsVerified(Boolean markEmailAsVerified){
         this.markEmailAsVerified = markEmailAsVerified;
+    }
+
+    /**
+     * Sets the organization ID. This allows the organization_id and organization_name to be included in the redirect URL query.
+     *
+     * @param orgId the ID of the organization
+     */
+    @JsonProperty("organization_id")
+    public void setOrganizationId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    /**
+     * Gets the organization ID
+     *
+     * @return the organization ID
+     */
+    @JsonProperty("organization_id")
+    public String getOrganizationId() {
+        return orgId;
     }
 
     /**

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -94,6 +94,19 @@ public class MockServer {
     public static final String MULTIPART_SAMPLE = "src/test/resources/mgmt/multipart_sample.json";
     public static final String PASSWORDLESS_EMAIL_RESPONSE = "src/test/resources/auth/passwordless_email.json";
     public static final String PASSWORDLESS_SMS_RESPONSE = "src/test/resources/auth/passwordless_sms.json";
+    public static final String ORGANIZATION = "src/test/resources/mgmt/organization.json";
+    public static final String ORGANIZATIONS_LIST = "src/test/resources/mgmt/organizations_list.json";
+    public static final String ORGANIZATIONS_PAGED_LIST = "src/test/resources/mgmt/organizations_paged_list.json";
+    public static final String ORGANIZATION_MEMBERS_LIST = "src/test/resources/mgmt/organization_members_list.json";
+    public static final String ORGANIZATION_MEMBERS_PAGED_LIST = "src/test/resources/mgmt/organization_members_paged_list.json";
+    public static final String ORGANIZATION_CONNECTIONS_LIST = "src/test/resources/mgmt/organization_connections_list.json";
+    public static final String ORGANIZATION_CONNECTIONS_PAGED_LIST = "src/test/resources/mgmt/organization_connections_paged_list.json";
+    public static final String ORGANIZATION_CONNECTION = "src/test/resources/mgmt/organization_connection.json";
+    public static final String ORGANIZATION_MEMBER_ROLES_LIST = "src/test/resources/mgmt/organization_member_roles_list.json";
+    public static final String ORGANIZATION_MEMBER_ROLES_PAGED_LIST = "src/test/resources/mgmt/organization_member_roles_paged_list.json";
+    public static final String INVITATION = "src/test/resources/mgmt/invitation.json";
+    public static final String INVITATIONS_LIST = "src/test/resources/mgmt/invitations_list.json";
+    public static final String INVITATIONS_PAGED_LIST = "src/test/resources/mgmt/invitations_paged_list.json";
 
     private final MockWebServer server;
 

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -234,6 +234,28 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldSendUserVerificationEmailWithOrgId() throws Exception {
+        Request<Job> request = api.jobs().sendVerificationEmail("google-oauth2|1234", "client_abc", null, "org_abc");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_VERIFICATION_EMAIL, 200);
+        Job response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/verification-email"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(3));
+        assertThat(body, hasEntry("user_id", "google-oauth2|1234"));
+        assertThat(body, hasEntry("client_id", "client_abc"));
+        assertThat(body, hasEntry("organization_id", "org_abc"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
     public void shouldThrowOnSendUserVerificationEmailWithNullIdentityProvider() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'identity provider' cannot be null!");

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -1,0 +1,906 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.filter.FieldsFilter;
+import com.auth0.client.mgmt.filter.InvitationsFilter;
+import com.auth0.client.mgmt.filter.PageFilter;
+import com.auth0.json.mgmt.RolesPage;
+import com.auth0.json.mgmt.organizations.*;
+import com.auth0.net.Request;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import java.util.*;
+
+import static com.auth0.client.MockServer.*;
+import static com.auth0.client.RecordedRequestMatcher.*;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OrganizationEntityTest extends BaseMgmtEntityTest {
+
+    //  Organizations entity
+
+    @Test
+    public void shouldListOrgsWithoutFilter() throws Exception {
+        Request<OrganizationsPage> request = api.organizations().list(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATIONS_LIST, 200);
+        OrganizationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListOrgsWithPage() throws Exception {
+        PageFilter filter = new PageFilter().withPage(2, 30);
+        Request<OrganizationsPage> request = api.organizations().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATIONS_PAGED_LIST, 200);
+        OrganizationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "2"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "30"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListOrgsWithTotals() throws Exception {
+        PageFilter filter = new PageFilter().withTotals(true);
+        Request<OrganizationsPage> request = api.organizations().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATIONS_PAGED_LIST, 200);
+        OrganizationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldThrowOnGetOrgWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().get(null);
+    }
+
+    @Test
+    public void shouldGetOrganization() throws Exception {
+        Request<Organization> request = api.organizations().get("org_123");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION, 200);
+        Organization response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnGetOrgWithNullName() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization name");
+        api.organizations().getByName(null);
+    }
+
+    @Test
+    public void shouldGetOrganizationByName() throws Exception {
+        Request<Organization> request = api.organizations().getByName("org-1");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION, 200);
+        Organization response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/name/org-1"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnCreateOrgWithNullOrg() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization");
+        api.organizations().create(null);
+    }
+
+    @Test
+    public void shouldCreateOrganization() throws Exception {
+        Organization orgToCreate = new Organization("test-org");
+        orgToCreate.setDisplayName("display name");
+
+        Colors colors = new Colors();
+        colors.setPageBackground("#FF0000");
+        colors.setPrimary("#FF0000");
+        Branding branding = new Branding();
+        branding.setColors(colors);
+        branding.setLogoUrl("https://some-uri.com");
+        orgToCreate.setBranding(branding);
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("key1", "val1");
+        orgToCreate.setMetadata(metadata);
+
+        Request<Organization> request = api.organizations().create(orgToCreate);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION, 200);
+        Organization response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(4));
+        assertThat(body, hasEntry("name", "test-org"));
+        assertThat(body, hasEntry("display_name", "display name"));
+        assertThat(body, hasEntry("metadata", metadata));
+        assertThat(body, hasEntry(is("branding"), is(notNullValue())));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnUpdateOrgWithNullOrgId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().update(null, new Organization());
+    }
+
+    @Test
+    public void shouldThrowOnUpdateOrgWithNullOrg() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization");
+        api.organizations().update("org_123", null);
+    }
+
+    @Test
+    public void shouldUpdateOrganization() throws Exception {
+        Organization orgToUpdate = new Organization("test-org");
+        orgToUpdate.setDisplayName("display name");
+
+        Colors colors = new Colors();
+        colors.setPageBackground("#FF0000");
+        colors.setPrimary("#FF0000");
+        Branding branding = new Branding();
+        branding.setColors(colors);
+        branding.setLogoUrl("https://some-uri.com");
+        orgToUpdate.setBranding(branding);
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("key1", "val1");
+        orgToUpdate.setMetadata(metadata);
+
+        Request<Organization> request = api.organizations().update("org_abc", orgToUpdate);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION, 200);
+        Organization response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/organizations/org_abc"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(4));
+        assertThat(body, hasEntry("name", "test-org"));
+        assertThat(body, hasEntry("display_name", "display name"));
+        assertThat(body, hasEntry("metadata", metadata));
+        assertThat(body, hasEntry(is("branding"), is(notNullValue())));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteOrgWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().delete(null);
+    }
+
+    @Test
+    public void shouldDeleteOrganization() throws Exception {
+        Request request = api.organizations().delete("org_abc");
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    // Organization members entity
+
+    @Test
+    public void shouldThrowOnGetMembersWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().getMembers(null, null);
+    }
+
+    @Test
+    public void shouldListOrgMembersWithoutFilter() throws Exception {
+        Request<MembersPage> request = api.organizations().getMembers("org_abc", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_LIST, 200);
+        MembersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(3));
+    }
+
+    @Test
+    public void shouldListOrgMembersWithPage() throws Exception {
+        PageFilter filter = new PageFilter().withPage(0, 20);
+        Request<MembersPage> request = api.organizations().getMembers("org_abc", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_LIST, 200);
+        MembersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "0"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "20"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(3));
+    }
+
+    @Test
+    public void shouldListOrgMembersWithTotals() throws Exception {
+        PageFilter filter = new PageFilter().withTotals(true);
+        Request<MembersPage> request = api.organizations().getMembers("org_abc", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_PAGED_LIST, 200);
+        MembersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(3));
+    }
+
+    @Test
+    public void shouldThrowOnAddMembersWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().addMembers(null, new Members(Collections.singletonList("user1")));
+    }
+
+    @Test
+    public void shouldThrowOnAddMembersWhenMembersIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("members");
+        api.organizations().addMembers("org_abc", null);
+    }
+
+    @Test
+    public void shouldAddMembersToOrganization() throws Exception {
+        List<String> membersList = Arrays.asList("user1", "user2");
+        Members members = new Members(membersList);
+        Request request = api.organizations().addMembers("org_abc", members);
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(1));
+        assertThat(body, hasEntry("members", membersList));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteMembersWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().deleteMembers(null, new Members(Collections.singletonList("user1")));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteMembersWhenMembersIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("members");
+        api.organizations().deleteMembers("org_abc", null);
+    }
+
+    @Test
+    public void shouldDeleteMembersFromOrganization() throws Exception {
+        List<String> membersList = Collections.singletonList("user1");
+        Members members = new Members(membersList);
+        Request request = api.organizations().deleteMembers("org_abc", members);
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(1));
+        assertThat(body, hasEntry("members", membersList));
+    }
+
+    // Organization connections
+
+    @Test
+    public void shouldThrowOnGetConnectionsWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().deleteMembers(null, null);
+    }
+
+    @Test
+    public void shouldListOrganizationConnectionsWithoutFilter() throws Exception {
+        Request<EnabledConnectionsPage> request = api.organizations().getConnections("org_abc", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_CONNECTIONS_LIST, 200);
+        EnabledConnectionsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/enabled_connections"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldGetOrganizationConnectionsWithPage() throws Exception {
+        PageFilter filter = new PageFilter().withPage(2, 30);
+        Request<EnabledConnectionsPage> request = api.organizations().getConnections("org_abc", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_CONNECTIONS_LIST, 200);
+        EnabledConnectionsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/enabled_connections"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "2"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "30"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldGetOrganizationConnectionsWithTotals() throws Exception {
+        PageFilter filter = new PageFilter().withTotals(true);
+        Request<EnabledConnectionsPage> request = api.organizations().getConnections("org_abc", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_CONNECTIONS_PAGED_LIST, 200);
+        EnabledConnectionsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/enabled_connections"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
+    public void shouldThrowOnAddConnectionWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().addConnection(null, new EnabledConnection());
+    }
+
+    @Test
+    public void shouldThrowOnAddConnectionWhenConnectionIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("connection");
+        api.organizations().addConnection("org_abc", null);
+    }
+
+    @Test
+    public void shouldAddConnection() throws Exception {
+        EnabledConnection connection = new EnabledConnection();
+        connection.setAssignMembershipOnLogin(false);
+        connection.setConnectionId("con_123");
+
+        Request<EnabledConnection> request = api.organizations().addConnection("org_abc", connection);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_CONNECTION, 201);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_abc/enabled_connections"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(2));
+        assertThat(body, hasEntry("connection_id", "con_123"));
+        assertThat(body, hasEntry("assign_membership_on_login", false));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteConnectionWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().deleteConnection(null, "con_123");
+    }
+
+    @Test
+    public void shouldThrowOnDeleteConnectionWhenConnectionIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("connection");
+        api.organizations().deleteConnection("org_abc", null);
+    }
+
+    @Test
+    public void shouldDeleteConnection() throws Exception {
+        Request request = api.organizations().deleteConnection("org_abc", "con_123");
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/enabled_connections/con_123"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    @Test
+    public void shouldThrowOnUpdateConnectionWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().updateConnection(null, "con_123", new EnabledConnection());
+    }
+
+    @Test
+    public void shouldThrowOnUpdateConnectionWhenUserIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("connection");
+        api.organizations().updateConnection("org_abc", null, new EnabledConnection());
+    }
+
+    @Test
+    public void shouldThrowOnUpdateConnectionWhenConnectionIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("connection");
+        api.organizations().updateConnection("org_abc", "con_123", null);
+    }
+
+    @Test
+    public void shouldUpdateOrgConnection() throws Exception {
+        EnabledConnection connection = new EnabledConnection();
+        connection.setAssignMembershipOnLogin(true);
+
+        Request<EnabledConnection> request = api.organizations().updateConnection("org_abc", "con_123", connection);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_CONNECTION, 201);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/organizations/org_abc/enabled_connections/con_123"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(1));
+        assertThat(body, hasEntry("assign_membership_on_login", true));
+    }
+
+    // Organization roles
+
+    @Test
+    public void shouldThrowOnGetOrgRolesWhenOrgIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().getRoles(null, "user_123",null);
+    }
+
+    @Test
+    public void shouldThrowOnGetOrgRolesWhenUserIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("user ID");
+        api.organizations().getRoles("org_abc", null, null);
+    }
+
+    @Test
+    public void shouldGetOrgRolesWithoutPaging() throws Exception {
+        Request<RolesPage> request = api.organizations().getRoles("org_abc", "user_123", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_MEMBER_ROLES_LIST, 200);
+        RolesPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members/user_123/roles"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(1));
+    }
+
+    @Test
+    public void shouldGetOrgRolesWithPaging() throws Exception {
+        Request<RolesPage> request = api.organizations().getRoles("org_abc", "user_123", new PageFilter().withPage(0, 20));
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_MEMBER_ROLES_LIST, 200);
+        RolesPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members/user_123/roles"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "0"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "20"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(1));
+    }
+
+    @Test
+    public void shouldGetOrgRolesWithIncludeTotals() throws Exception {
+        Request<RolesPage> request = api.organizations().getRoles("org_abc", "user_123", new PageFilter().withTotals(true));
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_MEMBER_ROLES_PAGED_LIST, 200);
+        RolesPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members/user_123/roles"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(1));
+    }
+
+    @Test
+    public void shouldThrowOnAddOrgRolesWhenOrgIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().addRoles(null, "user_123", new Roles(Collections.singletonList("role_id")));
+    }
+
+    @Test
+    public void shouldThrowOnAddOrgRolesWhenUserIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("user ID");
+        api.organizations().addRoles("org_abc", null, new Roles(Collections.singletonList("role_id")));
+    }
+
+    @Test
+    public void shouldThrowOnAddOrgRolesWhenRolesIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("roles");
+        api.organizations().addRoles("org_abc", "user_123", null);
+    }
+
+    @Test
+    public void shouldAddOrgRoles() throws Exception {
+        List<String> rolesList = Arrays.asList("role_1", "role_2");
+        Request request = api.organizations().addRoles("org_abc", "user_123", new Roles(rolesList));
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_abc/members/user_123/roles"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(1));
+        assertThat(body, hasEntry("roles", rolesList));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteOrgRolesWhenOrgIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().deleteRoles(null, "user_123", new Roles(Collections.singletonList("role_id")));
+    }
+
+    @Test
+    public void shouldThrowDeleteOrgRolesWhenUserIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("user ID");
+        api.organizations().deleteRoles("org_abc", null, new Roles(Collections.singletonList("role_id")));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteOrgRolesWhenRolesIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("roles");
+        api.organizations().deleteRoles("org_abc", "user_123", null);
+    }
+
+    @Test
+    public void shouldDeleteOrgRoles() throws Exception {
+        List<String> rolesList = Arrays.asList("role_1", "role_2");
+        Request request = api.organizations().deleteRoles("org_abc", "user_123", new Roles(rolesList));
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/members/user_123/roles"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(1));
+        assertThat(body, hasEntry("roles", rolesList));
+    }
+
+    // Invitations
+
+    @Test
+    public void shouldThrowOnGetInvitationWithNullOrgId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().getInvitation(null, "invitation_id", null);
+    }
+
+    @Test
+    public void shouldThrowOnGetInvitationWithNullInvitationId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("invitation ID");
+        api.organizations().getInvitation("org_id", null, null);
+    }
+
+    @Test
+    public void shouldGetInvitationWithoutFilter() throws Exception {
+        Request<Invitation> request = api.organizations().getInvitation("org_123", "invitation_id", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATION, 200);
+        Invitation response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations/invitation_id"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetInvitationWithFilter() throws Exception {
+        Request<Invitation> request = api.organizations().getInvitation("org_123", "invitation_id",
+            new FieldsFilter().withFields("id,invitation_url,invitee", true));
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATION, 200);
+        Invitation response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations/invitation_id"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("fields", "id,invitation_url,invitee"));
+        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnGetInvitationsWithNullOrgId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().getInvitations(null, null);
+    }
+
+    @Test
+    public void shouldGetInvitationsWithoutFilter() throws Exception {
+        Request<InvitationsPage> request = api.organizations().getInvitations("org_123", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATIONS_LIST, 200);
+        InvitationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetInvitationsWithFilter() throws Exception {
+        InvitationsFilter filter = new InvitationsFilter()
+            .withSort("created_at:1")
+            .withFields("invitee,inviter,created_at", true);
+
+        Request<InvitationsPage> request = api.organizations().getInvitations("org_123", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATIONS_LIST, 200);
+        InvitationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("fields", "invitee,inviter,created_at"));
+        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
+        assertThat(recordedRequest, hasQueryParameter("sort", "created_at:1"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetInvitationsWithPaging() throws Exception {
+        InvitationsFilter filter = new InvitationsFilter().withPage(0, 20);
+
+        Request<InvitationsPage> request = api.organizations().getInvitations("org_123", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATIONS_LIST, 200);
+        InvitationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "20"));
+        assertThat(recordedRequest, hasQueryParameter("page", "0"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetInvitationsWithTotals() throws Exception {
+        InvitationsFilter filter = new InvitationsFilter().withTotals(true);
+
+        Request<InvitationsPage> request = api.organizations().getInvitations("org_123", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATIONS_PAGED_LIST, 200);
+        InvitationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnCreateInvitationWithNullOrgId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().createInvitation(null, null);
+    }
+
+    @Test
+    public void shouldThrowOnCreateInvitationWithNullInvitation() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("invitation");
+        api.organizations().createInvitation("org_abc", null);
+    }
+
+    @Test
+    public void shouldCreateInvitation() throws Exception {
+        Invitation invitation = new Invitation(new Inviter("name"), new Invitee("name@domain.com"), "con_id");
+        invitation.setTtlInSeconds(300);
+        invitation.setConnectionId("con_id");
+        invitation.setSendInvitationEmail(true);
+
+        Request<Invitation> request = api.organizations().createInvitation("org_123", invitation);
+
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(INVITATION, 201);
+        Invitation response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_123/invitations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, aMapWithSize(6));
+        assertThat(body, hasEntry("send_invitation_email", true));
+        assertThat(body, hasEntry("connection_id", "con_id"));
+        assertThat(body, hasEntry("ttl_sec", 300));
+        assertThat(body, hasEntry("inviter", Collections.singletonMap("name", "name")));
+        assertThat(body, hasEntry("invitee", Collections.singletonMap("email", "name@domain.com")));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowOnDeleteInvitationWithNullOrgId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().deleteInvitation(null, "inv_123");
+    }
+
+    @Test
+    public void shouldThrowOnDeleteInvitationWithNullInvitationId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("invitation ID");
+        api.organizations().deleteInvitation("org_abc", null);
+    }
+
+    @Test
+    public void shouldDeleteInvitation() throws Exception {
+        Request request = api.organizations().deleteInvitation("org_abc", "inv_123");
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/invitations/inv_123"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.*;
 public class ClientTest extends JsonTest<Client> {
 
     private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
-    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}},\"refresh_token\":{\"rotation_type\":\"non-rotating\"}}";
+    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"organization_usage\":\"allow\",\"organization_require_behavior\":\"no_prompt\",\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}},\"refresh_token\":{\"rotation_type\":\"non-rotating\"}}";
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -56,6 +56,8 @@ public class ClientTest extends JsonTest<Client> {
         client.setMobile(mobile);
         RefreshToken refreshToken = new RefreshToken();
         client.setRefreshToken(refreshToken);
+        client.setOrganizationUsage("require");
+        client.setOrganizationRequireBehavior("pre_login_prompt");
 
         String serialized = toJSON(client);
         assertThat(serialized, is(notNullValue()));
@@ -87,6 +89,8 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("client_metadata", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("mobile", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("refresh_token", notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("organization_usage", "require"));
+        assertThat(serialized, JsonMatcher.hasEntry("organization_require_behavior", "pre_login_prompt"));
     }
 
     @Test
@@ -128,6 +132,8 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getClientMetadata(), IsMapContaining.hasEntry("key", "value"));
         assertThat(client.getMobile(), is(notNullValue()));
         assertThat(client.getRefreshToken(), is(notNullValue()));
+        assertThat(client.getOrganizationUsage(), is("allow"));
+        assertThat(client.getOrganizationRequireBehavior(), is("no_prompt"));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/organizations/EnabledConnectionsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/EnabledConnectionsPageTest.java
@@ -1,0 +1,79 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EnabledConnectionsPageTest extends JsonTest<EnabledConnectionsPage> {
+
+    private static String jsonWithoutTotals = "[\n" +
+        "    {\n" +
+        "        \"connection_id\": \"con_1\",\n" +
+        "        \"assign_membership_on_login\": false,\n" +
+        "        \"connection\": {\n" +
+        "            \"name\": \"google-oauth2\",\n" +
+        "            \"strategy\": \"google-oauth2\"\n" +
+        "        }\n" +
+        "    },\n" +
+        "    {\n" +
+        "        \"connection_id\": \"con_2\",\n" +
+        "        \"assign_membership_on_login\": true,\n" +
+        "        \"connection\": {\n" +
+        "            \"name\": \"Username-Password-Authentication\",\n" +
+        "            \"strategy\": \"auth0\"\n" +
+        "        }\n" +
+        "    }\n" +
+        "]";
+
+    private static String jsonWithTotals = "{\n" +
+        "    \"enabled_connections\": [\n" +
+        "        {\n" +
+        "            \"connection_id\": \"con_1\",\n" +
+        "            \"assign_membership_on_login\": false,\n" +
+        "            \"connection\": {\n" +
+        "                \"name\": \"google-oauth2\",\n" +
+        "                \"strategy\": \"google-oauth2\"\n" +
+        "            }\n" +
+        "        },\n" +
+        "        {\n" +
+        "            \"connection_id\": \"con_2\",\n" +
+        "            \"assign_membership_on_login\": true,\n" +
+        "            \"connection\": {\n" +
+        "                \"name\": \"Username-Password-Authentication\",\n" +
+        "                \"strategy\": \"auth0\"\n" +
+        "            }\n" +
+        "        }\n" +
+        "    ],\n" +
+        "    \"start\": 0,\n" +
+        "    \"limit\": 2,\n" +
+        "    \"total\": 2\n" +
+        "}";
+
+    @Test
+    public void shouldDeserializeWithoutTotals() throws Exception {
+        EnabledConnectionsPage page = fromJSON(jsonWithoutTotals, EnabledConnectionsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        EnabledConnectionsPage page = fromJSON(jsonWithTotals, EnabledConnectionsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getTotal(), is(2));
+        assertThat(page.getLimit(), is(2));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/EnabledConnectionsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/EnabledConnectionsTest.java
@@ -1,0 +1,55 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EnabledConnectionsTest extends JsonTest<EnabledConnection> {
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        Connection connection = new Connection();
+        connection.setName("con_1");
+        connection.setStrategy("strategy");
+
+        EnabledConnection enabledConnection = new EnabledConnection();
+        enabledConnection.setAssignMembershipOnLogin(true);
+        enabledConnection.setConnection(connection);
+
+        String serialized = toJSON(enabledConnection);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("assign_membership_on_login", true));
+        assertThat(serialized, JsonMatcher.hasEntry("connection", is(notNullValue())));
+
+        Map<String, String> connectionMap = new HashMap<>();
+        connectionMap.put("name", "con_1");
+        connectionMap.put("strategy", "strategy");
+        assertThat(serialized, JsonMatcher.hasEntry("connection", connectionMap));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        String json = "{\n" +
+            "   \"connection_id\": \"con_id\",\n" +
+            "   \"assign_membership_on_login\": false,\n" +
+            "   \"connection\": {\n" +
+            "       \"name\": \"google-oauth2\",\n" +
+            "       \"strategy\": \"google-oauth2\"\n" +
+            "   }\n" +
+            " }";
+
+        EnabledConnection enabledConnection = fromJSON(json, EnabledConnection.class);
+        assertThat(enabledConnection, is(notNullValue()));
+        assertThat(enabledConnection.getConnectionId(), is("con_id"));
+        assertThat(enabledConnection.isAssignMembershipOnLogin(), is(false));
+        assertThat(enabledConnection.getConnection(), is(notNullValue()));
+        assertThat(enabledConnection.getConnection().getName(), is("google-oauth2"));
+        assertThat(enabledConnection.getConnection().getStrategy(), is("google-oauth2"));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/InvitationTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/InvitationTest.java
@@ -1,0 +1,79 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class InvitationTest extends JsonTest<Invitation> {
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        String json = "{\n" +
+            "  \"id\": \"inv_1\",\n" +
+            "  \"client_id\": \"client-id\",\n" +
+            "  \"inviter\": {\n" +
+            "    \"name\": \"timmy\"\n" +
+            "  },\n" +
+            "  \"invitee\": {\n" +
+            "    \"email\": \"timmy@domain.com\"\n" +
+            "  },\n" +
+            "  \"invitation_url\": \"https://somedomain.com\",\n" +
+            "  \"ticket_id\": \"ticket-id\",\n" +
+            "  \"created_at\": \"2021-03-31T19:08:40.295Z\",\n" +
+            "  \"expires_at\": \"2021-04-07T19:08:40.295Z\",\n" +
+            "  \"organization_id\": \"org_abc\"\n" +
+            "}\n";
+
+        Invitation invitation = fromJSON(json, Invitation.class);
+
+        assertThat(invitation, is(notNullValue()));
+        assertThat(invitation.getId(), is("inv_1"));
+        assertThat(invitation.getClientId(), is("client-id"));
+        assertThat(invitation.getInviter(), is(notNullValue()));
+        assertThat(invitation.getInviter().getName(), is("timmy"));
+        assertThat(invitation.getInvitee(), is(notNullValue()));
+        assertThat(invitation.getInvitee().getEmail(), is("timmy@domain.com"));
+        assertThat(invitation.getInvitationUrl(), is("https://somedomain.com"));
+        assertThat(invitation.getTicketId(), is("ticket-id"));
+        assertThat(invitation.getCreatedAt(), is(parseJSONDate("2021-03-31T19:08:40.295Z")));
+        assertThat(invitation.getExpiresAt(), is(parseJSONDate("2021-04-07T19:08:40.295Z")));
+        assertThat(invitation.getOrganizationId(), is("org_abc"));
+    }
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        Map<String, Object> appMetadata = Collections.singletonMap("app1", "val1");
+        Map<String, Object> userMetadata = Collections.singletonMap("user1", "val1");
+        List<String> rolesList = Arrays.asList("role-1", "role-2");
+
+        Invitation invitation = new Invitation(new Inviter("name"), new Invitee("joe@domain.com"), "client-id");
+        invitation.setSendInvitationEmail(true);
+        invitation.setAppMetadata(appMetadata);
+        invitation.setUserMetadata(userMetadata);
+        invitation.setConnectionId("connId");
+        invitation.setRoles(new Roles(rolesList));
+        invitation.setTtlInSeconds(41);
+
+        String serialized = toJSON(invitation);
+
+        assertThat(serialized, is(notNullValue()));
+        System.out.println(serialized);
+        assertThat(serialized, JsonMatcher.hasEntry("client_id", "client-id"));
+        assertThat(serialized, JsonMatcher.hasEntry("ttl_sec", 41));
+        assertThat(serialized, JsonMatcher.hasEntry("connection_id", "connId"));
+        assertThat(serialized, JsonMatcher.hasEntry("send_invitation_email", true));
+        assertThat(serialized, JsonMatcher.hasEntry("roles", rolesList));
+        assertThat(serialized, JsonMatcher.hasEntry("app_metadata", appMetadata));
+        assertThat(serialized, JsonMatcher.hasEntry("user_metadata", userMetadata));
+        assertThat(serialized, JsonMatcher.hasEntry("inviter", is(notNullValue())));
+        assertThat(serialized, JsonMatcher.hasEntry("invitee", is(notNullValue())));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/InvitationsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/InvitationsPageTest.java
@@ -1,0 +1,109 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+
+public class InvitationsPageTest extends JsonTest<InvitationsPage> {
+
+    private static final String jsonWithoutTotals = "[\n" +
+        "  {\n" +
+        "    \"id\": \"uinv_Q3lgZ0a99aY7Rqs3\",\n" +
+        "    \"client_id\": \"klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb\",\n" +
+        "    \"inviter\": {\n" +
+        "      \"name\": \"dave!\"\n" +
+        "    },\n" +
+        "    \"invitee\": {\n" +
+        "      \"email\": \"dave@domain.com\"\n" +
+        "    },\n" +
+        "    \"invitation_url\": \"https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org\",\n" +
+        "    \"ticket_id\": \"U0o1uoXAl1VPkKbZla0a833soMUMOo1E\",\n" +
+        "    \"created_at\": \"2021-03-31T19:08:40.295Z\",\n" +
+        "    \"expires_at\": \"2021-04-07T19:08:40.295Z\",\n" +
+        "    \"organization_id\": \"org_W30s833MRbjhHuWK\"\n" +
+        "  },\n" +
+        "  {\n" +
+        "    \"id\": \"uinv_Q3lgZ0a99aY7Rqs3\",\n" +
+        "    \"client_id\": \"klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb\",\n" +
+        "    \"inviter\": {\n" +
+        "      \"name\": \"jim.anderson@auth0.com\"\n" +
+        "    },\n" +
+        "    \"invitee\": {\n" +
+        "      \"email\": \"jim.anderson+android@auth0.com\"\n" +
+        "    },\n" +
+        "    \"app_metadata\": {},\n" +
+        "    \"user_metadata\": {},\n" +
+        "    \"invitation_url\": \"https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org\",\n" +
+        "    \"ticket_id\": \"U0o1uoXAl1VPkK0a940a833soMUMOo1E\",\n" +
+        "    \"created_at\": \"2021-03-31T17:59:23.132Z\",\n" +
+        "    \"expires_at\": \"2021-04-07T17:59:23.132Z\",\n" +
+        "    \"organization_id\": \"org_W30s833MRbjhHuWK\"\n" +
+        "  }\n" +
+        "]\n";
+
+    private static final String jsonWithTotals = "{\n" +
+        "  \"invitations\": [\n" +
+        "    {\n" +
+        "      \"id\": \"uinv_Q3lgZ0a99aY7Rqs3\",\n" +
+        "      \"client_id\": \"klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb\",\n" +
+        "      \"inviter\": {\n" +
+        "        \"name\": \"dave!\"\n" +
+        "      },\n" +
+        "      \"invitee\": {\n" +
+        "        \"email\": \"dave@domain.com\"\n" +
+        "      },\n" +
+        "      \"invitation_url\": \"https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org\",\n" +
+        "      \"ticket_id\": \"U0o1uoXAl1VPkKbZla0a833soMUMOo1E\",\n" +
+        "      \"created_at\": \"2021-03-31T19:08:40.295Z\",\n" +
+        "      \"expires_at\": \"2021-04-07T19:08:40.295Z\",\n" +
+        "      \"organization_id\": \"org_W30s833MRbjhHuWK\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"id\": \"uinv_Q3lgZ0a99aY7Rqs3\",\n" +
+        "      \"client_id\": \"klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb\",\n" +
+        "      \"inviter\": {\n" +
+        "        \"name\": \"jim.anderson@auth0.com\"\n" +
+        "      },\n" +
+        "      \"invitee\": {\n" +
+        "        \"email\": \"jim.anderson+android@auth0.com\"\n" +
+        "      },\n" +
+        "      \"app_metadata\": {},\n" +
+        "      \"user_metadata\": {},\n" +
+        "      \"invitation_url\": \"https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org\",\n" +
+        "      \"ticket_id\": \"U0o1uoXAl1VPkK0a940a833soMUMOo1E\",\n" +
+        "      \"created_at\": \"2021-03-31T17:59:23.132Z\",\n" +
+        "      \"expires_at\": \"2021-04-07T17:59:23.132Z\",\n" +
+        "      \"organization_id\": \"org_W30s833MRbjhHuWK\"\n" +
+        "    }\n" +
+        "  ],\n" +
+        "  \"start\": 0,\n" +
+        "  \"limit\": 4\n" +
+        "}\n";
+
+    @Test
+    public void shouldDeserializeWithoutTotals() throws Exception {
+        InvitationsPage page = fromJSON(jsonWithoutTotals, InvitationsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        InvitationsPage page = fromJSON(jsonWithTotals, InvitationsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getLimit(), is(4));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/MembersPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/MembersPageTest.java
@@ -1,0 +1,72 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class MembersPageTest extends JsonTest<MembersPage> {
+    private static final String jsonWithoutTotals = "[\n" +
+        "  {\n" +
+        "    \"user_id\": \"auth0|605a1f57cbeb2c0070fdf123\",\n" +
+        "    \"email\": \"dave@domain.com\",\n" +
+        "    \"picture\": \"https://domain.com/img.png\",\n" +
+        "    \"name\": \"dave\"\n" +
+        "  },\n" +
+        "  {\n" +
+        "    \"user_id\": \"auth0|605a0fc1bef67f006851a123\",\n" +
+        "    \"email\": \"eric@domain.com\",\n" +
+        "    \"picture\": \"https://domain.com/img.png\",\n" +
+        "    \"name\": \"eric\"\n" +
+        "  }\n" +
+        "]\n";
+
+    private static final String jsonWithTotals = "{\n" +
+        "  \"members\": [\n" +
+        "    {\n" +
+        "      \"user_id\": \"auth0|605a1f57cbeb2c0070fdf123\",\n" +
+        "      \"email\": \"dave@domain.com\",\n" +
+        "      \"picture\": \"https://domain.com/img.png\",\n" +
+        "      \"name\": \"dave\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"user_id\": \"auth0|605a0fc1bef67f006851a123\",\n" +
+        "      \"email\": \"eric@domain.com\",\n" +
+        "      \"picture\": \"https://domain.com/img.png\",\n" +
+        "      \"name\": \"eric\"\n" +
+        "    }\n" +
+        "  ],\n" +
+        "  \"start\": 0,\n" +
+        "  \"limit\": 20,\n" +
+        "  \"total\": 2\n" +
+        "}\n";
+
+
+    @Test
+    public void shouldDeserializeWithoutTotals() throws Exception {
+        MembersPage page = fromJSON(jsonWithoutTotals, MembersPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        MembersPage page = fromJSON(jsonWithTotals, MembersPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getTotal(), is(2));
+        assertThat(page.getLimit(), is(20));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+}
+

--- a/src/test/java/com/auth0/json/mgmt/organizations/MembersTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/MembersTest.java
@@ -1,0 +1,43 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class MembersTest extends JsonTest<Member> {
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        Member member = new Member();
+        member.setEmail("email@domain.com");
+        member.setName("name");
+        member.setPicture("https://myprofilepic.com");
+
+        String serialized = toJSON(member);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("email", "email@domain.com"));
+        assertThat(serialized, JsonMatcher.hasEntry("name", "name"));
+        assertThat(serialized, JsonMatcher.hasEntry("picture", "https://myprofilepic.com"));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        String memberJson = "{\n" +
+            "   \"user_id\": \"user_123\",\n" +
+            "   \"email\": \"fred@domain.com\",\n" +
+            "   \"picture\": \"https://profilepic.com/mypic.png\",\n" +
+            "   \"name\": \"fred\"\n" +
+            "}";
+
+        Member member = fromJSON(memberJson, Member.class);
+        assertThat(member, is(notNullValue()));
+        assertThat(member.getUserId(), is("user_123"));
+        assertThat(member.getEmail(), is("fred@domain.com"));
+        assertThat(member.getPicture(), is("https://profilepic.com/mypic.png"));
+        assertThat(member.getName(), is("fred"));
+
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsPageTest.java
@@ -1,0 +1,87 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+
+public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
+
+        private static final String jsonWithoutTotals = "[\n" +
+        "    {\n" +
+        "        \"id\": \"org_1\",\n" +
+        "        \"name\": \"org-1\",\n" +
+        "        \"display_name\": \"org 1\",\n" +
+        "        \"branding\": {\n" +
+        "            \"logo_url\": \"https://some-url.com/\",\n" +
+        "            \"colors\": {\n" +
+        "                \"primary\": \"#FF0000\",\n" +
+        "                \"page_background\": \"#FF0000\"\n" +
+        "            }\n" +
+        "        },\n" +
+        "        \"metadata\": {\n" +
+        "            \"key1\": \"val1\"\n" +
+        "        }\n" +
+        "    },\n" +
+        "    {\n" +
+        "        \"id\": \"org_2\",\n" +
+        "        \"name\": \"org-2\",\n" +
+        "        \"display_name\": \"org 2\"\n" +
+        "    }\n" +
+        "]";
+
+    private static final String jsonWithTotals = "{\n" +
+        "    \"organizations\": [\n" +
+        "        {\n" +
+        "            \"id\": \"org_2\",\n" +
+        "            \"name\": \"org-1\",\n" +
+        "            \"display_name\": \"org 1\",\n" +
+        "            \"branding\": {\n" +
+        "                \"logo_url\": \"https://some-url.com/\",\n" +
+        "                \"colors\": {\n" +
+        "                    \"primary\": \"#FF0000\",\n" +
+        "                    \"page_background\": \"#FF0000\"\n" +
+        "                }\n" +
+        "            },\n" +
+        "            \"metadata\": {\n" +
+        "                \"key1\": \"val1\"\n" +
+        "            }\n" +
+        "        },\n" +
+        "        {\n" +
+        "            \"id\": \"org_2\",\n" +
+        "            \"name\": \"org-2\",\n" +
+        "            \"display_name\": \"org 2\"\n" +
+        "        }\n" +
+        "    ],\n" +
+        "    \"start\": 0,\n" +
+        "    \"limit\": 20,\n" +
+        "    \"total\": 2\n" +
+        "}";
+
+    @Test
+    public void shouldDeserializeWithoutTotals() throws Exception {
+        OrganizationsPage page = fromJSON(jsonWithoutTotals, OrganizationsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        OrganizationsPage page = fromJSON(jsonWithTotals, OrganizationsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getTotal(), is(2));
+        assertThat(page.getLimit(), is(20));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsTest.java
@@ -1,0 +1,70 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class OrganizationsTest extends JsonTest<Organization> {
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        String orgJson = "{\n" +
+            "        \"id\": \"org_abc\",\n" +
+            "        \"name\": \"org-name\",\n" +
+            "        \"display_name\": \"display name\",\n" +
+            "        \"branding\": {\n" +
+            "            \"logo_url\": \"https://some-url.com/\",\n" +
+            "            \"colors\": {\n" +
+            "                \"primary\": \"#FF0000\",\n" +
+            "                \"page_background\": \"#FF0000\"\n" +
+            "            }\n" +
+            "        },\n" +
+            "        \"metadata\": {\n" +
+            "            \"key1\": \"val1\"\n" +
+            "        }\n" +
+            "    }";
+
+        Organization org = fromJSON(orgJson, Organization.class);
+        assertThat(org, is(notNullValue()));
+        assertThat(org.getId(), is("org_abc"));
+        assertThat(org.getName(), is("org-name"));
+        assertThat(org.getDisplayName(), is("display name"));
+        assertThat(org.getBranding(), is(notNullValue()));
+        assertThat(org.getBranding().getLogoUrl(), is("https://some-url.com/"));
+        assertThat(org.getBranding().getColors(), is(notNullValue()));
+        assertThat(org.getBranding().getColors().getPrimary(), is("#FF0000"));
+        assertThat(org.getBranding().getColors().getPageBackground(), is("#FF0000"));
+        assertThat(org.getMetadata(), is(notNullValue()));
+        assertThat(org.getMetadata().get("key1"), is("val1"));
+    }
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        Colors colors = new Colors();
+        colors.setPrimary("#FF0000");
+        colors.setPageBackground("#DD0000");
+
+        Branding branding = new Branding();
+        branding.setLogoUrl("https://some-url.com");
+        branding.setColors(colors);
+
+        Map<String, Object> metadata = Collections.singletonMap("key1", "val1");
+        Organization organization = new Organization("org-name");
+        organization.setDisplayName("display name");
+        organization.setBranding(branding);
+        organization.setMetadata(metadata);
+
+        String serialized = toJSON(organization);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("name", "org-name"));
+        assertThat(serialized, JsonMatcher.hasEntry("display_name", "display name"));
+        assertThat(serialized, JsonMatcher.hasEntry("metadata", metadata));
+        assertThat(serialized, JsonMatcher.hasEntry("branding", is(notNullValue())));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
@@ -22,6 +22,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         ticket.setEmail("me@auth0.com");
         ticket.setNewPassword("pass123");
         ticket.setMarkEmailAsVerified(true);
+        ticket.setOrganizationId("org_abc");
 
         String serialized = toJSON(ticket);
         assertThat(serialized, is(notNullValue()));
@@ -32,6 +33,7 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(serialized, JsonMatcher.hasEntry("connection_id", "12"));
         assertThat(serialized, JsonMatcher.hasEntry("email", "me@auth0.com"));
         assertThat(serialized, JsonMatcher.hasEntry("mark_email_as_verified", true));
+        assertThat(serialized, JsonMatcher.hasEntry("organization_id", "org_abc"));
     }
 
     @SuppressWarnings("deprecation")

--- a/src/test/resources/mgmt/invitation.json
+++ b/src/test/resources/mgmt/invitation.json
@@ -1,0 +1,15 @@
+{
+  "id": "uinv_Q3lgZXkis997Rqs3",
+  "client_id": "klCnbSD1U1YAIeLRdvEAFMwDoOX5bfsb",
+  "inviter": {
+    "name": "timmy"
+  },
+  "invitee": {
+    "email": "timmy@domain.com"
+  },
+  "invitation_url": "https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org",
+  "ticket_id": "U0o1uoXAl1VPkKbZla0a833soMUMOo1E",
+  "created_at": "2021-03-31T19:08:40.295Z",
+  "expires_at": "2021-04-07T19:08:40.295Z",
+  "organization_id": "org_W30s833MRbjhHuWK"
+}

--- a/src/test/resources/mgmt/invitations_list.json
+++ b/src/test/resources/mgmt/invitations_list.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "uinv_Q3lgZ0a99aY7Rqs3",
+    "client_id": "klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb",
+    "inviter": {
+      "name": "dave!"
+    },
+    "invitee": {
+      "email": "dave@domain.com"
+    },
+    "invitation_url": "https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org",
+    "ticket_id": "U0o1uoXAl1VPkKbZla0a833soMUMOo1E",
+    "created_at": "2021-03-31T19:08:40.295Z",
+    "expires_at": "2021-04-07T19:08:40.295Z",
+    "organization_id": "org_W30s833MRbjhHuWK"
+  },
+  {
+    "id": "uinv_Q3lgZ0a99aY7Rqs3",
+    "client_id": "klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb",
+    "inviter": {
+      "name": "jim.anderson@auth0.com"
+    },
+    "invitee": {
+      "email": "jim.anderson+android@auth0.com"
+    },
+    "app_metadata": {},
+    "user_metadata": {},
+    "invitation_url": "https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org",
+    "ticket_id": "U0o1uoXAl1VPkK0a940a833soMUMOo1E",
+    "created_at": "2021-03-31T17:59:23.132Z",
+    "expires_at": "2021-04-07T17:59:23.132Z",
+    "organization_id": "org_W30s833MRbjhHuWK"
+  }
+]

--- a/src/test/resources/mgmt/invitations_paged_list.json
+++ b/src/test/resources/mgmt/invitations_paged_list.json
@@ -1,0 +1,38 @@
+{
+  "invitations": [
+    {
+      "id": "uinv_Q3lgZ0a99aY7Rqs3",
+      "client_id": "klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb",
+      "inviter": {
+        "name": "dave!"
+      },
+      "invitee": {
+        "email": "dave@domain.com"
+      },
+      "invitation_url": "https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org",
+      "ticket_id": "U0o1uoXAl1VPkKbZla0a833soMUMOo1E",
+      "created_at": "2021-03-31T19:08:40.295Z",
+      "expires_at": "2021-04-07T19:08:40.295Z",
+      "organization_id": "org_W30s833MRbjhHuWK"
+    },
+    {
+      "id": "uinv_Q3lgZ0a99aY7Rqs3",
+      "client_id": "klCnbSD1U1Yd0333dvEAFMwDoOX5bfsb",
+      "inviter": {
+        "name": "jim.anderson@auth0.com"
+      },
+      "invitee": {
+        "email": "jim.anderson+android@auth0.com"
+      },
+      "app_metadata": {},
+      "user_metadata": {},
+      "invitation_url": "https://some-domain.auth0.com/login?invitation=U0o1uoXAl1VPkKbZlaRWEWJadkeed1E&organization=org_W3OHp07dfbjhHuWK&organization_name=timmy-org",
+      "ticket_id": "U0o1uoXAl1VPkK0a940a833soMUMOo1E",
+      "created_at": "2021-03-31T17:59:23.132Z",
+      "expires_at": "2021-04-07T17:59:23.132Z",
+      "organization_id": "org_W30s833MRbjhHuWK"
+    }
+  ],
+  "start": 0,
+  "limit": 4
+}

--- a/src/test/resources/mgmt/organization.json
+++ b/src/test/resources/mgmt/organization.json
@@ -1,0 +1,15 @@
+{
+  "id": "org_VSZmSnzd0m9ITBZ7",
+  "name": "org-1",
+  "display_name": "org 1",
+  "branding": {
+    "logo_uri": "https://some-url.com/",
+    "colors": {
+      "primary": "#FF0000",
+      "page_background": "#FF0000"
+    }
+  },
+  "metadata": {
+    "key1": "val1"
+  }
+}

--- a/src/test/resources/mgmt/organization_connection.json
+++ b/src/test/resources/mgmt/organization_connection.json
@@ -1,0 +1,4 @@
+{
+  "connection_id": "con_At4BWXhV3lKv82jd",
+  "assign_membership_on_login": false
+}

--- a/src/test/resources/mgmt/organization_connections_list.json
+++ b/src/test/resources/mgmt/organization_connections_list.json
@@ -1,0 +1,18 @@
+[
+  {
+    "connection_id": "con_At4BWXhV3lKv82jd",
+    "assign_membership_on_login": false,
+    "connection": {
+      "name": "google-oauth2",
+      "strategy": "google-oauth2"
+    }
+  },
+  {
+    "connection_id": "con_kai93HmEDCs8ai3d",
+    "assign_membership_on_login": true,
+    "connection": {
+      "name": "Username-Password-Authentication",
+      "strategy": "auth0"
+    }
+  }
+]

--- a/src/test/resources/mgmt/organization_connections_paged_list.json
+++ b/src/test/resources/mgmt/organization_connections_paged_list.json
@@ -1,0 +1,23 @@
+{
+  "enabled_connections": [
+    {
+      "connection_id": "con_At4BWXhV3lKv82jd",
+      "assign_membership_on_login": false,
+      "connection": {
+        "name": "google-oauth2",
+        "strategy": "google-oauth2"
+      }
+    },
+    {
+      "connection_id": "con_kai93HmEDCs8ai3d",
+      "assign_membership_on_login": true,
+      "connection": {
+        "name": "Username-Password-Authentication",
+        "strategy": "auth0"
+      }
+    }
+  ],
+  "start": 0,
+  "limit": 20,
+  "total": 2
+}

--- a/src/test/resources/mgmt/organization_member_roles_list.json
+++ b/src/test/resources/mgmt/organization_member_roles_list.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "rol_YMmM7zN6kqtus91",
+    "name": "test role",
+    "description": "role for testing"
+  }
+]

--- a/src/test/resources/mgmt/organization_member_roles_paged_list.json
+++ b/src/test/resources/mgmt/organization_member_roles_paged_list.json
@@ -1,0 +1,12 @@
+{
+  "roles": [
+    {
+      "id": "rol_YMmM7zN6kqtus91",
+      "name": "test role",
+      "description": "role for testing"
+    }
+  ],
+  "start": 0,
+  "limit": 50,
+  "total": 1
+}

--- a/src/test/resources/mgmt/organization_members_list.json
+++ b/src/test/resources/mgmt/organization_members_list.json
@@ -1,0 +1,20 @@
+[
+  {
+    "user_id": "auth0|605a1f57cbeb2c0070fdf123",
+    "email": "dave@domain.com",
+    "picture": "https://domain.com/img.png",
+    "name": "dave"
+  },
+  {
+    "user_id": "auth0|605a0fc1bef67f006851a123",
+    "email": "eric@domain.com",
+    "picture": "https://domain.com/img.png",
+    "name": "eric"
+  },
+  {
+    "user_id": "auth0|5f5103d20e634f006d25a123",
+    "email": "john@domain.com",
+    "picture": "https://domain.com/img.png",
+    "name": "john"
+  }
+]

--- a/src/test/resources/mgmt/organization_members_paged_list.json
+++ b/src/test/resources/mgmt/organization_members_paged_list.json
@@ -1,0 +1,25 @@
+{
+  "members": [
+    {
+      "user_id": "auth0|605a1f57cbeb2c0070fdf123",
+      "email": "dave@domain.com",
+      "picture": "https://domain.com/img.png",
+      "name": "dave"
+    },
+    {
+      "user_id": "auth0|605a0fc1bef67f006851a123",
+      "email": "eric@domain.com",
+      "picture": "https://domain.com/img.png",
+      "name": "eric"
+    },
+    {
+      "user_id": "auth0|5f5103d20e634f006d25a123",
+      "email": "john@domain.com",
+      "picture": "https://domain.com/img.png",
+      "name": "john"
+    }
+  ],
+  "start": 0,
+  "limit": 20,
+  "total": 3
+}

--- a/src/test/resources/mgmt/organizations_list.json
+++ b/src/test/resources/mgmt/organizations_list.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "org_VSZmSnzd0m9ITBZ7",
+    "name": "org-1",
+    "display_name": "org 1",
+    "branding": {
+      "logo_uri": "https://some-url.com/",
+      "colors": {
+        "primary": "#FF0000",
+        "page_background": "#FF0000"
+      }
+    },
+    "metadata": {
+      "key1": "val1"
+    }
+  },
+  {
+    "id": "org_W3OH9wtMRbjhHuWK",
+    "name": "org-2",
+    "display_name": "org 2"
+  }
+]

--- a/src/test/resources/mgmt/organizations_paged_list.json
+++ b/src/test/resources/mgmt/organizations_paged_list.json
@@ -1,0 +1,27 @@
+{
+  "organizations": [
+    {
+      "id": "org_VSZmSnzd0m9ITBZ7",
+      "name": "org-1",
+      "display_name": "org 1",
+      "branding": {
+        "logo_uri": "https://some-url.com/",
+        "colors": {
+          "primary": "#FF0000",
+          "page_background": "#FF0000"
+        }
+      },
+      "metadata": {
+        "key1": "val1"
+      }
+    },
+    {
+      "id": "org_W3OH9wtMRbjhHuWK",
+      "name": "org-2",
+      "display_name": "org 2"
+    }
+  ],
+  "start": 0,
+  "limit": 20,
+  "total": 2
+}


### PR DESCRIPTION
### Changes

Adds and updates endpoints to manage Organizations through the MGMT APIs.

#### Endpoints Added

**Organizations**
POST Organization
PATCH Organization
GET Organizations
GET Organization
GET Organization (by name)
DELETE Organization

**Connections**
POST Organization Connection
PATCH Organization Connection
GET Organization Connections
GET Organization Connection
DELETE Organization Connection

**Members**
POST Organization Members
GET Organization Members
DELETE Organization Members

**Member Roles**
POST Organization Member Roles
GET Organization Member Roles
DELETE Organization Member Roles

**Invitations**
POST Organization Invitations
GET Organization Invitations
GET Organization Invitation
DELETE Organization Invitations

**Users**
GET User organizations

---- 

#### Endpoints Updated

**Email Verification**
POST Email Verification with org ID

**Tickets**
POST Password Change Ticket with org ID

**Clients**
POST Client with organization configuration
PATCH Client with organization configuration
GET Client with organization configuration
GET Clients with organization configuration

----

### Testing

In addition to including unit tests for the added models and APIs, I've also tested that the endpoints work as expected using a tenant with Organizations enabled.