### PR TITLE
Remove summary of Orgs feature from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,14 +284,6 @@ try {
 
 [Organizations](https://auth0.com/docs/organizations) is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
 
-Using Organizations, you can:
-
-- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
-- Manage their membership in a variety of ways, including user invitation.
-- Configure branded, federated login flows for each organization.
-- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
-- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
-
 Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
 
 #### Log in to an organization


### PR DESCRIPTION
Now that the Organizations feature is GA, removing the feature overview documentation from the README; that information can be found in the linked Auth0 docs.