### PR TITLE
remove warning for untyped requests

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -109,7 +109,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
      * @param clientGrantId the client grant id.
      * @return a Request to execute.
      */
-    public Request delete(String clientGrantId) {
+    public Request<Void> delete(String clientGrantId) {
         Asserts.assertNotNull(clientGrantId, "client grant id");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
@@ -79,7 +79,7 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
      * @param deviceCredentialsId the device credentials id
      * @return a Request to execute.
      */
-    public Request delete(String deviceCredentialsId) {
+    public Request<Void> delete(String deviceCredentialsId) {
         Asserts.assertNotNull(deviceCredentialsId, "device credentials id");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
@@ -76,7 +76,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
      *
      * @return a Request to execute.
      */
-    public Request delete() {
+    public Request<Void> delete() {
         String url = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/emails/provider")

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -54,7 +54,7 @@ public class GuardianEntity extends BaseManagementEntity {
      * @return a Request to execute.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id">Management API2 docs</a>
      */
-    public Request deleteEnrollment(String enrollmentId) {
+    public Request<Void> deleteEnrollment(String enrollmentId) {
         Asserts.assertNotNull(enrollmentId, "enrollment id");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -124,7 +124,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
      * @param logStreamId The ID of the Log Stream to delete.
      * @return the request to execute.
      */
-    public Request delete(String logStreamId) {
+    public Request<Void> delete(String logStreamId) {
         Asserts.assertNotNull(logStreamId, "log stream id");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -169,7 +169,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_organizations_by_id">https://auth0.com/docs/api/management/v2#!/Organizations/delete_organizations_by_id</a>
      */
-    public Request delete(String orgId) {
+    public Request<Void> delete(String orgId) {
         Asserts.assertNotNull(orgId, "organization ID");
 
         String url = baseUrl
@@ -222,7 +222,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_members">https://auth0.com/docs/api/management/v2#!/Organizations/post_members</a>
      */
-    public Request addMembers(String orgId, Members members) {
+    public Request<Void> addMembers(String orgId, Members members) {
         Asserts.assertNotNull(orgId, "organization ID");
         Asserts.assertNotNull(members, "members");
 
@@ -249,7 +249,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_members">https://auth0.com/docs/api/management/v2#!/Organizations/delete_members</a>
      */
-    public Request deleteMembers(String orgId, Members members) {
+    public Request<Void> deleteMembers(String orgId, Members members) {
         Asserts.assertNotNull(orgId, "organization ID");
         Asserts.assertNotNull(members, "members");
 
@@ -361,7 +361,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_enabled_connections_by_connectionId">https://auth0.com/docs/api/management/v2#!/Organizations/delete_enabled_connections_by_connectionId</a>
      */
-    public Request deleteConnection(String  orgId, String connectionId) {
+    public Request<Void> deleteConnection(String  orgId, String connectionId) {
         Asserts.assertNotNull(orgId, "organization ID");
         Asserts.assertNotNull(connectionId, "connection ID");
 
@@ -453,7 +453,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/post_organization_member_roles">https://auth0.com/docs/api/management/v2#!/Organizations/post_organization_member_roles</a>
      */
-    public Request addRoles(String orgId, String userId, Roles roles) {
+    public Request<Void> addRoles(String orgId, String userId, Roles roles) {
         Asserts.assertNotNull(orgId, "organization ID");
         Asserts.assertNotNull(userId, "user ID");
         Asserts.assertNotNull(roles, "roles");
@@ -484,7 +484,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_organization_member_roles">https://auth0.com/docs/api/management/v2#!/Organizations/delete_organization_member_roles</a>
      */
-    public Request deleteRoles(String orgId, String userId, Roles roles) {
+    public Request<Void> deleteRoles(String orgId, String userId, Roles roles) {
         Asserts.assertNotNull(orgId, "organization ID");
         Asserts.assertNotNull(userId, "user ID");
         Asserts.assertNotNull(roles, "roles");
@@ -602,7 +602,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
      *
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/delete_invitations_by_invitation_id">https://auth0.com/docs/api/management/v2#!/Organizations/delete_invitations_by_invitation_id</a>
      */
-    public Request deleteInvitation(String orgId, String invitationId) {
+    public Request<Void> deleteInvitation(String orgId, String invitationId) {
         Asserts.assertNotNull(orgId, "organization ID");
         Asserts.assertNotNull(invitationId, "invitation ID");
 

--- a/src/main/java/com/auth0/client/mgmt/RolesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RolesEntity.java
@@ -109,7 +109,7 @@ public class RolesEntity extends BaseManagementEntity {
    * @param roleId The id of the role to delete.
    * @return a Request to execute.
    */
-  public Request delete(String roleId) {
+  public Request<Void> delete(String roleId) {
     Asserts.assertNotNull(roleId, "role id");
 
     final String url = baseUrl
@@ -185,7 +185,7 @@ public class RolesEntity extends BaseManagementEntity {
    * @param userIds a list of user ids to assign to the role
    * @return a Request to execute.
    */
-  public Request assignUsers(String roleId, List<String> userIds) {
+  public Request<Void> assignUsers(String roleId, List<String> userIds) {
     Asserts.assertNotNull(roleId, "role id");
     Asserts.assertNotEmpty(userIds, "user ids");
 
@@ -242,7 +242,7 @@ public class RolesEntity extends BaseManagementEntity {
    * @param permissions a list of permission objects to un-associate from the role
    * @return a Request to execute
    */
-  public Request removePermissions(String roleId, List<Permission> permissions) {
+  public Request<Void> removePermissions(String roleId, List<Permission> permissions) {
     Asserts.assertNotNull(roleId, "role id");
     Asserts.assertNotEmpty(permissions, "permissions");
 
@@ -272,7 +272,7 @@ public class RolesEntity extends BaseManagementEntity {
    * @param permissions a list of permission objects to associate to the role
    * @return a Request to execute
    */
-  public Request addPermissions(String roleId, List<Permission> permissions) {
+  public Request<Void> addPermissions(String roleId, List<Permission> permissions) {
     Asserts.assertNotNull(roleId, "role id");
     Asserts.assertNotEmpty(permissions, "permissions");
 

--- a/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
@@ -51,7 +51,7 @@ public class RulesConfigsEntity extends BaseManagementEntity {
      * @param rulesConfigKey the rules config key
      * @return a Request to execute.
      */
-    public Request delete(String rulesConfigKey) {
+    public Request<Void> delete(String rulesConfigKey) {
         Asserts.assertNotNull(rulesConfigKey, "rules config key");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
@@ -52,7 +52,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
      * @param identifier the identifier. Either a username, phone_number, or email.
      * @return a Request to execute.
      */
-    public Request deleteByIdentifier(String identifier) {
+    public Request<Void> deleteByIdentifier(String identifier) {
         Asserts.assertNotNull(identifier, "identifier");
 
         String url = baseUrl
@@ -95,7 +95,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
      * @param userId the user id.
      * @return a Request to execute.
      */
-    public Request delete(String userId) {
+    public Request<Void> delete(String userId) {
         Asserts.assertNotNull(userId, "user id");
 
         String url = baseUrl

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -162,7 +162,7 @@ public class UsersEntity extends BaseManagementEntity {
      * @param userId the user id
      * @return a Request to execute.
      */
-    public Request delete(String userId) {
+    public Request<Void> delete(String userId) {
         Asserts.assertNotNull(userId, "user id");
 
         String url = baseUrl
@@ -266,7 +266,7 @@ public class UsersEntity extends BaseManagementEntity {
      * @param provider the multifactor provider
      * @return a Request to execute.
      */
-    public Request deleteMultifactorProvider(String userId, String provider) {
+    public Request<Void> deleteMultifactorProvider(String userId, String provider) {
         Asserts.assertNotNull(userId, "user id");
         Asserts.assertNotNull(provider, "provider");
 
@@ -441,7 +441,7 @@ public class UsersEntity extends BaseManagementEntity {
      * @param permissions a list of permission objects to remove from the user
      * @return a Request to execute
      */
-    public Request removePermissions(String userId, List<Permission> permissions) {
+    public Request<Void> removePermissions(String userId, List<Permission> permissions) {
         Asserts.assertNotNull(userId, "user id");
         Asserts.assertNotEmpty(permissions, "permissions");
 
@@ -470,7 +470,7 @@ public class UsersEntity extends BaseManagementEntity {
      * @param permissions a list of permission objects to assign to the user
      * @return a Request to execute
      */
-    public Request addPermissions(String userId, List<Permission> permissions) {
+    public Request<Void> addPermissions(String userId, List<Permission> permissions) {
         Asserts.assertNotNull(userId, "user id");
         Asserts.assertNotEmpty(permissions, "permissions");
 
@@ -528,7 +528,7 @@ public class UsersEntity extends BaseManagementEntity {
      * @param roleIds a list of role ids to remove from the user
      * @return a Request to execute
      */
-    public Request removeRoles(String userId, List<String> roleIds) {
+    public Request<Void> removeRoles(String userId, List<String> roleIds) {
         Asserts.assertNotNull(userId, "user id");
         Asserts.assertNotEmpty(roleIds, "role ids");
 
@@ -557,7 +557,7 @@ public class UsersEntity extends BaseManagementEntity {
      * @param roleIds a list of role ids to assign to the user
      * @return a Request to execute
      */
-    public Request addRoles(String userId, List<String> roleIds) {
+    public Request<Void> addRoles(String userId, List<String> roleIds) {
         Asserts.assertNotNull(userId, "user id");
         Asserts.assertNotEmpty(roleIds, "role ids");
 

--- a/src/test/java/com/auth0/client/mgmt/ActionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ActionsEntityTest.java
@@ -118,7 +118,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteAction() throws Exception {
-        Request request = api.actions().delete("action-id");
+        Request<Void> request = api.actions().delete("action-id");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -133,7 +133,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldForceDeleteAction() throws Exception {
-        Request request = api.actions().delete("action-id", true);
+        Request<Void> request = api.actions().delete("action-id", true);
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);

--- a/src/test/java/com/auth0/client/mgmt/BlacklistsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/BlacklistsEntityTest.java
@@ -61,7 +61,7 @@ public class BlacklistsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldBlacklistToken() throws Exception {
-        Request request = api.blacklists().blacklistToken(new Token("id"));
+        Request<Void> request = api.blacklists().blacklistToken(new Token("id"));
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_BLACKLISTED_TOKENS_LIST, 200);

--- a/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
@@ -185,7 +185,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteClientGrant() throws Exception {
-        Request request = api.clientGrants().delete("1");
+        Request<Void> request = api.clientGrants().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANT, 200);

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -211,7 +211,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteClient() throws Exception {
-        Request request = api.clients().delete("1");
+        Request<Void> request = api.clients().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);

--- a/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
@@ -273,7 +273,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteConnection() throws Exception {
-        Request request = api.connections().delete("1");
+        Request<Void> request = api.connections().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
@@ -336,7 +336,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteConnectionUser() throws Exception {
-        Request request = api.connections().deleteUser("1", "user@domain.com");
+        Request<Void> request = api.connections().deleteUser("1", "user@domain.com");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);

--- a/src/test/java/com/auth0/client/mgmt/DeviceCredentialsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/DeviceCredentialsEntityTest.java
@@ -163,7 +163,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteDeviceCredentials() throws Exception {
-        Request request = api.deviceCredentials().delete("1");
+        Request<Void> request = api.deviceCredentials().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS, 200);

--- a/src/test/java/com/auth0/client/mgmt/EmailProviderEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailProviderEntityTest.java
@@ -79,7 +79,7 @@ public class EmailProviderEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteEmailProvider() throws Exception {
-        Request request = api.emailProvider().delete();
+        Request<Void> request = api.emailProvider().delete();
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);

--- a/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
@@ -167,7 +167,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteGrantById() throws Exception {
-        Request request = api.grants().delete("1");
+        Request<Void> request = api.grants().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
@@ -188,7 +188,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteAllGrantsByUserId() throws Exception {
-        Request request = api.grants().deleteAll("userId");
+        Request<Void> request = api.grants().deleteAll("userId");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);

--- a/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
@@ -135,7 +135,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteLogStream() throws Exception {
-        Request request = api.logStreams().delete("1");
+        Request<Void> request = api.logStreams().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -249,7 +249,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteOrganization() throws Exception {
-        Request request = api.organizations().delete("org_abc");
+        Request<Void> request = api.organizations().delete("org_abc");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -364,7 +364,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     public void shouldAddMembersToOrganization() throws Exception {
         List<String> membersList = Arrays.asList("user1", "user2");
         Members members = new Members(membersList);
-        Request request = api.organizations().addMembers("org_abc", members);
+        Request<Void> request = api.organizations().addMembers("org_abc", members);
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -398,7 +398,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     public void shouldDeleteMembersFromOrganization() throws Exception {
         List<String> membersList = Collections.singletonList("user1");
         Members members = new Members(membersList);
-        Request request = api.organizations().deleteMembers("org_abc", members);
+        Request<Void> request = api.organizations().deleteMembers("org_abc", members);
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -562,7 +562,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteConnection() throws Exception {
-        Request request = api.organizations().deleteConnection("org_abc", "con_123");
+        Request<Void> request = api.organizations().deleteConnection("org_abc", "con_123");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -710,7 +710,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldAddOrgRoles() throws Exception {
         List<String> rolesList = Arrays.asList("role_1", "role_2");
-        Request request = api.organizations().addRoles("org_abc", "user_123", new Roles(rolesList));
+        Request<Void> request = api.organizations().addRoles("org_abc", "user_123", new Roles(rolesList));
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -750,7 +750,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     @Test
     public void shouldDeleteOrgRoles() throws Exception {
         List<String> rolesList = Arrays.asList("role_1", "role_2");
-        Request request = api.organizations().deleteRoles("org_abc", "user_123", new Roles(rolesList));
+        Request<Void> request = api.organizations().deleteRoles("org_abc", "user_123", new Roles(rolesList));
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
@@ -962,7 +962,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteInvitation() throws Exception {
-        Request request = api.organizations().deleteInvitation("org_abc", "inv_123");
+        Request<Void> request = api.organizations().deleteInvitation("org_abc", "inv_123");
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);

--- a/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
@@ -180,7 +180,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
 
   @Test
   public void shouldDeleteRole() throws Exception {
-    Request request = api.roles().delete("1");
+    Request<Void> request = api.roles().delete("1");
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
@@ -309,7 +309,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
   public void shouldAssignUsers() throws Exception {
     List<String> userIds = new ArrayList<>();
     userIds.add("userId");
-    Request request = api.roles().assignUsers("1", userIds);
+    Request<Void> request = api.roles().assignUsers("1", userIds);
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
@@ -414,7 +414,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     Permission permission = new Permission();
     permission.setName("permissionName");
     permissions.add(permission);
-    Request request = api.roles().addPermissions("1", permissions);
+    Request<Void> request = api.roles().addPermissions("1", permissions);
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
@@ -459,7 +459,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     Permission permission = new Permission();
     permission.setName("permissionName");
     permissions.add(permission);
-    Request request = api.roles().removePermissions("1", permissions);
+    Request<Void> request = api.roles().removePermissions("1", permissions);
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);

--- a/src/test/java/com/auth0/client/mgmt/RulesConfigsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesConfigsEntityTest.java
@@ -54,7 +54,7 @@ public class RulesConfigsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteRulesConfig() throws Exception {
-        Request request = api.rulesConfigs().delete("1");
+        Request<Void> request = api.rulesConfigs().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);

--- a/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
@@ -251,7 +251,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteRule() throws Exception {
-        Request request = api.rules().delete("1");
+        Request<Void> request = api.rules().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);

--- a/src/test/java/com/auth0/client/mgmt/UserBlocksEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UserBlocksEntityTest.java
@@ -69,7 +69,7 @@ public class UserBlocksEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteUserBlocksByIdentifier() throws Exception {
-        Request request = api.userBlocks().deleteByIdentifier("username");
+        Request<Void> request = api.userBlocks().deleteByIdentifier("username");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_BLOCKS, 200);
@@ -91,7 +91,7 @@ public class UserBlocksEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteUserBlocks() throws Exception {
-        Request request = api.userBlocks().delete("1");
+        Request<Void> request = api.userBlocks().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_BLOCKS, 200);

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -299,7 +299,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteUser() throws Exception {
-        Request request = api.users().delete("1");
+        Request<Void> request = api.users().delete("1");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER, 200);
@@ -514,7 +514,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldDeleteUserMultifactorProvider() throws Exception {
-        Request request = api.users().deleteMultifactorProvider("1", "duo");
+        Request<Void> request = api.users().deleteMultifactorProvider("1", "duo");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
@@ -774,7 +774,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldAddRoles() throws Exception {
-        Request request = api.users().addRoles("1",  Collections.singletonList("roleId"));
+        Request<Void> request = api.users().addRoles("1",  Collections.singletonList("roleId"));
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
@@ -815,7 +815,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldRemoveRoles() throws Exception {
-        Request request = api.users().removeRoles("1", Collections.singletonList("roleId"));
+        Request<Void> request = api.users().removeRoles("1", Collections.singletonList("roleId"));
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse( 200);
@@ -920,7 +920,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         Permission permission = new Permission();
         permission.setName("permissionName");
         permissions.add(permission);
-        Request request = api.users().addPermissions("1", permissions);
+        Request<Void> request = api.users().addPermissions("1", permissions);
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
@@ -965,7 +965,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         Permission permission = new Permission();
         permission.setName("permissionName");
         permissions.add(permission);
-        Request request = api.users().removePermissions("1", permissions);
+        Request<Void> request = api.users().removePermissions("1", permissions);
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

I Added specific typing for void requests. This is important because first, IDEs usually give warnings when an object's type is not specified. It does not do anything at runtime because of type-erasure, but it makes it impossible for the IDE to know what is supposed to come out of that object. 

![image](https://user-images.githubusercontent.com/24528884/139279522-8ce1a1ba-9c52-4779-80c9-10e8efb3b029.png)

This causes a small inconvenience when using the library. In my case, I wrapped the auth0 library with custom code that handles Rate-limiting better and automatically execute requests, which is why the dynamic typing is needed.

![image](https://user-images.githubusercontent.com/24528884/139279964-841649d7-2d91-4a62-a170-d2517b32c6fe.png)

I was therefore forced to specify myself the `Any` type (because the library doesn't specify the `Void`)

![image](https://user-images.githubusercontent.com/24528884/139281549-c0413e39-d4d0-4d41-9e0f-af64393d36ef.png)


### Testing

Does not impact tests. It just removes warnings.

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
