### PR TITLE
[SDK-2550] Add networking client timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,24 @@ Requests can be executed asynchronously, using the `executeAsync()` method, whic
 ## API Clients Recommendations
 The SDK implements a custom networking stack on top of the **OkHttp** library. The [official recommendation](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#okhttpclients-should-be-shared) from Square is to re-use as much as possible these clients. However, it's not possible to pass an existing `OkHttpClient` instance to our `AuthAPI` and `ManagementAPI` clients. 
 
+The networking client used by both the `AuthAPI` and `ManagementAPI` clients can be configured through the `HttpOptions`, which enables custom timeout configuration and proxy support:
+
+```java
+HttpOptions options = new HttpOptions();
+
+// configure timeouts; default is ten seconds for both connect and read timeouts:
+options.setConnectTimeout(5);
+options.setReadTimeout(15);
+
+// configure proxy:
+Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("{IP-ADDRESS}", {PORT}));
+ProxyOptions proxyOptions = new ProxyOptions(proxy);
+options.setProxyOptions(proxyOptions);
+
+// create client
+AuthAPI authAPI = new AuthAPI("{CLIENT_ID}", "{CLIENT_SECRET}", options);
+```
+
 Whenever you instantiate a client, a new `OkHttpClient` instance is created internally to handle the network requests. This instance is not directly exposed for customization. In order to reduce resource consumption, make use of the _singleton pattern_ to keep a single instance of this SDK's API client during the lifecycle of your application.
 
 For the particular case of the `ManagementAPI` client, if the token you've originally set has expired or you require to change its scopes, you can update the client's token with the `setApiToken(String)` method.    

--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -6,6 +6,8 @@ package com.auth0.client;
 public class HttpOptions {
 
     private ProxyOptions proxyOptions;
+    private int connectTimeout = 10;
+    private int readTimeout = 10;
 
     /**
      * Getter for the Proxy configuration options
@@ -23,5 +25,45 @@ public class HttpOptions {
      */
     public void setProxyOptions(ProxyOptions proxyOptions) {
         this.proxyOptions = proxyOptions;
+    }
+
+
+    /**
+     * @return the connect timeout, in seconds
+     */
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * Sets the value of the connect timeout, in seconds. Defaults to ten seconds. A value of zero results in no connect timeout.
+     * Negative numbers will be treated as zero.
+     * @param connectTimeout the value of the connect timeout to use.
+     */
+    public void setConnectTimeout(int connectTimeout) {
+        if (connectTimeout < 0) {
+            connectTimeout = 0;
+        }
+        this.connectTimeout = connectTimeout;
+    }
+
+    /**
+     * @return the read timeout, in seconds
+     */
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * Sets the value of the read timeout, in seconds. Defaults to ten seconds. A value of zero results in no read timeout.
+     * Negative numbers will be treated as zero.
+     *
+     * @param readTimeout the value of the read timeout to use.
+     */
+    public void setReadTimeout(int readTimeout) {
+        if (readTimeout < 0) {
+            readTimeout = 0;
+        }
+        this.readTimeout = readTimeout;
     }
 }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -14,6 +14,7 @@ import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class that provides an implementation of some of the Authentication and Authorization API methods defined in https://auth0.com/docs/api/authentication.
@@ -131,6 +132,8 @@ public class AuthAPI {
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
+                .connectTimeout(options.getConnectTimeout(), TimeUnit.SECONDS)
+                .readTimeout(options.getReadTimeout(), TimeUnit.SECONDS)
                 .build();
     }
 

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -10,6 +10,7 @@ import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class that provides an implementation of the Management API methods defined in https://auth0.com/docs/api/management/v2.
@@ -102,6 +103,8 @@ public class ManagementAPI {
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
+                .connectTimeout(options.getConnectTimeout(), TimeUnit.SECONDS)
+                .readTimeout(options.getReadTimeout(), TimeUnit.SECONDS)
                 .build();
     }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -106,6 +106,35 @@ public class AuthAPITest {
     }
 
     @Test
+    public void shouldUseDefaultTimeValues() {
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+        assertThat(api.getClient().connectTimeoutMillis(), is(10 * 1000));
+        assertThat(api.getClient().readTimeoutMillis(), is(10 * 1000));
+    }
+
+    @Test
+    public void shouldUseConfiguredTimeoutValues() {
+        HttpOptions options = new HttpOptions();
+        options.setConnectTimeout(20);
+        options.setReadTimeout(30);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+
+        assertThat(api.getClient().connectTimeoutMillis(), is(20 * 1000));
+        assertThat(api.getClient().readTimeoutMillis(), is(30 * 1000));
+    }
+
+    @Test
+    public void shouldUseZeroIfNegativeTimoutConfigured() {
+        HttpOptions options = new HttpOptions();
+        options.setConnectTimeout(-1);
+        options.setReadTimeout(-10);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+
+        assertThat(api.getClient().connectTimeoutMillis(), is(0));
+        assertThat(api.getClient().readTimeoutMillis(), is(0));
+    }
+
+    @Test
     public void shouldNotUseProxyByDefault() throws Exception {
         AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
         assertThat(api.getClient().proxy(), is(nullValue()));

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -140,6 +140,34 @@ public class ManagementAPITest {
     }
 
     @Test
+    public void shouldUseDefaultTimeoutIfNotSpecified() {
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
+        assertThat(api.getClient().connectTimeoutMillis(), is(10 * 1000));
+        assertThat(api.getClient().readTimeoutMillis(), is(10 * 1000));
+    }
+
+    @Test
+    public void shouldUseZeroIfNegativeTimeoutConfigured() {
+        HttpOptions options = new HttpOptions();
+        options.setConnectTimeout(-1);
+        options.setReadTimeout(-1);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().connectTimeoutMillis(), is(0));
+        assertThat(api.getClient().readTimeoutMillis(), is(0));
+
+    }
+
+    @Test
+    public void shouldSetTimeoutsIfConfigured() {
+        HttpOptions options = new HttpOptions();
+        options.setConnectTimeout(20);
+        options.setReadTimeout(30);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().connectTimeoutMillis(), is(20 * 1000));
+        assertThat(api.getClient().readTimeoutMillis(), is(30 * 1000));
+    }
+
+    @Test
     public void shouldNotUseProxyByDefault() throws Exception {
         ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
         assertThat(api.getClient().proxy(), is(nullValue()));


### PR DESCRIPTION
### Changes

Adds the ability to configure connect and read timeouts for both the `ManagementAPI` and `AuthAPI` clients through the existing `HttpOptions`:

```java
HttpOptions options = new HttpOptions();
options.setConnectTimeout(15); // default is 10 seconds
options.setReadTimeout(5); // default is 10 seconds

AuthAPI authAPI = new AuthAPI("{CLIENT_ID}", "{CLIENT_SECRET}", options);
ManagementAPI mgmtAPI = new ManagementAPI("{DOMAIN}", "{TOKEN}", options);
```