### PR TITLE
Fix `NoSuchMethodError` when projects have OkHttp 3 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,41 +31,6 @@ implementation 'com.auth0:auth0:1.28.0'
 
 The Auth0 Authentication API and User's Management API are available for Android in the `auth0.android` library. Check https://github.com/auth0/auth0.android for more information.
 
-### Using with Spring Dependency Management
-
-This library use OkHttp version 4 as the networking client used to make requests to the Auth0 Authentication and Management APIs. If you are using Spring's depdendency management, you may encounter `java.lang.NoSuchMethodError` errors when making requests, related to Spring's dependency management using OkHttp 3. To resolve this issue, you can override Spring's dependency on OkHttp:
-
-Maven ([more information](https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/)):
-```xml
-<dependencyManagement>
-		<dependencies>
-			<!--  Needed to avoid conflict with OkHttp being used in auth0-java and okhttp3 being used by spring -->
-			<dependency>
-				<groupId>com.squareup.okhttp3</groupId>
-				<artifactId>okhttp</artifactId>
-				<version>4.9.0</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-```
-
-Gradle ([more information](https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/)):
-```java
-plugins {
-  ...
-  // spring dependency plugin will define okhttp3, which will have issues with okhttp4 in auth0-java
-  id "io.spring.dependency-management" version "1.0.10.RELEASE"
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "com.squareup.okhttp3:okhttp-bom:4.9.0"
-    }
-}
-```
-
-More information can be found in this [Github issue](https://github.com/auth0/auth0-java/issues/324).
-
 ## Auth API
 
 The implementation is based on the [Authentication API Docs](https://auth0.com/docs/api/authentication).

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -42,12 +42,13 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected RequestBody createRequestBody() throws IOException {
         if (body == null && parameters.isEmpty()) {
             return null;
         }
         byte[] jsonBody = mapper.writeValueAsBytes(body != null ? body : parameters);
-        return RequestBody.create(jsonBody, MediaType.parse(CONTENT_TYPE_APPLICATION_JSON));
+        return RequestBody.create(MediaType.parse(CONTENT_TYPE_APPLICATION_JSON), jsonBody);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -48,6 +48,8 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
             return null;
         }
         byte[] jsonBody = mapper.writeValueAsBytes(body != null ? body : parameters);
+        // Use OkHttp v3 signature to ensure binary compatibility between v3 and v4
+        // https://github.com/auth0/auth0-java/issues/324
         return RequestBody.create(MediaType.parse(CONTENT_TYPE_APPLICATION_JSON), jsonBody);
     }
 

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -20,6 +20,8 @@ public class EmptyBodyRequest<T> extends CustomRequest<T> {
     @Override
     @SuppressWarnings("deprecation")
     protected RequestBody createRequestBody() {
+        // Use OkHttp v3 signature to ensure binary compatibility between v3 and v4
+        // https://github.com/auth0/auth0-java/issues/324
         return RequestBody.create(null, new byte[0]);
     }
 

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -18,8 +18,9 @@ public class EmptyBodyRequest<T> extends CustomRequest<T> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected RequestBody createRequestBody() {
-        return RequestBody.create(new byte[0], null);
+        return RequestBody.create(null, new byte[0]);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -72,6 +72,7 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public MultipartRequest<T> addPart(String name, File file, String mediaType) {
         assertNotNull(name, "name");
         assertNotNull(name, "file");
@@ -79,7 +80,7 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
             throw new IllegalArgumentException("Failed to add part because the file specified cannot be found.");
         }
         bodyBuilder.addFormDataPart(name, file.getName(),
-                RequestBody.create(file, MediaType.parse(mediaType)));
+            RequestBody.create(MediaType.parse(mediaType), file));
         partsCount++;
         return this;
     }

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -79,6 +79,8 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
         if (!file.exists()) {
             throw new IllegalArgumentException("Failed to add part because the file specified cannot be found.");
         }
+        // Use OkHttp v3 signature to ensure binary compatibility between v3 and v4
+        // https://github.com/auth0/auth0-java/issues/324
         bodyBuilder.addFormDataPart(name, file.getName(),
             RequestBody.create(MediaType.parse(mediaType), file));
         partsCount++;


### PR DESCRIPTION
### Changes

After updating to OkHttp v4, customers may experience `NoSuchMethodError` when making requests with this library, if OkHttp v3 is taking precedence on the runtime classpath. Given that OkHttp v4 is binary compatible with OkHttp v3, this change reverts to using (now-deprecated) OkHttp methods that do not exist in v4.

We cannot guarantee that we will never use any OkHttp v4 APIs, and the resolution to such issues may require managing the dependencies as discussed in #324. But for now, we can alleviate this issue for the majority of customers with this change.

### References

- https://square.github.io/okhttp/upgrading_to_okhttp_4/
- #324 