### PR TITLE
Add MFA Authentication policies to GuardianEntity

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
@@ -1,7 +1,12 @@
 package com.auth0.client.mgmt;
 
+import com.auth0.net.CustomRequest;
+import com.auth0.net.VoidRequest;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.function.Function;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.Nullable;
 
 abstract class BaseManagementEntity {
     protected final OkHttpClient client;
@@ -12,5 +17,56 @@ abstract class BaseManagementEntity {
         this.client = client;
         this.baseUrl = baseUrl;
         this.apiToken = apiToken;
+    }
+
+    protected VoidRequest createVoidRequest(
+        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
+        String method
+    ) {
+        return createVoidRequest(urlBuilder, method, null);
+    }
+
+    protected VoidRequest createVoidRequest(
+        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
+        String method,
+        @Nullable Object body
+    ) {
+        VoidRequest request = new VoidRequest(client, buildUrl(urlBuilder), method);
+        addAuthorizationAndBody(request, body);
+        return request;
+    }
+
+    protected <T> CustomRequest<T> createRequest(
+        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
+        String method,
+        TypeReference<T> responseType
+    ) {
+        return createRequest(urlBuilder, method, responseType, null);
+    }
+
+    protected <T> CustomRequest<T> createRequest(
+        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
+        String method,
+        TypeReference<T> responseType,
+        @Nullable Object body
+    ) {
+        CustomRequest<T> request = new CustomRequest<>(client, buildUrl(urlBuilder), method, responseType);
+        addAuthorizationAndBody(request, body);
+        return request;
+    }
+
+    private String buildUrl(Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder) {
+        return urlBuilder
+            .apply(baseUrl.newBuilder())
+            .build()
+            .toString();
+    }
+
+    private <T> void addAuthorizationAndBody(CustomRequest<T> request, @Nullable Object body) {
+        request.addHeader("Authorization", "Bearer " + apiToken);
+
+        if (body != null) {
+            request.setBody(body);
+        }
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
@@ -1,12 +1,7 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.net.CustomRequest;
-import com.auth0.net.VoidRequest;
-import com.fasterxml.jackson.core.type.TypeReference;
-import java.util.function.Function;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import org.jetbrains.annotations.Nullable;
 
 abstract class BaseManagementEntity {
     protected final OkHttpClient client;
@@ -17,56 +12,5 @@ abstract class BaseManagementEntity {
         this.client = client;
         this.baseUrl = baseUrl;
         this.apiToken = apiToken;
-    }
-
-    protected VoidRequest createVoidRequest(
-        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
-        String method
-    ) {
-        return createVoidRequest(urlBuilder, method, null);
-    }
-
-    protected VoidRequest createVoidRequest(
-        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
-        String method,
-        @Nullable Object body
-    ) {
-        VoidRequest request = new VoidRequest(client, buildUrl(urlBuilder), method);
-        addAuthorizationAndBody(request, body);
-        return request;
-    }
-
-    protected <T> CustomRequest<T> createRequest(
-        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
-        String method,
-        TypeReference<T> responseType
-    ) {
-        return createRequest(urlBuilder, method, responseType, null);
-    }
-
-    protected <T> CustomRequest<T> createRequest(
-        Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
-        String method,
-        TypeReference<T> responseType,
-        @Nullable Object body
-    ) {
-        CustomRequest<T> request = new CustomRequest<>(client, buildUrl(urlBuilder), method, responseType);
-        addAuthorizationAndBody(request, body);
-        return request;
-    }
-
-    private String buildUrl(Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder) {
-        return urlBuilder
-            .apply(baseUrl.newBuilder())
-            .build()
-            .toString();
-    }
-
-    private <T> void addAuthorizationAndBody(CustomRequest<T> request, @Nullable Object body) {
-        request.addHeader("Authorization", "Bearer " + apiToken);
-
-        if (body != null) {
-            request.setBody(body);
-        }
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -1,17 +1,18 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.json.mgmt.guardian.*;
+import com.auth0.json.mgmt.guardian.EnrollmentTicket;
+import com.auth0.json.mgmt.guardian.Factor;
+import com.auth0.json.mgmt.guardian.GuardianTemplates;
+import com.auth0.json.mgmt.guardian.SNSFactorProvider;
+import com.auth0.json.mgmt.guardian.TwilioFactorProvider;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
 import com.auth0.utils.Asserts;
 import com.fasterxml.jackson.core.type.TypeReference;
-import java.util.function.Function;
+import java.util.List;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-
-import java.util.List;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Class that provides an implementation of the Guardian methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Guardian
@@ -38,10 +39,10 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(enrollmentTicket, "enrollment ticket");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/enrollments/ticket")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/enrollments/ticket")
+                .build()
+                .toString();
 
         CustomRequest<EnrollmentTicket> request = new CustomRequest<>(client, url, "POST", new TypeReference<EnrollmentTicket>() {
         });
@@ -61,11 +62,11 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(enrollmentId, "enrollment id");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/enrollments")
-            .addPathSegment(enrollmentId)
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/enrollments")
+                .addPathSegment(enrollmentId)
+                .build()
+                .toString();
         VoidRequest request = new VoidRequest(client, url, "DELETE");
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
@@ -80,10 +81,10 @@ public class GuardianEntity extends BaseManagementEntity {
      */
     public Request<GuardianTemplates> getTemplates() {
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors/sms/templates")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors/sms/templates")
+                .build()
+                .toString();
         CustomRequest<GuardianTemplates> request = new CustomRequest<>(client, url, "GET", new TypeReference<GuardianTemplates>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -102,10 +103,10 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(guardianTemplates, "guardian templates");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors/sms/templates")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors/sms/templates")
+                .build()
+                .toString();
         CustomRequest<GuardianTemplates> request = new CustomRequest<>(client, url, "PUT", new TypeReference<GuardianTemplates>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -121,10 +122,10 @@ public class GuardianEntity extends BaseManagementEntity {
      */
     public Request<List<Factor>> listFactors() {
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors")
+                .build()
+                .toString();
         CustomRequest<List<Factor>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<Factor>>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -144,11 +145,11 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(enabled, "enabled");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors")
-            .addPathSegment(name)
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors")
+                .addPathSegment(name)
+                .build()
+                .toString();
         CustomRequest<Factor> request = new CustomRequest<>(client, url, "PUT", new TypeReference<Factor>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -165,10 +166,10 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<TwilioFactorProvider> getTwilioFactorProvider() {
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
+                .build()
+                .toString();
         CustomRequest<TwilioFactorProvider> request = new CustomRequest<>(client, url, "GET", new TypeReference<TwilioFactorProvider>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -186,10 +187,10 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(provider, "provider");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
+                .build()
+                .toString();
         CustomRequest<TwilioFactorProvider> request = new CustomRequest<>(client, url, "PUT", new TypeReference<TwilioFactorProvider>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -217,10 +218,10 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<SNSFactorProvider> getSNSFactorProvider() {
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
+                .build()
+                .toString();
         CustomRequest<SNSFactorProvider> request = new CustomRequest<>(client, url, "GET", new TypeReference<SNSFactorProvider>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -238,10 +239,10 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(provider, "provider");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
+                .build()
+                .toString();
         CustomRequest<SNSFactorProvider> request = new CustomRequest<>(client, url, "PUT", new TypeReference<SNSFactorProvider>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -268,10 +269,10 @@ public class GuardianEntity extends BaseManagementEntity {
      */
     public Request<List<String>> getAuthenticationPolicies() {
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/policies")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/policies")
+                .build()
+                .toString();
         CustomRequest<List<String>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<String>>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
@@ -288,10 +289,10 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(policies, "policies");
 
         String url = baseUrl
-            .newBuilder()
-            .addPathSegments("api/v2/guardian/policies")
-            .build()
-            .toString();
+                .newBuilder()
+                .addPathSegments("api/v2/guardian/policies")
+                .build()
+                .toString();
         CustomRequest<List<String>> request = new CustomRequest<>(client, url, "PUT", new TypeReference<List<String>>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -1,10 +1,6 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.json.mgmt.guardian.EnrollmentTicket;
-import com.auth0.json.mgmt.guardian.Factor;
-import com.auth0.json.mgmt.guardian.GuardianTemplates;
-import com.auth0.json.mgmt.guardian.SNSFactorProvider;
-import com.auth0.json.mgmt.guardian.TwilioFactorProvider;
+import com.auth0.json.mgmt.guardian.*;
 import com.auth0.net.CustomRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -117,27 +117,7 @@ public class GuardianEntity extends BaseManagementEntity {
      * Update an existing Guardian Factor. A token with scope update:guardian_factors is needed.
      *
      * @param name    the name of the Factor to update.
-     * @param enabled <T> CustomRequest<T> createRequest(
-     *                Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
-     *                String method,
-     *                TypeReference<T> responseType,
-     * @return a Request to execute.
-     * @Nullable Object body
-     * ) {
-     * String url = urlBuilder
-     * .apply(baseUrl.newBuilder())
-     * .build()
-     * .toString();
-     * <p>
-     * CustomRequest<T> request = new CustomRequest<>(client, url, method, responseType);
-     * request.addHeader("Authorization", "Bearer " + apiToken);
-     * <p>
-     * if (body != null) {
-     * request.setBody(body);
-     * }
-     * <p>
-     * return request;
-     * } whether to enable or disable the Factor.
+     * @param enabled  whether to enable or disable the Factor.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/put_factors_by_name">Management API2 docs</a>
      */
     public Request<Factor> updateFactor(String name, Boolean enabled) {

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -37,13 +37,17 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<EnrollmentTicket> createEnrollmentTicket(EnrollmentTicket enrollmentTicket) {
         Asserts.assertNotNull(enrollmentTicket, "enrollment ticket");
 
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/enrollments/ticket"),
-            "POST",
-            new TypeReference<EnrollmentTicket>() {
-            },
-            enrollmentTicket
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/enrollments/ticket")
+            .build()
+            .toString();
+
+        CustomRequest<EnrollmentTicket> request = new CustomRequest<>(client, url, "POST", new TypeReference<EnrollmentTicket>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(enrollmentTicket);
+        return request;
     }
 
     /**
@@ -53,13 +57,18 @@ public class GuardianEntity extends BaseManagementEntity {
      * @return a Request to execute.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id">Management API2 docs</a>
      */
-    public Request<Void> deleteEnrollment(String enrollmentId) {
+    public Request deleteEnrollment(String enrollmentId) {
         Asserts.assertNotNull(enrollmentId, "enrollment id");
 
-        return createVoidRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/enrollments").addPathSegment(enrollmentId),
-            "DELETE"
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/enrollments")
+            .addPathSegment(enrollmentId)
+            .build()
+            .toString();
+        VoidRequest request = new VoidRequest(client, url, "DELETE");
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
     }
 
     /**
@@ -70,12 +79,15 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_templates">Management API2 docs</a>
      */
     public Request<GuardianTemplates> getTemplates() {
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/templates"),
-            "GET",
-            new TypeReference<GuardianTemplates>() {
-            }
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors/sms/templates")
+            .build()
+            .toString();
+        CustomRequest<GuardianTemplates> request = new CustomRequest<>(client, url, "GET", new TypeReference<GuardianTemplates>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
     }
 
     /**
@@ -89,13 +101,16 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<GuardianTemplates> updateTemplates(GuardianTemplates guardianTemplates) {
         Asserts.assertNotNull(guardianTemplates, "guardian templates");
 
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/templates"),
-            "PUT",
-            new TypeReference<GuardianTemplates>() {
-            },
-            guardianTemplates
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors/sms/templates")
+            .build()
+            .toString();
+        CustomRequest<GuardianTemplates> request = new CustomRequest<>(client, url, "PUT", new TypeReference<GuardianTemplates>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(guardianTemplates);
+        return request;
     }
 
     /**
@@ -105,19 +120,22 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_factors">Management API2 docs</a>
      */
     public Request<List<Factor>> listFactors() {
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors"),
-            "GET",
-            new TypeReference<List<Factor>>() {
-            }
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors")
+            .build()
+            .toString();
+        CustomRequest<List<Factor>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<Factor>>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
     }
 
     /**
      * Update an existing Guardian Factor. A token with scope update:guardian_factors is needed.
      *
      * @param name    the name of the Factor to update.
-     * @param enabled  whether to enable or disable the Factor.
+     * @param enabled whether to enable or disable the Factor.
      * @return a Request to execute.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/put_factors_by_name">Management API2 docs</a>
      */
@@ -125,13 +143,15 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(name, "name");
         Asserts.assertNotNull(enabled, "enabled");
 
-        CustomRequest<Factor> request = createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors").addPathSegments(name),
-            "PUT",
-            new TypeReference<Factor>() {
-            }
-        );
-
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors")
+            .addPathSegment(name)
+            .build()
+            .toString();
+        CustomRequest<Factor> request = new CustomRequest<>(client, url, "PUT", new TypeReference<Factor>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("enabled", enabled);
         return request;
     }
@@ -143,12 +163,16 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_twilio">Management API2 docs</a>
      */
     public Request<TwilioFactorProvider> getTwilioFactorProvider() {
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/providers/twilio"),
-            "GET",
-            new TypeReference<TwilioFactorProvider>() {
-            }
-        );
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
+            .build()
+            .toString();
+        CustomRequest<TwilioFactorProvider> request = new CustomRequest<>(client, url, "GET", new TypeReference<TwilioFactorProvider>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
     }
 
     /**
@@ -161,13 +185,16 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<TwilioFactorProvider> updateTwilioFactorProvider(TwilioFactorProvider provider) {
         Asserts.assertNotNull(provider, "provider");
 
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/providers/twilio"),
-            "PUT",
-            new TypeReference<TwilioFactorProvider>() {
-            },
-            provider
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
+            .build()
+            .toString();
+        CustomRequest<TwilioFactorProvider> request = new CustomRequest<>(client, url, "PUT", new TypeReference<TwilioFactorProvider>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(provider);
+        return request;
     }
 
     /**
@@ -188,12 +215,16 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_sns">Management API2 docs</a>
      */
     public Request<SNSFactorProvider> getSNSFactorProvider() {
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors/push-notification/providers/sns"),
-            "GET",
-            new TypeReference<SNSFactorProvider>() {
-            }
-        );
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
+            .build()
+            .toString();
+        CustomRequest<SNSFactorProvider> request = new CustomRequest<>(client, url, "GET", new TypeReference<SNSFactorProvider>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
     }
 
     /**
@@ -206,13 +237,16 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<SNSFactorProvider> updateSNSFactorProvider(SNSFactorProvider provider) {
         Asserts.assertNotNull(provider, "provider");
 
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors/push-notification/providers/sns"),
-            "PUT",
-            new TypeReference<SNSFactorProvider>() {
-            },
-            provider
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
+            .build()
+            .toString();
+        CustomRequest<SNSFactorProvider> request = new CustomRequest<>(client, url, "PUT", new TypeReference<SNSFactorProvider>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(provider);
+        return request;
     }
 
     /**
@@ -233,12 +267,15 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_policies">Management API2 docs</a>
      */
     public Request<List<String>> getAuthenticationPolicies() {
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/policies"),
-            "GET",
-            new TypeReference<List<String>>() {
-            }
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/policies")
+            .build()
+            .toString();
+        CustomRequest<List<String>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<String>>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
     }
 
     /**
@@ -250,12 +287,15 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<List<String>> updateAuthenticationPolicies(List<String> policies) {
         Asserts.assertNotNull(policies, "policies");
 
-        return createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/policies"),
-            "PUT",
-            new TypeReference<List<String>>() {
-            },
-            policies
-        );
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/guardian/policies")
+            .build()
+            .toString();
+        CustomRequest<List<String>> request = new CustomRequest<>(client, url, "PUT", new TypeReference<List<String>>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        request.setBody(policies);
+        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -6,10 +6,12 @@ import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
 import com.auth0.utils.Asserts;
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.function.Function;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Class that provides an implementation of the Guardian methods of the Management API as defined in https://auth0.com/docs/api/management/v2#!/Guardian
@@ -35,17 +37,13 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<EnrollmentTicket> createEnrollmentTicket(EnrollmentTicket enrollmentTicket) {
         Asserts.assertNotNull(enrollmentTicket, "enrollment ticket");
 
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/enrollments/ticket")
-                .build()
-                .toString();
-
-        CustomRequest<EnrollmentTicket> request = new CustomRequest<>(client, url, "POST", new TypeReference<EnrollmentTicket>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        request.setBody(enrollmentTicket);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/enrollments/ticket"),
+            "POST",
+            new TypeReference<EnrollmentTicket>() {
+            },
+            enrollmentTicket
+        );
     }
 
     /**
@@ -55,18 +53,11 @@ public class GuardianEntity extends BaseManagementEntity {
      * @return a Request to execute.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id">Management API2 docs</a>
      */
-    public Request deleteEnrollment(String enrollmentId) {
-        Asserts.assertNotNull(enrollmentId, "enrollment id");
-
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/enrollments")
-                .addPathSegment(enrollmentId)
-                .build()
-                .toString();
-        VoidRequest request = new VoidRequest(client, url, "DELETE");
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+    public Request<Void> deleteEnrollment(String enrollmentId) {
+        return createVoidRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/enrollments").addPathSegment(enrollmentId),
+            "DELETE"
+        );
     }
 
     /**
@@ -77,15 +68,12 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_templates">Management API2 docs</a>
      */
     public Request<GuardianTemplates> getTemplates() {
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors/sms/templates")
-                .build()
-                .toString();
-        CustomRequest<GuardianTemplates> request = new CustomRequest<>(client, url, "GET", new TypeReference<GuardianTemplates>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/templates"),
+            "GET",
+            new TypeReference<GuardianTemplates>() {
+            }
+        );
     }
 
     /**
@@ -99,16 +87,13 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<GuardianTemplates> updateTemplates(GuardianTemplates guardianTemplates) {
         Asserts.assertNotNull(guardianTemplates, "guardian templates");
 
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors/sms/templates")
-                .build()
-                .toString();
-        CustomRequest<GuardianTemplates> request = new CustomRequest<>(client, url, "PUT", new TypeReference<GuardianTemplates>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        request.setBody(guardianTemplates);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/templates"),
+            "PUT",
+            new TypeReference<GuardianTemplates>() {
+            },
+            guardianTemplates
+        );
     }
 
     /**
@@ -118,38 +103,52 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_factors">Management API2 docs</a>
      */
     public Request<List<Factor>> listFactors() {
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors")
-                .build()
-                .toString();
-        CustomRequest<List<Factor>> request = new CustomRequest<>(client, url, "GET", new TypeReference<List<Factor>>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors"),
+            "GET",
+            new TypeReference<List<Factor>>() {
+            }
+        );
     }
 
     /**
      * Update an existing Guardian Factor. A token with scope update:guardian_factors is needed.
      *
      * @param name    the name of the Factor to update.
-     * @param enabled whether to enable or disable the Factor.
+     * @param enabled <T> CustomRequest<T> createRequest(
+     *                Function<HttpUrl.Builder, HttpUrl.Builder> urlBuilder,
+     *                String method,
+     *                TypeReference<T> responseType,
      * @return a Request to execute.
+     * @Nullable Object body
+     * ) {
+     * String url = urlBuilder
+     * .apply(baseUrl.newBuilder())
+     * .build()
+     * .toString();
+     * <p>
+     * CustomRequest<T> request = new CustomRequest<>(client, url, method, responseType);
+     * request.addHeader("Authorization", "Bearer " + apiToken);
+     * <p>
+     * if (body != null) {
+     * request.setBody(body);
+     * }
+     * <p>
+     * return request;
+     * } whether to enable or disable the Factor.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/put_factors_by_name">Management API2 docs</a>
      */
     public Request<Factor> updateFactor(String name, Boolean enabled) {
         Asserts.assertNotNull(name, "name");
         Asserts.assertNotNull(enabled, "enabled");
 
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors")
-                .addPathSegment(name)
-                .build()
-                .toString();
-        CustomRequest<Factor> request = new CustomRequest<>(client, url, "PUT", new TypeReference<Factor>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        CustomRequest<Factor> request = createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors"),
+            "PUT",
+            new TypeReference<Factor>() {
+            }
+        );
+
         request.addParameter("enabled", enabled);
         return request;
     }
@@ -161,16 +160,12 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_twilio">Management API2 docs</a>
      */
     public Request<TwilioFactorProvider> getTwilioFactorProvider() {
-
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
-                .build()
-                .toString();
-        CustomRequest<TwilioFactorProvider> request = new CustomRequest<>(client, url, "GET", new TypeReference<TwilioFactorProvider>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/providers/twilio"),
+            "GET",
+            new TypeReference<TwilioFactorProvider>() {
+            }
+        );
     }
 
     /**
@@ -183,16 +178,13 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<TwilioFactorProvider> updateTwilioFactorProvider(TwilioFactorProvider provider) {
         Asserts.assertNotNull(provider, "provider");
 
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors/sms/providers/twilio")
-                .build()
-                .toString();
-        CustomRequest<TwilioFactorProvider> request = new CustomRequest<>(client, url, "PUT", new TypeReference<TwilioFactorProvider>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        request.setBody(provider);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors/sms/providers/twilio"),
+            "PUT",
+            new TypeReference<TwilioFactorProvider>() {
+            },
+            provider
+        );
     }
 
     /**
@@ -213,16 +205,12 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_sns">Management API2 docs</a>
      */
     public Request<SNSFactorProvider> getSNSFactorProvider() {
-
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
-                .build()
-                .toString();
-        CustomRequest<SNSFactorProvider> request = new CustomRequest<>(client, url, "GET", new TypeReference<SNSFactorProvider>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors/push-notification/providers/sns"),
+            "GET",
+            new TypeReference<SNSFactorProvider>() {
+            }
+        );
     }
 
     /**
@@ -235,16 +223,13 @@ public class GuardianEntity extends BaseManagementEntity {
     public Request<SNSFactorProvider> updateSNSFactorProvider(SNSFactorProvider provider) {
         Asserts.assertNotNull(provider, "provider");
 
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/guardian/factors/push-notification/providers/sns")
-                .build()
-                .toString();
-        CustomRequest<SNSFactorProvider> request = new CustomRequest<>(client, url, "PUT", new TypeReference<SNSFactorProvider>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        request.setBody(provider);
-        return request;
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors/push-notification/providers/sns"),
+            "PUT",
+            new TypeReference<SNSFactorProvider>() {
+            },
+            provider
+        );
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -54,6 +54,8 @@ public class GuardianEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id">Management API2 docs</a>
      */
     public Request<Void> deleteEnrollment(String enrollmentId) {
+        Asserts.assertNotNull(enrollmentId, "enrollment id");
+
         return createVoidRequest(
             (builder) -> builder.addPathSegments("api/v2/guardian/enrollments").addPathSegment(enrollmentId),
             "DELETE"
@@ -143,7 +145,7 @@ public class GuardianEntity extends BaseManagementEntity {
         Asserts.assertNotNull(enabled, "enabled");
 
         CustomRequest<Factor> request = createRequest(
-            (builder) -> builder.addPathSegments("api/v2/guardian/factors"),
+            (builder) -> builder.addPathSegments("api/v2/guardian/factors").addPathSegments(name),
             "PUT",
             new TypeReference<Factor>() {
             }
@@ -241,5 +243,38 @@ public class GuardianEntity extends BaseManagementEntity {
      */
     public Request<SNSFactorProvider> resetSNSFactorProvider() {
         return updateSNSFactorProvider(new SNSFactorProvider(null, null, null, null, null));
+    }
+
+    /**
+     * Get Guardian's MFA authentication policies. A token with scope read:mfa_policies is needed.
+     *
+     * @return a Request to execute
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/get_policies">Management API2 docs</a>
+     */
+    public Request<List<String>> getAuthenticationPolicies() {
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/policies"),
+            "GET",
+            new TypeReference<List<String>>() {
+            }
+        );
+    }
+
+    /**
+     * Updates Guardian's MFA authentication policies. A token with scope update:mfa_policies is needed.
+     *
+     * @return a Request to execute
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/put_policies">Management API2 docs</a>
+     */
+    public Request<List<String>> updateAuthenticationPolicies(List<String> policies) {
+        Asserts.assertNotNull(policies, "policies");
+
+        return createRequest(
+            (builder) -> builder.addPathSegments("api/v2/guardian/policies"),
+            "PUT",
+            new TypeReference<List<String>>() {
+            },
+            policies
+        );
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -118,6 +118,7 @@ public class GuardianEntity extends BaseManagementEntity {
      *
      * @param name    the name of the Factor to update.
      * @param enabled  whether to enable or disable the Factor.
+     * @return a Request to execute.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/put_factors_by_name">Management API2 docs</a>
      */
     public Request<Factor> updateFactor(String name, Boolean enabled) {

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -1,7 +1,10 @@
 package com.auth0.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.MapType;
+import java.util.ArrayList;
+import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -70,6 +73,7 @@ public class MockServer {
     public static final String MGMT_USER = "src/test/resources/mgmt/user.json";
     public static final String MGMT_RECOVERY_CODE = "src/test/resources/mgmt/recovery_code.json";
     public static final String MGMT_IDENTITIES_LIST = "src/test/resources/mgmt/identities_list.json";
+    public static final String MGMT_GUARDIAN_AUTHENTICATION_POLICIES_LIST = "src/test/resources/mgmt/guardian_authentication_policies_list.json";
     public static final String MGMT_GUARDIAN_ENROLLMENT = "src/test/resources/mgmt/guardian_enrollment.json";
     public static final String MGMT_GUARDIAN_ENROLLMENTS_LIST = "src/test/resources/mgmt/guardian_enrollments_list.json";
     public static final String MGMT_GUARDIAN_ENROLLMENT_TICKET = "src/test/resources/mgmt/guardian_enrollment_ticket.json";
@@ -182,6 +186,14 @@ public class MockServer {
         MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
         try (Buffer body = request.getBody()) {
             return mapper.readValue(body.inputStream(), mapType);
+        }
+    }
+
+    public static List<Object> bodyListFromRequest(RecordedRequest request) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        CollectionType listType = mapper.getTypeFactory().constructCollectionType(ArrayList.class, Object.class);
+        try (Buffer body = request.getBody()) {
+            return mapper.readValue(body.inputStream(), listType);
         }
     }
 

--- a/src/test/resources/mgmt/guardian_authentication_policies_list.json
+++ b/src/test/resources/mgmt/guardian_authentication_policies_list.json
@@ -1,0 +1,1 @@
+["all-applications"]


### PR DESCRIPTION
### Changes
I added the endpoints for that were missing. This is kind of required to enable the MFA for your application. 
- Getting MFA policies. https://auth0.com/docs/api/management/v2#!/Guardian/get_policies  
- Update MFA policies https://auth0.com/docs/api/management/v2#!/Guardian/put_policies 

### Testing

```java
AuthAPI auth = new AuthAPI("<>", "<>", "<>");
ManagementAPI api = new ManagementAPI("<>", auth.requestToken("<>").execute().getAccessToken());

System.out.println(api.guardian().getAuthenticationPolicies().execute());
System.out.println(api.guardian().updateAuthenticationPolicies(Arrays.asList("all-applications")).execute());
System.out.println(api.guardian().getAuthenticationPolicies().execute());
System.out.println(api.guardian().updateAuthenticationPolicies(Arrays.asList()).execute());
System.out.println(api.guardian().getAuthenticationPolicies().execute());
```

outputs 

```
[]
[all-applications]
[all-applications]
[]
[]
```

Putting the value to `all-applications` produces the following 
![image](https://user-images.githubusercontent.com/24528884/135723877-7d9ef3e1-b4bb-4a25-b594-e904f1d0093b.png)


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
