### PR TITLE
[SDK-2686] Add retry on rate limit errors for management API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
     implementation "com.auth0:java-jwt:3.14.0"
+    implementation "net.jodah:failsafe:2.4.1"
 
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"
     testImplementation "org.mockito:mockito-core:3.7.7"

--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -8,6 +8,7 @@ public class HttpOptions {
     private ProxyOptions proxyOptions;
     private int connectTimeout = 10;
     private int readTimeout = 10;
+    private int mgmtApiMaxRetries = 3;
 
     /**
      * Getter for the Proxy configuration options
@@ -65,5 +66,31 @@ public class HttpOptions {
             readTimeout = 0;
         }
         this.readTimeout = readTimeout;
+    }
+
+    /**
+     * @return the configured number of maximum retries to attempt when a rate-limit error is encountered by the Management API client.
+     */
+    public int getManagementAPIMaxRetries() {
+        return mgmtApiMaxRetries;
+    }
+
+    /**
+     * Sets the maximum number of consecutive retries for Management API requests that fail due to rate-limits being reached.
+     * By default, rate-limited requests will be retries a maximum of three times. To disable retries on rate-limit
+     * errors, set this value to zero.
+     *
+     * <p>
+     * <strong>Note: Rate-limiting retries is only applicable to the Management API client.</strong>
+     * </p>
+     *
+     * @param maxRetries the maximum number of consecutive retries to attempt upon a rate-limit error. Defaults to three.
+     *                   Must be a number between zero (do not retry) and ten.
+     */
+    public void setManagementAPIMaxRetries(int maxRetries) {
+        if (maxRetries < 0 || maxRetries > 10) {
+            throw new IllegalArgumentException("Retries must be between zero and ten.");
+        }
+        this.mgmtApiMaxRetries = maxRetries;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -2,6 +2,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.client.HttpOptions;
 import com.auth0.client.ProxyOptions;
+import com.auth0.net.RateLimitInterceptor;
 import com.auth0.net.Telemetry;
 import com.auth0.net.TelemetryInterceptor;
 import com.auth0.utils.Asserts;
@@ -103,6 +104,7 @@ public class ManagementAPI {
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
+                .addInterceptor(new RateLimitInterceptor(options.getManagementAPIMaxRetries()))
                 .connectTimeout(options.getConnectTimeout(), TimeUnit.SECONDS)
                 .readTimeout(options.getReadTimeout(), TimeUnit.SECONDS)
                 .build();

--- a/src/main/java/com/auth0/net/RateLimitInterceptor.java
+++ b/src/main/java/com/auth0/net/RateLimitInterceptor.java
@@ -1,0 +1,82 @@
+package com.auth0.net;
+
+import com.auth0.client.HttpOptions;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import net.jodah.failsafe.event.ExecutionAttemptedEvent;
+import net.jodah.failsafe.function.CheckedConsumer;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * An OkHttp {@linkplain Interceptor} responsible for retrying rate-limit errors (429) using a configurable maximum
+ * number of retries, and an exponential backoff on retry attempts.
+ * <p>
+ * See {@link com.auth0.client.HttpOptions#setManagementAPIMaxRetries(int)} and {@link com.auth0.client.mgmt.ManagementAPI#ManagementAPI(String, String, HttpOptions)}
+ * </p>
+ * <p>
+ * <strong>Note: This class is not intended for general use or extension, and may change at any time.</strong>
+ * </p>
+ */
+public class RateLimitInterceptor implements Interceptor {
+
+    private final int maxRetries;
+    private final CheckedConsumer<? extends ExecutionAttemptedEvent<Response>> retryListener;
+
+    static final Long INITIAL_INTERVAL = 100L;
+    static final Long MAX_INTERVAL = 1000L;
+    static final Double JITTER = 0.2D;
+
+    /**
+     * Constructs a new instance with the maximum number of allowed retries.
+     * @param maxRetries the maximum number of consecutive retries to attempt.
+     */
+    public RateLimitInterceptor(int maxRetries) {
+        this(maxRetries, null);
+    }
+
+    /**
+     * Visible for testing purposes only.
+     * @param maxRetries the maximum number of consecutive retries to attempt.
+     * @param retryListener a listener to call prior to a retry attempt.
+     */
+    RateLimitInterceptor(int maxRetries, CheckedConsumer<? extends ExecutionAttemptedEvent<Response>> retryListener) {
+        this.maxRetries = maxRetries;
+        this.retryListener = retryListener;
+    }
+
+    /**
+     * @return the configured number of maximum retries.
+     */
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    @NotNull
+    @Override
+    public Response intercept(@NotNull Chain chain) throws IOException {
+
+        RetryPolicy<Response> retryPolicy = new RetryPolicy<Response>()
+            .withMaxRetries(maxRetries)
+            .withBackoff(INITIAL_INTERVAL, MAX_INTERVAL, ChronoUnit.MILLIS)
+            .withJitter(JITTER)
+            .handleResultIf(response -> {
+                if (response.code() == 429) {
+                    response.close();
+                    return true;
+                }
+                return false;
+            });
+
+        // For testing purposes only, allow test to hook into retry listener to enable verification of retry backoff
+        if (retryListener != null) {
+            retryPolicy.onRetry(retryListener);
+        }
+
+        return Failsafe.with(retryPolicy).get(() -> chain.proceed(chain.request()));
+    }
+}

--- a/src/test/java/com/auth0/net/RateLimitInterceptorTest.java
+++ b/src/test/java/com/auth0/net/RateLimitInterceptorTest.java
@@ -1,0 +1,178 @@
+package com.auth0.net;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class RateLimitInterceptorTest {
+
+    MockWebServer server = new MockWebServer();
+
+    @Before
+    public void setUp() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldRetryRateLimitResponses() throws Exception {
+        OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(new RateLimitInterceptor(3))
+            .build();
+
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        okhttp3.Request request = new Request.Builder()
+            .get()
+            .url(server.url("/"))
+            .build();
+
+        Response resp = client.newCall(request).execute();
+
+        server.takeRequest();
+        server.takeRequest();
+        server.takeRequest();
+        RecordedRequest finalRequest = server.takeRequest();
+
+        assertThat(resp.code(), is(200));
+
+        // verify that a total of 4 requests were made (zero index; 3 failures and one successful retry)
+        assertThat(finalRequest.getSequenceNumber(), is(3));
+    }
+
+    @Test
+    public void shouldNotRetryIfMaxRetriesIsZero() throws Exception {
+        OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(new RateLimitInterceptor(0))
+            .build();
+
+        server.enqueue(new MockResponse().setResponseCode(429));
+
+        okhttp3.Request request = new Request.Builder()
+            .get()
+            .url(server.url("/"))
+            .build();
+
+        Response resp = client.newCall(request).execute();
+        assertThat(resp.code(), is(429));
+
+        // verify that only one request was made (no retries)
+        assertThat(server.takeRequest().getSequenceNumber(), is(0));
+    }
+
+    @Test
+    public void shouldReturnResponseWhenMaxRetriesHit() throws Exception {
+        int maxRetries = 3;
+
+        OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(new RateLimitInterceptor(maxRetries))
+            .build();
+
+        MockResponse mockResponse = new MockResponse().setResponseCode(429);
+
+        for (int i = 0; i < maxRetries + 1; i++) {
+            server.enqueue(mockResponse);
+        }
+
+        okhttp3.Request request = new Request.Builder()
+            .get()
+            .url(server.url("/"))
+            .build();
+
+        Response response = client.newCall(request).execute();
+
+        int index = 0;
+        for (int i = 0; i < maxRetries + 1; i++) {
+            System.out.println("about to take request " + i);
+            index = server.takeRequest().getSequenceNumber();
+            System.out.println("took request " + i);
+        }
+
+        assertThat(response.code(), is(429));
+
+        // Verify that a total of four requests were made (original plus three retries)
+        assertThat(index, is(3));
+    }
+
+    @Test
+    public void shouldNotRetryNonRateLimitErrors() throws Exception {
+        OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(new RateLimitInterceptor(3))
+            .build();
+
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        okhttp3.Request request = new Request.Builder()
+            .get()
+            .url(server.url("/"))
+            .build();
+
+        Response response = client.newCall(request).execute();
+
+        assertThat(response.code(), is(500));
+
+        // verify only one request was made (not retried)
+        assertThat(server.takeRequest().getSequenceNumber(), is(0));
+    }
+
+    @Test
+    public void shouldBackOffOnRetries()  throws Exception {
+        int maxRetries = 10;
+        List<Long> retryTimings = new ArrayList<>();
+
+        RateLimitInterceptor interceptor = new RateLimitInterceptor(maxRetries, c -> {
+            // keep a sequential list of the elapsed time since last execution request (retry delay)
+            retryTimings.add(c.getElapsedAttemptTime().toMillis());
+        });
+
+        OkHttpClient client = new OkHttpClient.Builder()
+            .addInterceptor(interceptor)
+            .build();
+
+        MockResponse mockResponse = new MockResponse().setResponseCode(429);
+
+        for (int i = 0; i < maxRetries + 1; i++) {
+            server.enqueue(mockResponse);
+        }
+
+        okhttp3.Request request = new Request.Builder()
+            .get()
+            .url(server.url("/"))
+            .build();
+
+        client.newCall(request).execute();
+
+        // Verify that the last retry attempt is at least 3x greater than the first
+        assertThat(retryTimings.get(maxRetries - 1), greaterThan(retryTimings.get(0) * 3L));
+
+        // Verify that the final retry is close to the maximum delay of 1000ms, within variance from jitter
+        assertThat(retryTimings.get(maxRetries - 1).doubleValue(), closeTo(1000, 220));
+
+        // Basic checks that retry retryTimings are increasing as retry count increases
+        // Different retry attempts are compared to account for backoff growth as well as random jitter
+        assertThat(retryTimings.get(2), greaterThan(retryTimings.get(0)));
+        assertThat(retryTimings.get(5), greaterThan(retryTimings.get(2)));
+    }
+
+}


### PR DESCRIPTION
### Changes

This change adds the ability to retry requests to the Management API that fail due to a rate-limit (429) error. It does so through a new [OkHttp Interceptor](https://square.github.io/okhttp/interceptors/) and the [failsafe library](https://failsafe-lib.github.io/https://failsafe-lib.github.io/).

Details:
* By default, 429 responses are retried three times
* The maximum retries are configurable, between zero and ten. A value of zero results in no retries.
* Retries are configured with an initial delay of 100ms, using an exponential backoff, up to a maximum of 1 second. A jitter factor of 0.2 is applied.
* The configuration of maximum retries is done via the `HttpOptions` object. If/when retries are applied to authentication requests, a similar configuration point will be added for clients to be able to independently configure the maximum retries.
