### PR TITLE
Fix to rollback action version endpoint

### DIFF
--- a/src/test/java/com/auth0/client/mgmt/ActionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ActionsEntityTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.util.*;
 
 import static com.auth0.client.MockServer.bodyFromRequest;
+import static com.auth0.client.MockServer.readFromRequest;
 import static com.auth0.client.RecordedRequestMatcher.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -304,7 +305,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
         assertThat(recordedRequest.getBody(), is(notNullValue()));
-        assertThat(recordedRequest.getBody().size(), is(0L));
+        assertThat(readFromRequest(recordedRequest), is("{}"));
 
         assertThat(response, is(notNullValue()));
     }


### PR DESCRIPTION
### Changes

The rollback action version endpoint currently requires an empty JSON object on the request body, instead of any empty body request. This is a bug and will be addressed, but in the meantime this change sends the empty object on the request.

### References

* See DXEX-1738 for additional information

### Testing

In addition to the updated unit test, this change has been manually verified against the real API.