### PR TITLE
MU-2967 added method to support PKCE token exchange

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -756,6 +756,48 @@ public class AuthAPI {
     }
 
     /**
+     * Creates a request to exchange the code obtained in the /authorize call using the 'Authorization Code Flow with PKCE'.
+     * <pre>
+     * {@code
+     * // client secret not used in this call
+     * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "");
+     * try {
+     *      TokenHolder result = auth.exchangeCode("SnWoFLMzApDskr", "https://me.auth0.com/callback", "YOUR_GENERATED_CODE_VERIFIER")
+     *          .setScope("openid name nickname")
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param code          the authorization code received from the redirect after successful user Authorization via PKCE {@see https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow-with-pkce#authorize-user}
+     * @param redirectUri   the redirect uri used to generate the authorization url {@see https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow-with-pkce#example-authorization-url}
+     * @param codeVerifier  The cryptographically-random key that you generated and used in the authorization url {@see https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow-with-pkce#create-code-verifier}
+     * @return a Request to configure and execute.
+     */
+    public TokenRequest exchangeCode(String code, String redirectUri, String codeVerifier) {
+        Asserts.assertNotNull(code, "code");
+        Asserts.assertNotNull(codeVerifier, "code verifier");
+        Asserts.assertNotNull(redirectUri, "redirect uri");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegment(PATH_OAUTH)
+            .addPathSegment(PATH_TOKEN)
+            .build()
+            .toString();
+        TokenRequest request = new TokenRequest(client, url);
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        request.addParameter(KEY_GRANT_TYPE, "authorization_code");
+        request.addParameter("code", code);
+        request.addParameter("code_verifier", codeVerifier);
+        request.addParameter("redirect_uri", redirectUri);
+
+        return request;
+    }
+
+    /**
      * Create a request to send an email containing a link or a code to begin authentication with Passwordless connections.
      *
      * <pre>

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -769,6 +769,88 @@ public class AuthAPITest {
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
+    //Log In with PCKE AuthorizationCode Grant
+
+    @Test
+    public void shouldThrowOnLogInWithPckeAuthorizationCodeGrantAndRedirectUriWithNullCode() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'code' cannot be null!");
+        api.exchangeCode(null, "https://domain.auth0.com/callback", "code_verifier");
+    }
+
+    @Test
+    public void shouldThrowOnLogInWithPckeAuthorizationCodeGrantAndRedirectUriWithNullRedirectUri() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'redirect uri' cannot be null!");
+        api.exchangeCode("code", null, "code_verifier");
+    }
+
+    @Test
+    public void shouldThrowOnLogInWithPckeAuthorizationCodeGrantAndRedirectUriWithNullCodeVerifier() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'code verifier' cannot be null!");
+        api.exchangeCode("code", "https://domain.auth0.com/callback", null);
+    }
+
+    @Test
+    public void shouldCreateLogInWithPckeAuthorizationCodeGrantRequest() throws Exception {
+        AuthRequest request = api.exchangeCode("code123", "https://domain.auth0.com/callback", "code_verifier");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("code", "code123"));
+        assertThat(body, hasEntry("redirect_uri", "https://domain.auth0.com/callback"));
+        assertThat(body, hasEntry("grant_type", "authorization_code"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("code_verifier", "code_verifier"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateLogInWithPckeAuthorizationCodeGrantRequestWithCustomParameters() throws Exception {
+        AuthRequest request = api.exchangeCode("code123", "https://domain.auth0.com/callback", "code_verifier");
+        assertThat(request, is(notNullValue()));
+        request.setAudience("https://myapi.auth0.com/users");
+        request.setRealm("dbconnection");
+        request.setScope("profile photos contacts");
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("code", "code123"));
+        assertThat(body, hasEntry("redirect_uri", "https://domain.auth0.com/callback"));
+        assertThat(body, hasEntry("grant_type", "authorization_code"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("code_verifier", "code_verifier"));
+        assertThat(body, hasEntry("audience", "https://myapi.auth0.com/users"));
+        assertThat(body, hasEntry("realm", "dbconnection"));
+        assertThat(body, hasEntry("scope", "profile photos contacts"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), is(notNullValue()));
+    }
 
     //Log In with Password grant
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Added method to exchange authorization codes generated through the [PKCE](https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow-with-pkce) flow

### References

Please include relevant links supporting this change such as a:

- https://auth0.com/docs/authorization/flows/call-your-api-using-the-authorization-code-flow-with-pkce

### Testing

I generated a URL & code via this kotlin code

```kotlin
import com.toasttab.service.authentication.services.Auth0Service.Companion.SCOPES
import java.security.MessageDigest
import java.security.SecureRandom
import java.util.Base64
import javax.ws.rs.core.UriBuilder

data class GetAuthorizationCodeUrlRequest(
    val audience: String,
    val domain: String,
    val nativeClientId: String,
    val redirectUrl: String,
    val authState: String? = null
)

data class AuthorizationCodeUrlResponse(
    val codeVerifier: String,
    val url: String
)

fun getAuthorizationCodeUrl(request: GetAuthorizationCodeUrlRequest): AuthorizationCodeUrlResponse {
    // create code verifier
    val sr = SecureRandom()
    val code = ByteArray(32)
    sr.nextBytes(code)
    val verifier: String = Base64.getUrlEncoder().withoutPadding().encodeToString(code)
    // create code challenge
    val bytes = verifier.toByteArray(charset("US-ASCII"))
    val md = MessageDigest.getInstance("SHA-256")
    md.update(bytes, 0, bytes.size)
    val digest = md.digest()
    val challenge: String = org.apache.commons.codec.binary.Base64.encodeBase64URLSafeString(digest)
    // authorize user
    val urlBuilder = UriBuilder
        .fromPath("https://${request.domain}/authorize")
        .queryParam("response_type", "code")
        .queryParam("code_challenge_method", "S256")
        .queryParam("code_challenge", challenge)
        .queryParam("scope", SCOPES)
        .queryParam("client_id", request.nativeClientId)
        .queryParam("audience", request.audience)
        .queryParam("redirect_uri", request.redirectUrl)

    if (!request.authState.isNullOrBlank()) {
        urlBuilder.queryParam("state", request.authState)
    }

    return AuthorizationCodeUrlResponse(codeVerifier = verifier, url = urlBuilder.build().toString())
}

val request = GetAuthorizationCodeUrlRequest(
    audience = "redacted",
    domain =  "redacted",
    nativeClientId =  "redacted",
    redirectUrl =  "redacted",
)

val response = getAuthorizationCodeUrl(request)
```

I then navigated to the generated url, signed in as a user, and then used the library as so

```kotlin
val tokenResponse: TokenHolder = AuthAPI("redacted-domain", "redacted-client-id", "")
    .exchangeCode("authorization-code", "redacted-redirect", "code-verifier")
    .execute()
```
which returned a correct JWT

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
