### PR TITLE
Updated page number to start at 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ You can pass an optional Filter to narrow the results in the response.
 Example:
 ```java
 UserFilter filter = new UserFilter()
-    .withPage(1, 20);
+    .withPage(0, 20);
 //...
 Request<UsersPage> request = mgmt.users().list(filter);
 try {


### PR DESCRIPTION
### Changes

- Updated UserFilter `pageNumber` to `0` instead of `1` since first page is 0 as per https://auth0.com/docs/api/management/v2#!/Users/get_users
- I copied the example and was not getting any users back even though there are users in the Auth0 management portal. Quickly realized as the request included page 1 and size 20 and there were only 8 users in the management dashboard, the response returned no users. After changing the pageNumber to `0`, users were returned correctly.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
