### PR TITLE
Add user_name field to LogEvent

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
@@ -33,6 +33,8 @@ public class LogEvent {
     private String ip;
     @JsonProperty("user_id")
     private String userId;
+    @JsonProperty("user_name")
+    private String userName;
     @JsonProperty("location_info")
     private Map<String, Object> locationInfo;
     @JsonProperty("details")
@@ -117,6 +119,16 @@ public class LogEvent {
     @JsonProperty("user_id")
     public String getUserId() {
         return userId;
+    }
+
+    /**
+     * Getter for the user name related to this event.
+     *
+     * @return the user id.
+     */
+    @JsonProperty("user_name")
+    public String getUserName() {
+        return userName;
     }
 
     /**

--- a/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
+++ b/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class LogEventTest extends JsonTest<LogEvent> {
 
-    private static final String json = "{\"_id\":\"123\", \"log_id\":\"123\", \"date\":\"2016-02-23T19:57:29.532Z\",\"type\":\"thetype\",\"location_info\":{},\"details\":{},\"client_id\":\"clientId\",\"client_name\":\"clientName\",\"ip\":\"233.233.233.11\",\"user_id\":\"userId\"}";
+    private static final String json = "{\"_id\":\"123\", \"log_id\":\"123\", \"date\":\"2016-02-23T19:57:29.532Z\",\"type\":\"thetype\",\"location_info\":{},\"details\":{},\"client_id\":\"clientId\",\"client_name\":\"clientName\",\"ip\":\"233.233.233.11\",\"user_id\":\"userId\",\"user_name\":\"userName\"}";
 
     @Test
     public void shouldDeserialize() throws Exception {
@@ -24,6 +24,7 @@ public class LogEventTest extends JsonTest<LogEvent> {
         assertThat(logEvent.getClientName(), is("clientName"));
         assertThat(logEvent.getIP(), is("233.233.233.11"));
         assertThat(logEvent.getUserId(), is("userId"));
+        assertThat(logEvent.getUserName(), is("userName"));
         assertThat(logEvent.getLocationInfo(), is(notNullValue()));
         assertThat(logEvent.getDetails(), is(notNullValue()));
     }


### PR DESCRIPTION
### Changes

This change adds the `user_name` field to the `LogEvent` entity, which was previously missing. 