### PR TITLE
Adds method to get an organization's enabled connection and update JavaDocs

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -297,6 +297,34 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
+     * Get an organization's connection.
+     *
+     * @param orgId the ID of the organization
+     * @param connectionId the ID of the connection
+     * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections_by_connectionId">https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections_by_connectionId</a>
+     */
+    public Request<EnabledConnection> getConnection(String orgId, String connectionId) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(connectionId, "connection ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("enabled_connections")
+            .addPathSegment(connectionId)
+            .build()
+            .toString();
+
+        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, url, "GET", new TypeReference<EnabledConnection>() {
+        });
+        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
      * Add a connection to an organization. A token with {@code create:organization_connections} scope is required.
      *
      * @param orgId the ID of the organization

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -35,10 +35,12 @@ public class OrganizationsEntity extends BaseManagementEntity {
     // Organizations Entity
 
     /**
-     * Get all organizations. A token with read:organizations scope is required.
+     * Get all organizations. A token with {@code read:organizations} scope is required.
      *
      * @param filter an optional pagination filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations">https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations</a>
      */
     public Request<OrganizationsPage> list(PageFilter filter) {
         HttpUrl.Builder builder = baseUrl
@@ -56,10 +58,12 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Get an organization. A token with read:organizations scope is required.
+     * Get an organization. A token with {@code read:organizations} scope is required.
      *
      * @param orgId the ID of the organization to retrieve
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations_by_id">https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations_by_id</a>
      */
     public Request<Organization> get(String orgId) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -79,10 +83,12 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Get an organization. A token with read:organizations scope is required.
+     * Get an organization. A token with {@code read:organizations} scope is required.
      *
      * @param orgName the name of the organization to retrieve
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_name_by_name">https://auth0.com/docs/api/management/v2#!/Organizations/get_name_by_name</a>
      */
     public Request<Organization> getByName(String orgName) {
         Asserts.assertNotNull(orgName, "organization name");
@@ -103,10 +109,12 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Create an organization. A token with create:organizations scope is required.
+     * Create an organization. A token with {@code create:organizations} scope is required.
      *
      * @param organization the organization to create
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_organizations">https://auth0.com/docs/api/management/v2#!/Organizations/post_organizations</a>
      */
     public Request<Organization> create(Organization organization) {
         Asserts.assertNotNull(organization, "organization");
@@ -126,11 +134,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Update an organization. A token with update:organizations scope is required.
+     * Update an organization. A token with {@code update:organizations} scope is required.
      *
      * @param orgId the ID of the organization to update
      * @param organization the updated organization
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/patch_organizations_by_id">https://auth0.com/docs/api/management/v2#!/Organizations/patch_organizations_by_id</a>
      */
     public Request<Organization> update(String orgId, Organization organization) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -152,10 +162,12 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Delete an organization. A token with delete:organizations scope is required.
+     * Delete an organization. A token with {@code delete:organizations} scope is required.
      *
      * @param orgId the ID of the organization to delete
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_organizations_by_id">https://auth0.com/docs/api/management/v2#!/Organizations/delete_organizations_by_id</a>
      */
     public Request delete(String orgId) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -175,11 +187,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     // Organization members
 
     /**
-     * Get the members of an organization. A token with read:organization_members scope is required.
+     * Get the members of an organization. A token with {@code read:organization_members} scope is required.
      *
      * @param orgId the ID of the organization
      * @param filter an optional pagination filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_members">https://auth0.com/docs/api/management/v2#!/Organizations/get_members</a>
      */
     public Request<MembersPage> getMembers(String orgId, PageFilter filter) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -200,11 +214,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Add members to an organization. A token with create:organization_members scope is required.
+     * Add members to an organization. A token with {@code create:organization_members} scope is required.
      *
      * @param orgId the ID of the organization
      * @param members The members to add
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_members">https://auth0.com/docs/api/management/v2#!/Organizations/post_members</a>
      */
     public Request addMembers(String orgId, Members members) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -225,11 +241,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Delete members from an organization. A token with delete:organization_members scope is required.
+     * Delete members from an organization. A token with {@code delete:organization_members} scope is required.
      *
      * @param orgId the ID of the organization
      * @param members The members to remove
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_members">https://auth0.com/docs/api/management/v2#!/Organizations/delete_members</a>
      */
     public Request deleteMembers(String orgId, Members members) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -252,11 +270,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     // Organization connections
 
     /**
-     * Get the connections of an organization. A token with read:organization_connections scope is required.
+     * Get the connections of an organization. A token with {@code read:organization_connections} scope is required.
      *
      * @param orgId the ID of the organization
      * @param filter an optional pagination filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections">https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections</a>
      */
     public Request<EnabledConnectionsPage> getConnections(String orgId, PageFilter filter) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -277,11 +297,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Add a connection to an organization. A token with create:organization_connections scope is required.
+     * Add a connection to an organization. A token with {@code create:organization_connections} scope is required.
      *
      * @param orgId the ID of the organization
      * @param connection The connection to add
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_enabled_connections">https://auth0.com/docs/api/management/v2#!/Organizations/post_enabled_connections</a>
      */
     public Request<EnabledConnection> addConnection(String  orgId, EnabledConnection connection) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -303,11 +325,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Delete a connection from an organization. A token with delete:organization_connections scope is required.
+     * Delete a connection from an organization. A token with {@code delete:organization_connections} scope is required.
      *
      * @param orgId the ID of the organization
      * @param connectionId the ID of the connection to delete
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_enabled_connections_by_connectionId">https://auth0.com/docs/api/management/v2#!/Organizations/delete_enabled_connections_by_connectionId</a>
      */
     public Request deleteConnection(String  orgId, String connectionId) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -328,12 +352,14 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Update a connection of an organization. A token with update:organization_connections scope is required.
+     * Update a connection of an organization. A token with {@code update:organization_connections} scope is required.
      *
      * @param orgId the ID of the organization
      * @param connectionId the ID of the connection to update
      * @param connection the connection to update
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/patch_enabled_connections_by_connectionId">https://auth0.com/docs/api/management/v2#!/Organizations/patch_enabled_connections_by_connectionId</a>
      */
     public Request<EnabledConnection> updateConnection(String orgId, String connectionId, EnabledConnection connection) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -359,12 +385,14 @@ public class OrganizationsEntity extends BaseManagementEntity {
     // Org roles
 
     /**
-     * Get the roles for a member of an organization. A token with read:organization_members scope is required.
+     * Get the roles for a member of an organization. A token with {@code read:organization_members} scope is required.
      *
      * @param orgId the ID of the organization
      * @param userId the ID of the user
      * @param filter an optional pagination filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_organization_member_roles">https://auth0.com/docs/api/management/v2#!/Organizations/get_organization_member_roles</a>
      */
     public Request<RolesPage> getRoles(String orgId, String userId, PageFilter filter) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -388,12 +416,14 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Add roles for a member of an organization. A token with create:organization_member_roles scope is required.
+     * Add roles for a member of an organization. A token with {@code create:organization_member_roles} scope is required.
      *
      * @param orgId the ID of the organization
      * @param userId the ID of the user
      * @param roles the roles to add
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_organization_member_roles">https://auth0.com/docs/api/management/v2#!/Organizations/post_organization_member_roles</a>
      */
     public Request addRoles(String orgId, String userId, Roles roles) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -417,12 +447,14 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Delete roles from a member of an organization. A token with delete:organization_member_roles scope is required.
+     * Delete roles from a member of an organization. A token with {@code delete:organization_member_roles} scope is required.
      *
      * @param orgId the ID of the organization
      * @param userId the ID of the user
      * @param roles the roles to delete
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_organization_member_roles">https://auth0.com/docs/api/management/v2#!/Organizations/delete_organization_member_roles</a>
      */
     public Request deleteRoles(String orgId, String userId, Roles roles) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -448,11 +480,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     // Organization invitations
 
     /**
-     * Create an invitation. A token with create:organization_invitations scope is required.
+     * Create an invitation. A token with {@code create:organization_invitations} scope is required.
      *
      * @param orgId the ID of the organization
      * @param invitation the invitation to create
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_invitations">https://auth0.com/docs/api/management/v2#!/Organizations/post_invitations</a>
      */
     public Request<Invitation> createInvitation(String orgId, Invitation invitation) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -475,12 +509,14 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Get an invitation. A token with read:organization_invitations scope is required.
+     * Get an invitation. A token with {@code read:organization_invitations} scope is required.
      *
      * @param orgId the ID of the organization
      * @param invitationId the ID of the invitation
      * @param filter an optional result filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations_by_invitation_id">https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations_by_invitation_id</a>
      */
     public Request<Invitation> getInvitation(String orgId, String invitationId, FieldsFilter filter) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -503,11 +539,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Gets all invitations for an organization. A token with read:organization_invitations scope is required.
+     * Gets all invitations for an organization. A token with {@code read:organization_invitations} scope is required.
      *
      * @param orgId the ID of the organization
      * @param filter an optional result filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations">https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations</a>
      */
     public Request<InvitationsPage> getInvitations(String orgId, InvitationsFilter filter) {
         Asserts.assertNotNull(orgId, "organization ID");
@@ -528,11 +566,13 @@ public class OrganizationsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Delete an invitation. A token with delete:organization_invitations scope is required.
+     * Delete an invitation. A token with {@code delete:organization_invitations`} scope is required.
      *
      * @param orgId the ID of the organization
      * @param invitationId the ID of the invitation to delete
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_invitations_by_invitation_id">https://auth0.com/docs/api/management/v2#!/Organizations/delete_invitations_by_invitation_id</a>
      */
     public Request deleteInvitation(String orgId, String invitationId) {
         Asserts.assertNotNull(orgId, "organization ID");

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -579,11 +579,13 @@ public class UsersEntity extends BaseManagementEntity {
 
     /**
      * Get the organizations a user belongs to.
-     * A token with read:users and read:organizations is required.
+     * A token with {@code read:users} and {@code read:organizations} is required.
      *
      * @param userId the user ID
      * @param filter an optional pagination filter
      * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Users/get_organizations">https://auth0.com/docs/api/management/v2#!/Users/get_organizations</a>
      */
     public Request<OrganizationsPage> getOrganizations(String userId, PageFilter filter) {
         Asserts.assertNotNull(userId, "user ID");

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -440,6 +440,36 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldThrowOnGetConnectionWhenOrgIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("organization ID");
+        api.organizations().getConnection(null, "con_id");
+    }
+
+    @Test
+    public void shouldThrowOnGetConnectionWhenConnectionIdNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("connection ID");
+        api.organizations().getConnection("org_abc", null);
+    }
+
+    @Test
+    public void shouldGetConnection() throws Exception {
+        Request<EnabledConnection> request = api.organizations().getConnection("org_123", "con_abc");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_CONNECTION, 200);
+        EnabledConnection response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/enabled_connections/con_abc"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
     public void shouldThrowOnAddConnectionWhenOrgIdNull() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("organization ID");


### PR DESCRIPTION
### Changes

* Adds a method to [get an organization's connection by ID](https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections_by_connectionId)
* Adds links to the API documentation for new Organizations endpoints to the JavaDocs

### References

* Related to #341