### PR TITLE
[SDK-2537] Add missing parameters to Ticket entities

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/tickets/EmailVerificationTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/EmailVerificationTicket.java
@@ -25,6 +25,10 @@ public class EmailVerificationTicket {
     private String ticket;
     @JsonProperty("includeEmailInRedirect")
     private Boolean includeEmailInRedirect;
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("organization_id")
+    private String organizationId;
     @JsonProperty("identity")
     private EmailVerificationIdentity identity;
 
@@ -70,6 +74,31 @@ public class EmailVerificationTicket {
      */
     public void setIncludeEmailInRedirect(Boolean includeEmailInRedirect) {
         this.includeEmailInRedirect = includeEmailInRedirect;
+    }
+
+    /**
+     * Sets the ID of the client. If provided for tenants using New Universal Login experience, the user will be prompted
+     * to redirect to the default login route of the corresponding application once the ticket is used.
+     *
+     * @param clientId the ID of the client
+     *
+     * @see <a href="https://auth0.com/docs/universal-login/configure-default-login-routes#completing-the-password-reset-flow">Configuring Default Login Routes</a>  for more details.
+     */
+    @JsonProperty("client_id")
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * Sets the ID of the Organization. If provided, organization parameters will be made available to the email template
+     * and organization branding will be applied to the prompt. In addition, the redirect link in the prompt will include
+     * {@code organization_id} and {@code organization_name} query string parameters.
+     *
+     * @param organizationId the ID of the organization
+     */
+    @JsonProperty("organization_id")
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
     }
 
     /**

--- a/src/main/java/com/auth0/json/mgmt/tickets/EmailVerificationTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/EmailVerificationTicket.java
@@ -82,7 +82,7 @@ public class EmailVerificationTicket {
      *
      * @param clientId the ID of the client
      *
-     * @see <a href="https://auth0.com/docs/universal-login/configure-default-login-routes#completing-the-password-reset-flow">Configuring Default Login Routes</a>  for more details.
+     * @see <a href="https://auth0.com/docs/universal-login/configure-default-login-routes#completing-the-password-reset-flow">Configuring Default Login Routes</a>
      */
     @JsonProperty("client_id")
     public void setClientId(String clientId) {

--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -59,7 +59,7 @@ public class PasswordChangeTicket {
 
     /**
      * Setter for the client_id
-     * @param clientId
+     * @param clientId the ID of the client to set
      */
     public void setClientId(String clientId) {
         this.clientId = clientId;

--- a/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/tickets/PasswordChangeTicket.java
@@ -32,6 +32,10 @@ public class PasswordChangeTicket {
     private Boolean markEmailAsVerified;
     @JsonProperty("organization_id")
     private String orgId;
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("includeEmailInRedirect")
+    private Boolean includeEmailInRedirect;
 
     @JsonCreator
     public PasswordChangeTicket(@JsonProperty("user_id") String userId) {
@@ -44,13 +48,25 @@ public class PasswordChangeTicket {
     }
 
     /**
-     * Setter for the id of the user this ticket is meant to.
+     * Setter for the id of the user for whom the ticket should be created.
      *
      * @param userId the user id to set.
      */
     @JsonProperty("user_id")
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    /**
+     * Setter for the client_id
+     * @param clientId
+     */
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setIncludeEmailInRedirect(Boolean includeEmailInRedirect) {
+        this.includeEmailInRedirect = includeEmailInRedirect;
     }
 
     /**

--- a/src/test/java/com/auth0/json/mgmt/tickets/EmailVerificationTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/EmailVerificationTicketTest.java
@@ -22,6 +22,8 @@ public class EmailVerificationTicketTest extends JsonTest<EmailVerificationTicke
         ticket.setResultUrl("https://page.auth0.com/result");
         ticket.setTTLSeconds(36000);
         ticket.setIncludeEmailInRedirect(true);
+        ticket.setClientId("client_abc");
+        ticket.setOrganizationId("org_abc");
 
         String serialized = toJSON(ticket);
         assertThat(serialized, is(notNullValue()));
@@ -29,6 +31,8 @@ public class EmailVerificationTicketTest extends JsonTest<EmailVerificationTicke
         assertThat(serialized, JsonMatcher.hasEntry("result_url", "https://page.auth0.com/result"));
         assertThat(serialized, JsonMatcher.hasEntry("ttl_sec", 36000));
         assertThat(serialized, JsonMatcher.hasEntry("includeEmailInRedirect", true));
+        assertThat(serialized, JsonMatcher.hasEntry("client_id", "client_abc"));
+        assertThat(serialized, JsonMatcher.hasEntry("organization_id", "org_abc"));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tickets/PasswordChangeTicketTest.java
@@ -23,6 +23,8 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         ticket.setNewPassword("pass123");
         ticket.setMarkEmailAsVerified(true);
         ticket.setOrganizationId("org_abc");
+        ticket.setClientId("client_abc");
+        ticket.setIncludeEmailInRedirect(false);
 
         String serialized = toJSON(ticket);
         assertThat(serialized, is(notNullValue()));
@@ -34,6 +36,8 @@ public class PasswordChangeTicketTest extends JsonTest<PasswordChangeTicket> {
         assertThat(serialized, JsonMatcher.hasEntry("email", "me@auth0.com"));
         assertThat(serialized, JsonMatcher.hasEntry("mark_email_as_verified", true));
         assertThat(serialized, JsonMatcher.hasEntry("organization_id", "org_abc"));
+        assertThat(serialized, JsonMatcher.hasEntry("client_id", "client_abc"));
+        assertThat(serialized, JsonMatcher.hasEntry("includeEmailInRedirect", false));
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
### Changes

Adds missing body parameters to [create an email verification ticket](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification) and to [create a password change ticket](https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change).

The following fields were added to the `EmailVerificationTicket` entity:
* `client_id`
* `organization_id`

The following fields were added to the `PasswordChangeTicket` entity:
* `client_id`
* `includeEmailInRedirect`

This resolves #351 