### PR TITLE
Fix de/serialization of Invitation roles

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
@@ -1,12 +1,7 @@
 package com.auth0.json.mgmt.organizations;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.deser.std.StringArrayDeserializer;
-import com.fasterxml.jackson.databind.ser.impl.StringArraySerializer;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -51,9 +46,7 @@ public class Invitation {
     @JsonProperty("organization_id")
     private String organizationId;
     @JsonProperty("roles")
-    @JsonDeserialize(using = StringArrayDeserializer.class)
-    @JsonSerialize(using = StringArraySerializer.class)
-    private String[] roles;
+    private List<String> roles;
 
     /**
      * Create a new instance.
@@ -204,7 +197,7 @@ public class Invitation {
      */
     @JsonIgnore
     public Roles getRoles() {
-        return new Roles(Arrays.asList(roles));
+        return new Roles(roles);
     }
 
     /**
@@ -214,8 +207,7 @@ public class Invitation {
      */
     @JsonIgnore
     public void setRoles(Roles roles) {
-        List<String> listOfRoles = roles.getRoles();
-        this.roles = listOfRoles.toArray(new String[0]);
+        this.roles = roles.getRoles();
     }
 
     /**

--- a/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Invitation.java
@@ -1,12 +1,19 @@
 package com.auth0.json.mgmt.organizations;
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StringArrayDeserializer;
+import com.fasterxml.jackson.databind.ser.impl.StringArraySerializer;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Represents the Invitation object for an organization.
+ *
  * @see com.auth0.client.mgmt.OrganizationsEntity
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -44,14 +51,16 @@ public class Invitation {
     @JsonProperty("organization_id")
     private String organizationId;
     @JsonProperty("roles")
-    private Roles roles;
+    @JsonDeserialize(using = StringArrayDeserializer.class)
+    @JsonSerialize(using = StringArraySerializer.class)
+    private String[] roles;
 
     /**
      * Create a new instance.
      *
-     * @param inviter the {@linkplain Inviter} of this invitation.
-     * @param invitee the {@linkplain Invitee} of this invitation.
-     * @param clientId The id of the connection the invitee will authenticate with.\
+     * @param inviter  the {@linkplain Inviter} of this invitation.
+     * @param invitee  the {@linkplain Invitee} of this invitation.
+     * @param clientId Auth0 client ID. Used to resolve the application's login initiation endpoint.
      */
     @JsonCreator
     public Invitation(@JsonProperty("inviter") Inviter inviter, @JsonProperty("invitee") Invitee invitee, @JsonProperty("client_id") String clientId) {
@@ -193,8 +202,9 @@ public class Invitation {
     /**
      * @return the roles associated with the user invited.
      */
+    @JsonIgnore
     public Roles getRoles() {
-        return roles;
+        return new Roles(Arrays.asList(roles));
     }
 
     /**
@@ -202,8 +212,10 @@ public class Invitation {
      *
      * @param roles the {@linkplain Roles} to associated with the user invited.
      */
+    @JsonIgnore
     public void setRoles(Roles roles) {
-        this.roles = roles;
+        List<String> listOfRoles = roles.getRoles();
+        this.roles = listOfRoles.toArray(new String[0]);
     }
 
     /**

--- a/src/test/java/com/auth0/json/mgmt/organizations/InvitationTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/InvitationTest.java
@@ -29,12 +29,16 @@ public class InvitationTest extends JsonTest<Invitation> {
             "  \"ticket_id\": \"ticket-id\",\n" +
             "  \"created_at\": \"2021-03-31T19:08:40.295Z\",\n" +
             "  \"expires_at\": \"2021-04-07T19:08:40.295Z\",\n" +
-            "  \"organization_id\": \"org_abc\"\n" +
+            "  \"organization_id\": \"org_abc\",\n" +
+            "  \"roles\": [\n" +
+            "    \"rol_0987\"\n" +
+            "  ]\n" +
             "}\n";
 
         Invitation invitation = fromJSON(json, Invitation.class);
 
         assertThat(invitation, is(notNullValue()));
+        assertThat(invitation.getRoles().getRoles(), is(contains("rol_0987")));
         assertThat(invitation.getId(), is("inv_1"));
         assertThat(invitation.getClientId(), is("client-id"));
         assertThat(invitation.getInviter(), is(notNullValue()));


### PR DESCRIPTION
### Changes

The Invitation object has an array of strings for the `roles` ids. This is NOT an object and thus, should not be serialized wrapped as an object.

### References

Fixes #378 without introducing breaking changes.

### Testing

Manually tested with the following snippets. Also, fixed unit tests.

```java
static void assignRole(ManagementAPI api) {
    try {
        api.organizations().addRoles(ORG_ID,
            USER_ID,
            new Roles(Arrays.asList(ADMIN_ROLE_ID)))
            .execute();
    } catch (Auth0Exception e) {
        e.printStackTrace();
    }
}

static void listInvitations(ManagementAPI api) {
    try {
        // Originally failed when invitation contains one or more Roles
        InvitationsPage page = api.organizations().getInvitations(ORG_ID, null).execute();
        for (Invitation i : page.getItems()) {
            System.out.println(i);
        }
    } catch (Auth0Exception e) {
        e.printStackTrace();
    }
}

static void sendInvitation(ManagementAPI api) {
    Invitation invitation = new Invitation(
        new Inviter("Luciano"),
        new Invitee("luciano.balmaceda@auth0.com"),
        CLIENT_ID
    );
    invitation.setRoles(new Roles(Arrays.asList(ADMIN_ROLE_ID)));
    Invitation result;
    try {
        // Originally failed because invitation contains one or more Roles
        result = api.organizations().createInvitation(ORG_ID, invitation).execute();
        System.out.println(result.getInvitationUrl());
    } catch (Auth0Exception e) {
        e.printStackTrace();
    }
}
```
