### PR TITLE
Invitation fails when you want to invite with roles

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
@@ -3,6 +3,7 @@ package com.auth0.json.mgmt.organizations;
 import com.fasterxml.jackson.annotation.*;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -44,7 +45,7 @@ public class Invitation {
     @JsonProperty("organization_id")
     private String organizationId;
     @JsonProperty("roles")
-    private Roles roles;
+    private List<String> roles;
 
     /**
      * Create a new instance.
@@ -193,7 +194,7 @@ public class Invitation {
     /**
      * @return the roles associated with the user invited.
      */
-    public Roles getRoles() {
+    public List<String> getRoles() {
         return roles;
     }
 
@@ -202,7 +203,7 @@ public class Invitation {
      *
      * @param roles the {@linkplain Roles} to associated with the user invited.
      */
-    public void setRoles(Roles roles) {
+    public void setRoles(List<String> roles) {
         this.roles = roles;
     }
 

--- a/src/test/java/com/auth0/json/mgmt/organizations/InvitationTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/InvitationTest.java
@@ -59,7 +59,7 @@ public class InvitationTest extends JsonTest<Invitation> {
         invitation.setAppMetadata(appMetadata);
         invitation.setUserMetadata(userMetadata);
         invitation.setConnectionId("connId");
-        invitation.setRoles(new Roles(rolesList));
+        invitation.setRoles(rolesList);
         invitation.setTtlInSeconds(41);
 
         String serialized = toJSON(invitation);


### PR DESCRIPTION

### Changes

The invitation API call fails when you invite the user with a particular role. This is because when the request is serialized it gets serialized as ```{"roles" : {"roles": ["role-1", "role-2"]}```. The REST API expects a JSON array but gets a JSON Object.

Due to this API fails with the following error:
com.auth0.exception.APIException: Request failed with status code 400:
Payload validation error: 'Expected type array but found type object'
on property roles (List of roles IDs to associated with the user).

This commit fixes that.

### References


### Testing

The change was tested by running InvitatonTest.java and seeing the output that is printed. The JSONMatcher that is used for testing seems to be buggy because it did not catch this. I did not attempt to fix that because I don't know what that would break.


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
