### PR TITLE
[SDK-2458] Updated guidance for working with tokens and organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,8 @@ String url = auth.authorizeUrl("https://me.auth0.com/callback")
     .build();
 ```
 
-**Important!** When logging into an organization, it is important to ensure the `org_id` claim of the ID Token matches the expected organization value. The `IdTokenVerifier` can be configured with an expected `org_id` claim value:
+**Important!** When logging into an organization, it is important to ensure the `org_id` claim of the ID Token matches the expected organization value. The `IdTokenVerifier` can be configured with an expected `org_id` claim value, as the example below demonstrates.
+For more information, please read [Work with Tokens and Organizations](https://auth0.com/docs/organizations/using-tokens) on Auth0 Docs.
 ```java
 IdTokenVerifier.init("{ISSUER}", "{AUDIENCE}", signatureVerifier)
     .withOrganization("{ORG_ID}")

--- a/README.md
+++ b/README.md
@@ -305,13 +305,13 @@ String url = auth.authorizeUrl("https://me.auth0.com/callback")
     .build();
 ```
 
-> When logging into an organization, it is important to ensure the `org_id` claim of the ID Token matches the expected organization value. The `IdTokenVerifier` can be configured with an expected `org_id` claim value:
->```java
->IdTokenVerifier.init("{ISSUER}", "{AUDIENCE}", signatureVerifier)
->    .withOrganization("{ORG_ID}")
->    .build()
->    .verify(jwt);
->```
+**Important!** When logging into an organization, it is important to ensure the `org_id` claim of the ID Token matches the expected organization value. The `IdTokenVerifier` can be configured with an expected `org_id` claim value:
+```java
+IdTokenVerifier.init("{ISSUER}", "{AUDIENCE}", signatureVerifier)
+    .withOrganization("{ORG_ID}")
+    .build()
+    .verify(jwt);
+```
 
 ### Accept user invitations
 


### PR DESCRIPTION
### Changes

* Removes blockquote from org_id claim validation documentation, to ensure the information is highlighted rather than appearing as an afterthought
* Links to the [Auth0 Tokens and Orgs docs](https://auth0.com/docs/organizations/using-tokens)