### PR TITLE
[SDK-2519] Remove commons-codec dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
-    implementation "commons-codec:commons-codec:1.15"
-    implementation "com.auth0:java-jwt:3.12.1"
+    implementation "com.auth0:java-jwt:3.14.0"
 
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"
     testImplementation "org.mockito:mockito-core:3.7.7"

--- a/src/main/java/com/auth0/net/Telemetry.java
+++ b/src/main/java/com/auth0/net/Telemetry.java
@@ -2,8 +2,8 @@ package com.auth0.net;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.codec.binary.Base64;
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +64,7 @@ public class Telemetry {
         String tmpValue;
         try {
             String json = new ObjectMapper().writeValueAsString(values);
-            tmpValue = Base64.encodeBase64URLSafeString(json.getBytes());
+            tmpValue = Base64.getUrlEncoder().encodeToString(json.getBytes());
         } catch (JsonProcessingException e) {
             tmpValue = null;
             e.printStackTrace();

--- a/src/test/java/com/auth0/net/TelemetryTest.java
+++ b/src/test/java/com/auth0/net/TelemetryTest.java
@@ -2,10 +2,10 @@ package com.auth0.net;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
@@ -20,7 +20,7 @@ public class TelemetryTest {
         assertThat(value, is(notNullValue()));
         assertThat(value, is("eyJuYW1lIjoiYXV0aDAtamF2YSIsImVudiI6eyJqYXZhIjoiMS44In0sInZlcnNpb24iOiIxLjAuMCJ9"));
 
-        String completeString = new String(Base64.decodeBase64(value), StandardCharsets.UTF_8);
+        String completeString = new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
         TypeReference<Map<String, Object>> mapType = new TypeReference<Map<String, Object>>() {
         };
         Map<String, Object> complete = new ObjectMapper().readValue(completeString, mapType);
@@ -38,7 +38,7 @@ public class TelemetryTest {
         assertThat(value, is(notNullValue()));
         assertThat(value, is("eyJuYW1lIjoibG9jayIsImVudiI6eyJqYXZhIjoiMS44IiwiYXV0aDAtamF2YSI6IjIuMS4zIn0sInZlcnNpb24iOiIxLjAuMCJ9"));
 
-        String completeString = new String(Base64.decodeBase64(value), StandardCharsets.UTF_8);
+        String completeString = new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
         TypeReference<Map<String, Object>> mapType = new TypeReference<Map<String, Object>>() {
         };
         Map<String, Object> complete = new ObjectMapper().readValue(completeString, mapType);


### PR DESCRIPTION
### Changes

Removes the `commons-codec` dependency, which was used for Base64 encoding/decoding, and replaces it with Java's built-in Base64 support.