### PR TITLE
[SDK-2664] Add support for checkpoint pagination

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/filter/PageFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/PageFilter.java
@@ -32,4 +32,37 @@ public class PageFilter extends BaseFilter {
         return this;
     }
 
+    /**
+     * Include the {@code from} parameter to specify where to start the page selection. Only applicable for endpoints that
+     * support checkpoint pagination.
+     * <p>
+     * <strong>Note: If this or the {@linkplain PageFilter#withTake(int)} is specified, any offset paging parameters set
+     * via {@linkplain PageFilter#withPage(int, int)} or {@linkplain PageFilter#withTotals(boolean)} will be disregarded
+     * by the API.</strong>
+     * </p>
+     * @param from the ID from which to start selection. This can be obtained from the {@code next} field returned from
+     *             a checkpoint-paginated result.
+     * @return this filter instance.
+     */
+    public PageFilter withFrom(String from) {
+        parameters.put("from", from);
+        return this;
+    }
+
+    /**
+     * Include the {@code take} parameter to specify the amount of results to return per page. Only applicable for endpoints that
+     * support checkpoint pagination.
+     * <p>
+     * <strong>Note: If this or the {@linkplain PageFilter#withFrom(String)} is specified, any offset paging parameters set
+     * via {@linkplain PageFilter#withPage(int, int)} or {@linkplain PageFilter#withTotals(boolean)} will be disregarded
+     * by the API.</strong>
+     * </p>
+     * @param take the amount of entries to retrieve per page.
+     * @return this filter instance.
+     */
+    public PageFilter withTake(int take) {
+        parameters.put("take", take);
+        return this;
+    }
+
 }

--- a/src/main/java/com/auth0/json/mgmt/Page.java
+++ b/src/main/java/com/auth0/json/mgmt/Page.java
@@ -24,6 +24,8 @@ public abstract class Page<T> {
     private Integer total;
     @JsonProperty("limit")
     private Integer limit;
+    @JsonProperty("next")
+    private String next;
     private final List<T> items;
 
     public Page(List<T> items) {
@@ -31,10 +33,15 @@ public abstract class Page<T> {
     }
 
     public Page(Integer start, Integer length, Integer total, Integer limit, List<T> items) {
+        this(start, length, total, limit, null, items);
+    }
+
+    public Page(Integer start, Integer length, Integer total, Integer limit, String next, List<T> items) {
         this.start = start;
         this.length = length;
         this.total = total;
         this.limit = limit;
+        this.next = next;
         this.items = items;
     }
 
@@ -76,6 +83,15 @@ public abstract class Page<T> {
     @JsonProperty("limit")
     public Integer getLimit() {
         return limit;
+    }
+
+    /**
+     * Getter for the next value, if using checkpoint pagination, which can be used to fetch the next page of results.
+     * @return the next value.
+     */
+    @JsonProperty("next")
+    public String getNext() {
+        return next;
     }
 
     /**

--- a/src/main/java/com/auth0/json/mgmt/organizations/MembersPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/MembersPage.java
@@ -23,4 +23,8 @@ public class MembersPage extends Page<Member> {
     public MembersPage(Integer start, Integer length, Integer total, Integer limit, List<Member> items) {
         super(start, length, total, limit, items);
     }
+
+    public MembersPage(Integer start, Integer length, Integer total, Integer limit, String next, List<Member> items) {
+        super(start, length, total, limit, next, items);
+    }
 }

--- a/src/main/java/com/auth0/json/mgmt/organizations/MembersPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/MembersPageDeserializer.java
@@ -22,4 +22,9 @@ public class MembersPageDeserializer extends PageDeserializer<MembersPage, Membe
     protected MembersPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Member> items) {
         return new MembersPage(start, length, total, limit, items);
     }
+
+    @Override
+    protected MembersPage createPage(Integer start, Integer length, Integer total, Integer limit, String next, List<Member> items) {
+        return new MembersPage(start, length, total, limit, next, items);
+    }
 }

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPage.java
@@ -23,4 +23,8 @@ public class OrganizationsPage extends Page<Organization> {
     public OrganizationsPage(Integer start, Integer length, Integer total, Integer limit, List<Organization> items) {
         super(start, length, total, limit, items);
     }
+
+    public OrganizationsPage(Integer start, Integer length, Integer total, Integer limit, String next, List<Organization> items) {
+        super(start, length, total, limit, next, items);
+    }
 }

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationsPageDeserializer.java
@@ -1,7 +1,6 @@
 package com.auth0.json.mgmt.organizations;
 
 import com.auth0.json.mgmt.PageDeserializer;
-import com.auth0.json.mgmt.logevents.LogEvent;
 
 import java.util.List;
 
@@ -22,5 +21,10 @@ public class OrganizationsPageDeserializer extends PageDeserializer<Organization
     @Override
     protected OrganizationsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<Organization> items) {
         return new OrganizationsPage(start, length, total, limit, items);
+    }
+
+    @Override
+    protected OrganizationsPage createPage(Integer start, Integer length, Integer total, Integer limit, String next, List<Organization> items) {
+        return new OrganizationsPage(start, length, total, limit, next, items);
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/users/UsersPage.java
+++ b/src/main/java/com/auth0/json/mgmt/users/UsersPage.java
@@ -24,4 +24,7 @@ public class UsersPage extends Page<User> {
         super(start, length, total, limit, items);
     }
 
+    public UsersPage(Integer start, Integer length, Integer total, Integer limit, String next, List<User> items) {
+        super(start, length, total, limit, next, items);
+    }
 }

--- a/src/main/java/com/auth0/json/mgmt/users/UsersPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/users/UsersPageDeserializer.java
@@ -29,4 +29,8 @@ class UsersPageDeserializer extends PageDeserializer<UsersPage, User> {
         return new UsersPage(start, length, total, limit, items);
     }
 
+    @Override
+    protected UsersPage createPage(Integer start, Integer length, Integer total, Integer limit, String next, List<User> items) {
+        return new UsersPage(start, length, total, limit, next, items);
+    }
 }

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -54,6 +54,7 @@ public class MockServer {
     public static final String MGMT_ROLE_PERMISSIONS_PAGED_LIST = "src/test/resources/mgmt/role_permissions_paged_list.json";
     public static final String MGMT_ROLE_USERS_LIST = "src/test/resources/mgmt/role_users_list.json";
     public static final String MGMT_ROLE_USERS_PAGED_LIST = "src/test/resources/mgmt/role_users_paged_list.json";
+    public static final String MGMT_ROLE_USERS_CHECKPOINT_PAGED_LIST = "src/test/resources/mgmt/role_users_checkpoint_paged_list.json";
     public static final String MGMT_RULES_LIST = "src/test/resources/mgmt/rules_list.json";
     public static final String MGMT_RULES_CONFIGS_LIST = "src/test/resources/mgmt/rules_configs_list.json";
     public static final String MGMT_RULES_PAGED_LIST = "src/test/resources/mgmt/rules_paged_list.json";
@@ -97,8 +98,10 @@ public class MockServer {
     public static final String ORGANIZATION = "src/test/resources/mgmt/organization.json";
     public static final String ORGANIZATIONS_LIST = "src/test/resources/mgmt/organizations_list.json";
     public static final String ORGANIZATIONS_PAGED_LIST = "src/test/resources/mgmt/organizations_paged_list.json";
+    public static final String ORGANIZATIONS_CHECKPOINT_PAGED_LIST = "src/test/resources/mgmt/organizations_checkpoint_paged_list.json";
     public static final String ORGANIZATION_MEMBERS_LIST = "src/test/resources/mgmt/organization_members_list.json";
     public static final String ORGANIZATION_MEMBERS_PAGED_LIST = "src/test/resources/mgmt/organization_members_paged_list.json";
+    public static final String ORGANIZATION_MEMBERS_CHECKPOINT_PAGED_LIST = "src/test/resources/mgmt/organization_members_checkpoint_paged_list.json";
     public static final String ORGANIZATION_CONNECTIONS_LIST = "src/test/resources/mgmt/organization_connections_list.json";
     public static final String ORGANIZATION_CONNECTIONS_PAGED_LIST = "src/test/resources/mgmt/organization_connections_paged_list.json";
     public static final String ORGANIZATION_CONNECTION = "src/test/resources/mgmt/organization_connection.json";

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -59,6 +59,26 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldListOrgsWithCheckpointPagination() throws Exception {
+        PageFilter filter = new PageFilter().withTake(10).withFrom("from-id");
+        Request<OrganizationsPage> request = api.organizations().list(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATIONS_CHECKPOINT_PAGED_LIST, 200);
+        OrganizationsPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("take", "10"));
+        assertThat(recordedRequest, hasQueryParameter("from", "from-id"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(2));
+    }
+
+    @Test
     public void shouldListOrgsWithTotals() throws Exception {
         PageFilter filter = new PageFilter().withTotals(true);
         Request<OrganizationsPage> request = api.organizations().list(filter);
@@ -301,6 +321,26 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
         assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(3));
+    }
+
+    @Test
+    public void shouldListOrgMembersWithCheckpointPageResponse() throws Exception {
+        PageFilter filter = new PageFilter().withTake(3).withFrom("from-pointer");
+        Request<MembersPage> request = api.organizations().getMembers("org_abc", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(ORGANIZATION_MEMBERS_CHECKPOINT_PAGED_LIST, 200);
+        MembersPage response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("take", "3"));
+        assertThat(recordedRequest, hasQueryParameter("from", "from-pointer"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(3));

--- a/src/test/java/com/auth0/client/mgmt/filter/PageFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/PageFilterTest.java
@@ -1,12 +1,12 @@
 package com.auth0.client.mgmt.filter;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PageFilterTest {
 
@@ -36,4 +36,12 @@ public class PageFilterTest {
         assertThat(filter.getAsMap(), Matchers.hasEntry("include_totals", true));
     }
 
+    @Test
+    public void shouldIncludeCheckpointParams() {
+        PageFilter instance = filter.withFrom("abc123").withTake(2);
+
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("from", "abc123"));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("take", 2));
+    }
 }

--- a/src/test/java/com/auth0/json/mgmt/organizations/MembersPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/MembersPageTest.java
@@ -3,6 +3,8 @@ package com.auth0.json.mgmt.organizations;
 import com.auth0.json.JsonTest;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -99,6 +101,17 @@ public class MembersPageTest extends JsonTest<MembersPage> {
         assertThat(page.getNext(), is("MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldBeCreatedWithoutNextField() {
+        MembersPage page = new MembersPageDeserializer().createPage(0, 5, 20, 50, new ArrayList<>());
+
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getLength(), is(5));
+        assertThat(page.getTotal(), is(20));
+        assertThat(page.getLimit(), is(50));
+        assertThat(page.getItems(), is(notNullValue()));
     }
 }
 

--- a/src/test/java/com/auth0/json/mgmt/organizations/MembersPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/MembersPageTest.java
@@ -42,6 +42,23 @@ public class MembersPageTest extends JsonTest<MembersPage> {
         "  \"total\": 2\n" +
         "}\n";
 
+    private static final String jsonWithCheckpointPageResponse = "{\n" +
+        "  \"members\": [\n" +
+        "    {\n" +
+        "      \"user_id\": \"auth0|605a1f57cbeb2c0070fdf123\",\n" +
+        "      \"email\": \"dave@domain.com\",\n" +
+        "      \"picture\": \"https://domain.com/img.png\",\n" +
+        "      \"name\": \"dave\"\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"user_id\": \"auth0|605a0fc1bef67f006851a123\",\n" +
+        "      \"email\": \"eric@domain.com\",\n" +
+        "      \"picture\": \"https://domain.com/img.png\",\n" +
+        "      \"name\": \"eric\"\n" +
+        "    }\n" +
+        "  ],\n" +
+        "  \"next\": \"MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw\"\n" +
+        "}\n";
 
     @Test
     public void shouldDeserializeWithoutTotals() throws Exception {
@@ -52,6 +69,7 @@ public class MembersPageTest extends JsonTest<MembersPage> {
         assertThat(page.getLength(), is(nullValue()));
         assertThat(page.getTotal(), is(nullValue()));
         assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getNext(), is(nullValue()));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(2));
     }
@@ -61,10 +79,24 @@ public class MembersPageTest extends JsonTest<MembersPage> {
         MembersPage page = fromJSON(jsonWithTotals, MembersPage.class);
 
         assertThat(page, is(notNullValue()));
-        assertThat(page, is(notNullValue()));
         assertThat(page.getStart(), is(0));
         assertThat(page.getTotal(), is(2));
         assertThat(page.getLimit(), is(20));
+        assertThat(page.getNext(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldDeserializeWithNextItemPointer() throws Exception {
+        MembersPage page = fromJSON(jsonWithCheckpointPageResponse, MembersPage.class);
+
+        assertThat(page, is(notNullValue()));
+
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getNext(), is("MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(2));
     }

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsPageTest.java
@@ -3,6 +3,8 @@ package com.auth0.json.mgmt.organizations;
 import com.auth0.json.JsonTest;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -85,6 +87,35 @@ public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
         "    \"next\": \"MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw\"\n" +
         "}";
 
+    private static final String jsonWithNulls = "{\n" +
+        "    \"organizations\": [\n" +
+        "        {\n" +
+        "            \"id\": \"org_2\",\n" +
+        "            \"name\": \"org-1\",\n" +
+        "            \"display_name\": \"org 1\",\n" +
+        "            \"branding\": {\n" +
+        "                \"logo_url\": \"https://some-url.com/\",\n" +
+        "                \"colors\": {\n" +
+        "                    \"primary\": \"#FF0000\",\n" +
+        "                    \"page_background\": \"#FF0000\"\n" +
+        "                }\n" +
+        "            },\n" +
+        "            \"metadata\": {\n" +
+        "                \"key1\": \"val1\"\n" +
+        "            }\n" +
+        "        },\n" +
+        "        {\n" +
+        "            \"id\": \"org_2\",\n" +
+        "            \"name\": \"org-2\",\n" +
+        "            \"display_name\": \"org 2\"\n" +
+        "        }\n" +
+        "    ],\n" +
+        "    \"start\": null,\n" +
+        "    \"limit\": 20,\n" +
+        "    \"total\": 2,\n" +
+        "    \"next\": null" +
+        "}";
+
     @Test
     public void shouldDeserializeWithoutTotals() throws Exception {
         OrganizationsPage page = fromJSON(jsonWithoutTotals, OrganizationsPage.class);
@@ -121,6 +152,30 @@ public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
         assertThat(page.getStart(), is(nullValue()));
         assertThat(page.getTotal(), is(nullValue()));
         assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldBeCreatedWithoutNextField() {
+        OrganizationsPage page = new OrganizationsPageDeserializer().createPage(0, 5, 20, 50, new ArrayList<>());
+
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getLength(), is(5));
+        assertThat(page.getTotal(), is(20));
+        assertThat(page.getLimit(), is(50));
+        assertThat(page.getItems(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldHandleNullFields() throws Exception {
+        OrganizationsPage page = fromJSON(jsonWithNulls, OrganizationsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getNext(), is(nullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getTotal(), is(2));
+        assertThat(page.getLimit(), is(20));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(2));
     }

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsPageTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.is;
 
 public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
 
@@ -60,6 +59,32 @@ public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
         "    \"total\": 2\n" +
         "}";
 
+    private static final String jsonWithCheckpointPageResponse = "{\n" +
+        "    \"organizations\": [\n" +
+        "        {\n" +
+        "            \"id\": \"org_2\",\n" +
+        "            \"name\": \"org-1\",\n" +
+        "            \"display_name\": \"org 1\",\n" +
+        "            \"branding\": {\n" +
+        "                \"logo_url\": \"https://some-url.com/\",\n" +
+        "                \"colors\": {\n" +
+        "                    \"primary\": \"#FF0000\",\n" +
+        "                    \"page_background\": \"#FF0000\"\n" +
+        "                }\n" +
+        "            },\n" +
+        "            \"metadata\": {\n" +
+        "                \"key1\": \"val1\"\n" +
+        "            }\n" +
+        "        },\n" +
+        "        {\n" +
+        "            \"id\": \"org_2\",\n" +
+        "            \"name\": \"org-2\",\n" +
+        "            \"display_name\": \"org 2\"\n" +
+        "        }\n" +
+        "    ],\n" +
+        "    \"next\": \"MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw\"\n" +
+        "}";
+
     @Test
     public void shouldDeserializeWithoutTotals() throws Exception {
         OrganizationsPage page = fromJSON(jsonWithoutTotals, OrganizationsPage.class);
@@ -71,6 +96,7 @@ public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
         assertThat(page.getLimit(), is(nullValue()));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(2));
+        assertThat(page.getNext(), is(nullValue()));
     }
 
     @Test
@@ -81,6 +107,20 @@ public class OrganizationsPageTest extends JsonTest<OrganizationsPage> {
         assertThat(page.getStart(), is(0));
         assertThat(page.getTotal(), is(2));
         assertThat(page.getLimit(), is(20));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+        assertThat(page.getNext(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldDeserializeWithCheckpointResponse() throws Exception {
+        OrganizationsPage page = fromJSON(jsonWithCheckpointPageResponse, OrganizationsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getNext(), is("MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(2));
     }

--- a/src/test/java/com/auth0/json/mgmt/users/UsersPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UsersPageTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.*;
 public class UsersPageTest extends JsonTest<UsersPage> {
     private static final String jsonWithTotals = "{\"start\":0,\"length\":10,\"total\":14,\"limit\":50,\"users\":[{\"connection\":\"auth0\",\"client_id\":\"client123\",\"password\":\"pwd\",\"verify_password\":true,\"username\":\"usr\",\"email\":\"me@auth0.com\",\"email_verified\":true,\"verify_email\":true,\"phone_number\":\"1234567890\",\"phone_verified\":true,\"verify_phone_number\":true,\"picture\":\"https://pic.ture/12\",\"name\":\"John\",\"nickname\":\"Johny\",\"given_name\":\"John\",\"family_name\":\"Walker\",\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[],\"app_metadata\":{},\"user_metadata\":{},\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"blocked\":true}]}";
     private static final String jsonWithoutTotals = "[{\"connection\":\"auth0\",\"client_id\":\"client123\",\"password\":\"pwd\",\"verify_password\":true,\"username\":\"usr\",\"email\":\"me@auth0.com\",\"email_verified\":true,\"verify_email\":true,\"phone_number\":\"1234567890\",\"phone_verified\":true,\"verify_phone_number\":true,\"picture\":\"https://pic.ture/12\",\"name\":\"John\",\"nickname\":\"Johny\",\"given_name\":\"John\",\"family_name\":\"Walker\",\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[],\"app_metadata\":{},\"user_metadata\":{},\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"blocked\":true}]";
+    private static final String jsonWithCheckpointPageResponse = "{\"users\":[{\"connection\":\"auth0\",\"client_id\":\"client123\",\"password\":\"pwd\",\"verify_password\":true,\"username\":\"usr\",\"email\":\"me@auth0.com\",\"email_verified\":true,\"verify_email\":true,\"phone_number\":\"1234567890\",\"phone_verified\":true,\"verify_phone_number\":true,\"picture\":\"https://pic.ture/12\",\"name\":\"John\",\"nickname\":\"Johny\",\"given_name\":\"John\",\"family_name\":\"Walker\",\"created_at\":\"2016-02-23T19:57:29.532Z\",\"updated_at\":\"2016-02-23T19:57:29.532Z\",\"identities\":[],\"app_metadata\":{},\"user_metadata\":{},\"last_ip\":\"10.0.0.1\",\"last_login\":\"2016-02-23T19:57:29.532Z\",\"logins_count\":10,\"blocked\":true}],\"next\":\"MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw\"}";
 
     @Test
     public void shouldDeserializeWithoutTotals() throws Exception {
@@ -19,6 +20,7 @@ public class UsersPageTest extends JsonTest<UsersPage> {
         assertThat(page.getLength(), is(nullValue()));
         assertThat(page.getTotal(), is(nullValue()));
         assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getNext(), is(nullValue()));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(1));
     }
@@ -32,8 +34,21 @@ public class UsersPageTest extends JsonTest<UsersPage> {
         assertThat(page.getLength(), is(10));
         assertThat(page.getTotal(), is(14));
         assertThat(page.getLimit(), is(50));
+        assertThat(page.getNext(), is(nullValue()));
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getItems().size(), is(1));
     }
 
+    @Test
+    public void shouldDeserializeWithCheckpointResponse() throws Exception {
+        UsersPage page = fromJSON(jsonWithCheckpointPageResponse, UsersPage.class);
+
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getNext(), is("MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"));
+        assertThat(page.getItems().size(), is(1));
+    }
 }

--- a/src/test/java/com/auth0/json/mgmt/users/UsersPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/UsersPageTest.java
@@ -3,6 +3,8 @@ package com.auth0.json.mgmt.users;
 import com.auth0.json.JsonTest;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -50,5 +52,16 @@ public class UsersPageTest extends JsonTest<UsersPage> {
         assertThat(page.getItems(), is(notNullValue()));
         assertThat(page.getNext(), is("MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"));
         assertThat(page.getItems().size(), is(1));
+    }
+
+    @Test
+    public void shouldBeCreatedWithoutNextField() {
+        UsersPage page = new UsersPageDeserializer().createPage(0, 5, 20, 50, new ArrayList<>());
+
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getLength(), is(5));
+        assertThat(page.getTotal(), is(20));
+        assertThat(page.getLimit(), is(50));
+        assertThat(page.getItems(), is(notNullValue()));
     }
 }

--- a/src/test/resources/mgmt/organization_members_checkpoint_paged_list.json
+++ b/src/test/resources/mgmt/organization_members_checkpoint_paged_list.json
@@ -1,0 +1,23 @@
+{
+  "members": [
+    {
+      "user_id": "auth0|605a1f57cbeb2c0070fdf123",
+      "email": "dave@domain.com",
+      "picture": "https://domain.com/img.png",
+      "name": "dave"
+    },
+    {
+      "user_id": "auth0|605a0fc1bef67f006851a123",
+      "email": "eric@domain.com",
+      "picture": "https://domain.com/img.png",
+      "name": "eric"
+    },
+    {
+      "user_id": "auth0|5f5103d20e634f006d25a123",
+      "email": "john@domain.com",
+      "picture": "https://domain.com/img.png",
+      "name": "john"
+    }
+  ],
+  "next": "MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"
+}

--- a/src/test/resources/mgmt/organizations_checkpoint_paged_list.json
+++ b/src/test/resources/mgmt/organizations_checkpoint_paged_list.json
@@ -1,0 +1,25 @@
+{
+  "organizations": [
+    {
+      "id": "org_VSZmSnzd0m9ITBZ7",
+      "name": "org-1",
+      "display_name": "org 1",
+      "branding": {
+        "logo_uri": "https://some-url.com/",
+        "colors": {
+          "primary": "#FF0000",
+          "page_background": "#FF0000"
+        }
+      },
+      "metadata": {
+        "key1": "val1"
+      }
+    },
+    {
+      "id": "org_W3OH9wtMRbjhHuWK",
+      "name": "org-2",
+      "display_name": "org 2"
+    }
+  ],
+  "next": "MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"
+}

--- a/src/test/resources/mgmt/role_users_checkpoint_paged_list.json
+++ b/src/test/resources/mgmt/role_users_checkpoint_paged_list.json
@@ -1,0 +1,17 @@
+{
+  "users": [
+    {
+      "email": "john.doe@gmail.com",
+      "user_id": "usr_5457edea1b8f33391a000004",
+      "picture": "",
+      "name": ""
+    },
+    {
+      "email": "john.doe2@gmail.com",
+      "user_id": "usr_5457edea1b8f33391a000004",
+      "picture": "",
+      "name": ""
+    }
+  ],
+  "next": "MjAyMS0wMy0yOSAxNjo1MDo09s44NDYxODcrMDAsb3JnX2Y0VXZUbG1iSWd2005zTGw"
+}


### PR DESCRIPTION
### Changes

This change adds checkpoint pagination support to the following APIs:
* `OrganizationEntity#list(PageFilter filter)`
* `OrganizationEntity#getMembers(String orgId, PageFilter filter)`
* `RolesEntity#listUsers(String roleId, PageFilter filter)`

While the methods listed above are not changed directly, the following changes enable supporting checkpoint pagination:
* Added new methods `withFrom(String from)` and `withTake(int take)` to `PageFilter` to support the `from` and `take` query parameters.
* Added a new field to the `Page` POJO for the `next` field that may be returned when using checkpoint pagination, along with a new constructor that accepts the `next` parameter.
* Added a new method to `PageDeserializer` to create a `Page` with the `next` parameter. Unlike the other methods in this class, this new method is _not_ abstract, as doing so would require all subclasses to implement this method, and would be a breaking change. Instead, the new method delegates to the existing method to create the `Page`, and any subclasses that need to support checkpoint pagination will need to override this method to construct the `Page` with the `next` field.

### References

In addition to SDK-2664, the following API2 endpoints can be consulted for documentation on the checkpoint pagination support they offer:
* [GET /api/v2/organiizations](https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations)
* [GET /api/v2/organizations/{orgId}/members](https://auth0.com/docs/api/management/v2#!/Organizations/get_members)
* [GET /api/v2/roles/{roleId}/users](https://auth0.com/docs/api/management/v2#!/Roles/get_role_user)

### Testing

In addition to the unit tests included, manual testing was also performed with the changes.