### PR TITLE
Include log_id in the LogEvent entity

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
@@ -18,6 +18,8 @@ public class LogEvent {
 
     @JsonProperty("_id")
     private String id;
+    @JsonProperty("log_id")
+    private String logId;
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("date")
     private Date date;
@@ -44,6 +46,16 @@ public class LogEvent {
     @JsonProperty("_id")
     public String getId() {
         return id;
+    }
+
+    /**
+     * Getter for the log_id of this event.
+     *
+     * @return the log_id of this event.
+     */
+    @JsonProperty("log_id")
+    public String getLogId() {
+        return logId;
     }
 
     /**

--- a/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
+++ b/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class LogEventTest extends JsonTest<LogEvent> {
 
-    private static final String json = "{\"_id\":\"123\", \"date\":\"2016-02-23T19:57:29.532Z\",\"type\":\"thetype\",\"location_info\":{},\"details\":{},\"client_id\":\"clientId\",\"client_name\":\"clientName\",\"ip\":\"233.233.233.11\",\"user_id\":\"userId\"}";
+    private static final String json = "{\"_id\":\"123\", \"log_id\":\"123\", \"date\":\"2016-02-23T19:57:29.532Z\",\"type\":\"thetype\",\"location_info\":{},\"details\":{},\"client_id\":\"clientId\",\"client_name\":\"clientName\",\"ip\":\"233.233.233.11\",\"user_id\":\"userId\"}";
 
     @Test
     public void shouldDeserialize() throws Exception {
@@ -17,6 +17,7 @@ public class LogEventTest extends JsonTest<LogEvent> {
 
         assertThat(logEvent, is(notNullValue()));
         assertThat(logEvent.getId(), is("123"));
+        assertThat(logEvent.getLogId(), is("123"));
         assertThat(logEvent.getDate(), is(parseJSONDate("2016-02-23T19:57:29.532Z")));
         assertThat(logEvent.getType(), is("thetype"));
         assertThat(logEvent.getClientId(), is("clientId"));


### PR DESCRIPTION
### Changes

The log event schema defines `log_id`, but the `LogEvent` entity only includes `_id`. Actual responses _do_ include both `_id` and `log_id`, so this change adds a new field for the `log_id`.

Fixes #371 