### PR TITLE
[SDK-2622] Add expiresAt to token response

### DIFF
--- a/src/main/java/com/auth0/json/auth/TokenHolder.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolder.java
@@ -1,36 +1,37 @@
 package com.auth0.json.auth;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Class that contains the Tokens obtained after a call to the {@link com.auth0.client.auth.AuthAPI} methods.
  */
 @SuppressWarnings("unused")
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = TokenHolderDeserializer.class)
 public class TokenHolder {
 
-    @JsonProperty("access_token")
     private String accessToken;
-    @JsonProperty("id_token")
     private String idToken;
-    @JsonProperty("refresh_token")
     private String refreshToken;
-    @JsonProperty("token_type")
     private String tokenType;
-    @JsonProperty("expires_in")
     private long expiresIn;
-    @JsonProperty("scope")
     private String scope;
+
+    public TokenHolder() {}
+
+    public TokenHolder(String accessToken, String idToken, String refreshToken, String tokenType, long expiresIn, String scope) {
+        this.accessToken = accessToken;
+        this.idToken = idToken;
+        this.refreshToken = refreshToken;
+        this.tokenType = tokenType;
+        this.expiresIn = expiresIn;
+        this.scope = scope;
+    }
 
     /**
      * Getter for the Auth0's access token.
      *
      * @return the access token or null if missing.
      */
-    @JsonProperty("access_token")
     public String getAccessToken() {
         return accessToken;
     }
@@ -40,7 +41,6 @@ public class TokenHolder {
      *
      * @return the id token or null if missing.
      */
-    @JsonProperty("id_token")
     public String getIdToken() {
         return idToken;
     }
@@ -50,7 +50,6 @@ public class TokenHolder {
      *
      * @return the refresh token or null if missing.
      */
-    @JsonProperty("refresh_token")
     public String getRefreshToken() {
         return refreshToken;
     }
@@ -60,7 +59,6 @@ public class TokenHolder {
      *
      * @return the token type or null if missing.
      */
-    @JsonProperty("token_type")
     public String getTokenType() {
         return tokenType;
     }
@@ -70,7 +68,6 @@ public class TokenHolder {
      *
      * @return the number of seconds in which this token will expire, since the time it was issued.
      */
-    @JsonProperty("expires_in")
     public long getExpiresIn() {
         return expiresIn;
     }
@@ -80,7 +77,6 @@ public class TokenHolder {
      *
      * @return a space-delimited string of the granted scopes of this token.
      */
-    @JsonProperty
     public String getScope() {
         return scope;
     }

--- a/src/main/java/com/auth0/json/auth/TokenHolder.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolder.java
@@ -2,6 +2,8 @@ package com.auth0.json.auth;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.Date;
+
 /**
  * Class that contains the Tokens obtained after a call to the {@link com.auth0.client.auth.AuthAPI} methods.
  */
@@ -15,16 +17,18 @@ public class TokenHolder {
     private String tokenType;
     private long expiresIn;
     private String scope;
+    private Date expiresAt;
 
     public TokenHolder() {}
 
-    public TokenHolder(String accessToken, String idToken, String refreshToken, String tokenType, long expiresIn, String scope) {
+    public TokenHolder(String accessToken, String idToken, String refreshToken, String tokenType, long expiresIn, String scope, Date expiresAt) {
         this.accessToken = accessToken;
         this.idToken = idToken;
         this.refreshToken = refreshToken;
         this.tokenType = tokenType;
         this.expiresIn = expiresIn;
         this.scope = scope;
+        this.expiresAt = expiresAt;
     }
 
     /**
@@ -73,6 +77,16 @@ public class TokenHolder {
     }
 
     /**
+     * Get the expiration date of this token. This value is <strong>not</strong> part of the actual token response from the
+     * API, but rather is calculated and provided for convenience.
+     *
+     * @return the the date of this token's expiration.
+     */
+    public Date getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
      * Gets the granted scope value for this token.
      *
      * @return a space-delimited string of the granted scopes of this token.
@@ -80,4 +94,5 @@ public class TokenHolder {
     public String getScope() {
         return scope;
     }
+
 }

--- a/src/main/java/com/auth0/json/auth/TokenHolder.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolder.java
@@ -19,6 +19,8 @@ public class TokenHolder {
     private String scope;
     private Date expiresAt;
 
+    // We need to maintain a default constructor for backwards-compatibility
+    @SuppressWarnings("unused")
     public TokenHolder() {}
 
     public TokenHolder(String accessToken, String idToken, String refreshToken, String tokenType, long expiresIn, String scope, Date expiresAt) {
@@ -68,19 +70,20 @@ public class TokenHolder {
     }
 
     /**
-     * Getter for the duration of this token in seconds since it was issued.
+     * Getter for the duration of the Access Token token in seconds from the time it was issued. If no Access Token was
+     * present the value will be zero.
      *
-     * @return the number of seconds in which this token will expire, since the time it was issued.
+     * @return the number of seconds in which the Access Token token will expire, from the time it was issued.
      */
     public long getExpiresIn() {
         return expiresIn;
     }
 
     /**
-     * Get the expiration date of this token. This value is <strong>not</strong> part of the actual token response from the
+     * Get the expiration date of the Access Token. This value is <strong>not</strong> part of the actual token response from the
      * API, but rather is calculated and provided for convenience.
      *
-     * @return the the date of this token's expiration.
+     * @return the date of the Access Token's expiration. If no Access Token was present on the response, returns {@code null}
      */
     public Date getExpiresAt() {
         return expiresAt;

--- a/src/main/java/com/auth0/json/auth/TokenHolderDeserializer.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolderDeserializer.java
@@ -44,8 +44,7 @@ public class TokenHolderDeserializer extends StdDeserializer<TokenHolder> {
 
         // As a primitive, if expires_in is not sent on the response, value will be 0 instead of null
         long expiresIn = expiresInNode !=  null ? expiresInNode.asLong() : 0L;
-
-        Date expiresAt = Date.from(Instant.now().plusSeconds(expiresIn));
+        Date expiresAt = expiresInNode != null ? Date.from(Instant.now().plusSeconds(expiresIn)) : null;
 
         return new TokenHolder(accessToken, idToken, refreshToken, tokenType, expiresIn, scope, expiresAt);
     }

--- a/src/main/java/com/auth0/json/auth/TokenHolderDeserializer.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolderDeserializer.java
@@ -1,0 +1,42 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+public class TokenHolderDeserializer extends StdDeserializer<TokenHolder> {
+
+    public TokenHolderDeserializer() {
+        this(null);
+    }
+
+    public TokenHolderDeserializer(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public TokenHolder deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        JsonNode node = p.getCodec().readTree(p);
+
+        JsonNode accessTokenNode = node.get("access_token");
+        JsonNode idTokenNode = node.get("id_token");
+        JsonNode refreshTokenNode = node.get("refresh_token");
+        JsonNode tokenTypeNode = node.get("token_type");
+        JsonNode scopeNode = node.get("scope");
+        JsonNode expiresInNode = node.get("expires_in");
+
+
+        String accessToken = accessTokenNode != null ? accessTokenNode.asText() : null;
+        String idToken = idTokenNode !=  null ? idTokenNode.asText() : null;
+        String refreshToken = refreshTokenNode != null ? refreshTokenNode.asText() : null;
+        String tokenType = tokenTypeNode != null  ? tokenTypeNode.asText() : null;
+        String scope = scopeNode != null ?  scopeNode.asText() : null;
+        long expiresIn = expiresInNode !=  null ? expiresInNode.asLong() : 0L;
+
+        return new TokenHolder(accessToken, idToken, refreshToken, tokenType, expiresIn, scope);
+    }
+}

--- a/src/main/java/com/auth0/json/auth/TokenHolderDeserializer.java
+++ b/src/main/java/com/auth0/json/auth/TokenHolderDeserializer.java
@@ -7,9 +7,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
 
+/**
+ * A custom Jackson Deserializer for the {@linkplain TokenHolder} object. It deserializes the JSON response and calculates
+ * an {@code expiresAt} date derived from the current time and the {@code expires_at} returned on the response.
+ */
 public class TokenHolderDeserializer extends StdDeserializer<TokenHolder> {
 
+    @SuppressWarnings("unused")
     public TokenHolderDeserializer() {
         this(null);
     }
@@ -29,14 +36,17 @@ public class TokenHolderDeserializer extends StdDeserializer<TokenHolder> {
         JsonNode scopeNode = node.get("scope");
         JsonNode expiresInNode = node.get("expires_in");
 
-
         String accessToken = accessTokenNode != null ? accessTokenNode.asText() : null;
         String idToken = idTokenNode !=  null ? idTokenNode.asText() : null;
         String refreshToken = refreshTokenNode != null ? refreshTokenNode.asText() : null;
         String tokenType = tokenTypeNode != null  ? tokenTypeNode.asText() : null;
         String scope = scopeNode != null ?  scopeNode.asText() : null;
+
+        // As a primitive, if expires_in is not sent on the response, value will be 0 instead of null
         long expiresIn = expiresInNode !=  null ? expiresInNode.asLong() : 0L;
 
-        return new TokenHolder(accessToken, idToken, refreshToken, tokenType, expiresIn, scope);
+        Date expiresAt = Date.from(Instant.now().plusSeconds(expiresIn));
+
+        return new TokenHolder(accessToken, idToken, refreshToken, tokenType, expiresIn, scope, expiresAt);
     }
 }

--- a/src/test/java/com/auth0/json/auth/TokenHolderTest.java
+++ b/src/test/java/com/auth0/json/auth/TokenHolderTest.java
@@ -50,16 +50,16 @@ public class TokenHolderTest extends JsonTest<TokenHolder> {
 
     @Test
     public void shouldDeserializeWithMissingFields() throws Exception {
-        String json = "{\"access_token\":\"A9CvPwFojaBI...\",\"token_type\": \"bearer\", \"scope\": \"openid profile email\"}";
+        String json = "{}";
 
         TokenHolder holder = fromJSON(json, TokenHolder.class);
 
         assertThat(holder, is(notNullValue()));
-        assertThat(holder.getAccessToken(), is("A9CvPwFojaBI..."));
+        assertThat(holder.getAccessToken(), is(nullValue()));
         assertThat(holder.getIdToken(), is(nullValue()));
         assertThat(holder.getRefreshToken(), is(nullValue()));
-        assertThat(holder.getTokenType(), is("bearer"));
-        assertThat(holder.getScope(), is("openid profile email"));
+        assertThat(holder.getTokenType(), is(nullValue()));
+        assertThat(holder.getScope(), is(nullValue()));
 
         // as a primitive, a missing value in the JSON will result in a value of zero on the value object.
         assertThat(holder.getExpiresIn(), is(0L));

--- a/src/test/java/com/auth0/json/auth/TokenHolderTest.java
+++ b/src/test/java/com/auth0/json/auth/TokenHolderTest.java
@@ -68,6 +68,13 @@ public class TokenHolderTest extends JsonTest<TokenHolder> {
 
     }
 
+    @Test
+    public void shouldHaveDefaultConstructor() {
+        // To ensure default constructor exists for backwards-compatibility
+        TokenHolder tokenHolder = new TokenHolder();
+        assertThat(tokenHolder, is(notNullValue()));
+    }
+
     private long getExpectedExpiredAtDiff(long expiresIn, Date expiresAt) {
         Instant expectedExpiresAt  = Instant.now().plusSeconds(expiresIn);
         long expectedEpochSeconds = expectedExpiresAt.getEpochSecond();

--- a/src/test/java/com/auth0/json/auth/TokenHolderTest.java
+++ b/src/test/java/com/auth0/json/auth/TokenHolderTest.java
@@ -4,24 +4,54 @@ import com.auth0.json.JsonTest;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class TokenHolderTest extends JsonTest<TokenHolder> {
 
-    private static final String json = "{\"id_token\":\"eyJ0eXAiOiJKV1Qi...\",\"access_token\":\"A9CvPwFojaBI...\",\"refresh_token\":\"GEbRxBN...edjnXbL\",\"token_type\": \"bearer\",\"expires_in\":86000, \"scope\": \"openid profile email\"}";
-
     @Test
     public void shouldDeserialize() throws Exception {
+        String json = "{\"id_token\":\"eyJ0eXAiOiJKV1Qi...\",\"access_token\":\"A9CvPwFojaBI...\",\"refresh_token\":\"GEbRxBN...edjnXbL\",\"token_type\": \"bearer\",\"expires_in\":86000, \"scope\": \"openid profile email\"}";
+
         TokenHolder holder = fromJSON(json, TokenHolder.class);
 
         assertThat(holder, is(notNullValue()));
-
         assertThat(holder.getAccessToken(), is(notNullValue()));
         assertThat(holder.getIdToken(), is(notNullValue()));
         assertThat(holder.getRefreshToken(), is(notNullValue()));
         assertThat(holder.getTokenType(), is(notNullValue()));
         assertThat(holder.getExpiresIn(), is(notNullValue()));
+        assertThat(holder.getScope(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldDeserializeWithUnexpectedValues() throws Exception {
+        String json = "{\"id_token\":\"eyJ0eXAiOiJKV1Qi...\",\"access_token\":\"A9CvPwFojaBI...\",\"refresh_token\":\"GEbRxBN...edjnXbL\",\"token_type\": \"bearer\",\"expires_in\":86000, \"scope\": \"openid profile email\", \"some-key\": \"some-value\"}";
+
+        TokenHolder holder = fromJSON(json, TokenHolder.class);
+
+        assertThat(holder, is(notNullValue()));
+        assertThat(holder.getAccessToken(), is(notNullValue()));
+        assertThat(holder.getIdToken(), is(notNullValue()));
+        assertThat(holder.getRefreshToken(), is(notNullValue()));
+        assertThat(holder.getTokenType(), is(notNullValue()));
+        assertThat(holder.getExpiresIn(), is(notNullValue()));
+        assertThat(holder.getScope(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldDeserializeWithMissingFields() throws Exception {
+        String json = "{\"access_token\":\"A9CvPwFojaBI...\",\"token_type\": \"bearer\", \"scope\": \"openid profile email\"}";
+
+        TokenHolder holder = fromJSON(json, TokenHolder.class);
+
+        assertThat(holder, is(notNullValue()));
+        assertThat(holder.getAccessToken(), is(notNullValue()));
+        assertThat(holder.getIdToken(), is(nullValue()));
+        assertThat(holder.getRefreshToken(), is(nullValue()));
+        assertThat(holder.getTokenType(), is(notNullValue()));
+
+        // as a primitive, a missing value in the JSON will result in a value of zero on the value object.
+        assertThat(holder.getExpiresIn(), is(0L));
         assertThat(holder.getScope(), is(notNullValue()));
     }
 }

--- a/src/test/java/com/auth0/json/auth/TokenHolderTest.java
+++ b/src/test/java/com/auth0/json/auth/TokenHolderTest.java
@@ -63,8 +63,7 @@ public class TokenHolderTest extends JsonTest<TokenHolder> {
 
         // as a primitive, a missing value in the JSON will result in a value of zero on the value object.
         assertThat(holder.getExpiresIn(), is(0L));
-        // allow for a small tolerance since now may be calculated at slightly different times in the test
-        assertThat(getExpectedExpiredAtDiff(0, holder.getExpiresAt()), is(lessThanOrEqualTo(2L)));
+        assertThat(holder.getExpiresAt(), is(nullValue()));
 
     }
 

--- a/src/test/java/com/auth0/json/auth/TokenHolderTest.java
+++ b/src/test/java/com/auth0/json/auth/TokenHolderTest.java
@@ -3,6 +3,9 @@ package com.auth0.json.auth;
 import com.auth0.json.JsonTest;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.util.Date;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -15,12 +18,16 @@ public class TokenHolderTest extends JsonTest<TokenHolder> {
         TokenHolder holder = fromJSON(json, TokenHolder.class);
 
         assertThat(holder, is(notNullValue()));
-        assertThat(holder.getAccessToken(), is(notNullValue()));
-        assertThat(holder.getIdToken(), is(notNullValue()));
-        assertThat(holder.getRefreshToken(), is(notNullValue()));
-        assertThat(holder.getTokenType(), is(notNullValue()));
-        assertThat(holder.getExpiresIn(), is(notNullValue()));
-        assertThat(holder.getScope(), is(notNullValue()));
+        assertThat(holder.getAccessToken(), is("A9CvPwFojaBI..."));
+        assertThat(holder.getIdToken(), is("eyJ0eXAiOiJKV1Qi..."));
+        assertThat(holder.getRefreshToken(), is("GEbRxBN...edjnXbL"));
+        assertThat(holder.getTokenType(), is("bearer"));
+        assertThat(holder.getExpiresIn(), is(86000L));
+        assertThat(holder.getScope(), is("openid profile email"));
+
+        // allow for a small tolerance since now may be calculated at slightly different times in the test
+        assertThat(getExpectedExpiredAtDiff(86000, holder.getExpiresAt()), is(lessThanOrEqualTo(2L)));
+
     }
 
     @Test
@@ -30,12 +37,15 @@ public class TokenHolderTest extends JsonTest<TokenHolder> {
         TokenHolder holder = fromJSON(json, TokenHolder.class);
 
         assertThat(holder, is(notNullValue()));
-        assertThat(holder.getAccessToken(), is(notNullValue()));
-        assertThat(holder.getIdToken(), is(notNullValue()));
-        assertThat(holder.getRefreshToken(), is(notNullValue()));
-        assertThat(holder.getTokenType(), is(notNullValue()));
-        assertThat(holder.getExpiresIn(), is(notNullValue()));
-        assertThat(holder.getScope(), is(notNullValue()));
+        assertThat(holder.getAccessToken(), is("A9CvPwFojaBI..."));
+        assertThat(holder.getIdToken(), is("eyJ0eXAiOiJKV1Qi..."));
+        assertThat(holder.getRefreshToken(), is("GEbRxBN...edjnXbL"));
+        assertThat(holder.getTokenType(), is("bearer"));
+        assertThat(holder.getExpiresIn(), is(86000L));
+        assertThat(holder.getScope(), is("openid profile email"));
+
+        // allow for a small tolerance since now may be calculated at slightly different times in the test
+        assertThat(getExpectedExpiredAtDiff(86000, holder.getExpiresAt()), is(lessThanOrEqualTo(2L)));
     }
 
     @Test
@@ -45,13 +55,23 @@ public class TokenHolderTest extends JsonTest<TokenHolder> {
         TokenHolder holder = fromJSON(json, TokenHolder.class);
 
         assertThat(holder, is(notNullValue()));
-        assertThat(holder.getAccessToken(), is(notNullValue()));
+        assertThat(holder.getAccessToken(), is("A9CvPwFojaBI..."));
         assertThat(holder.getIdToken(), is(nullValue()));
         assertThat(holder.getRefreshToken(), is(nullValue()));
-        assertThat(holder.getTokenType(), is(notNullValue()));
+        assertThat(holder.getTokenType(), is("bearer"));
+        assertThat(holder.getScope(), is("openid profile email"));
 
         // as a primitive, a missing value in the JSON will result in a value of zero on the value object.
         assertThat(holder.getExpiresIn(), is(0L));
-        assertThat(holder.getScope(), is(notNullValue()));
+        // allow for a small tolerance since now may be calculated at slightly different times in the test
+        assertThat(getExpectedExpiredAtDiff(0, holder.getExpiresAt()), is(lessThanOrEqualTo(2L)));
+
+    }
+
+    private long getExpectedExpiredAtDiff(long expiresIn, Date expiresAt) {
+        Instant expectedExpiresAt  = Instant.now().plusSeconds(expiresIn);
+        long expectedEpochSeconds = expectedExpiresAt.getEpochSecond();
+        long actualEpochSeconds = expiresAt.toInstant().getEpochSecond();
+        return Math.abs(expectedEpochSeconds - actualEpochSeconds);
     }
 }


### PR DESCRIPTION
### Changes

The response from `/oauth/token` includes an `expires_in` field, which is the time (from issuance) that the access token expires in. As noted in #356, customers wishing to know the expiry status of the token need to manage this manually, by calculating the expiry time from the issuance and `expires_in` value. This change introduces a new calculated value to `TokenHolder` that represents the expiration time of the access token.

#### Reviewer notes
* See the individual commit history to see how tests and refactorings were introduced to mitigate any unintended side effects (added tests for regression cases, refactored to custom deserializer, then added new calculated field)
* `Date` type was used for the new `expiresAt` field, to provide consistency with other types (customers can use `Date.from(Instant value)` to take advantage of modern date/time APIs, as the unit tests demonstrate)