### PR TITLE
Update OSS release plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'com.auth0.gradle.oss-library.java'
-    id "com.jfrog.bintray" version "1.8.5"
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,9 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
+        id 'com.auth0.gradle.oss-library.java' version '0.16.0'
     }
 }
 


### PR DESCRIPTION
### Changes
This PR updates the OSS release plugin version to 0.16.0, which makes use of a newer Javadoc HTML template.

I also removed the bintray plugin which is no longer used.