### PR TITLE
Release 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.36.0](https://github.com/auth0/auth0-java/tree/1.36.0) (2022-01-10)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/1.35.0...1.36.0)
+
+**Fixed**
+- [SDK-2975] Fix withOrganization method visibility on token verifier [\#388](https://github.com/auth0/auth0-java/pull/388) ([jimmyjames](https://github.com/jimmyjames))
+- remove warning for untyped requests [\#385](https://github.com/auth0/auth0-java/pull/385) ([pelletier197](https://github.com/pelletier197))
+
 ## [1.35.0](https://github.com/auth0/auth0-java/tree/1.35.0) (2021-10-20)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/1.34.1...1.35.0)
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Get Auth0 Java via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>1.35.0</version>
+  <version>1.36.0</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:1.35.0'
+implementation 'com.auth0:auth0:1.36.0'
 ```
 
 


### PR DESCRIPTION
Release 1.36.0.

**Fixed**
- [SDK-2975] Fix withOrganization method visibility on token verifier [\#388](https://github.com/auth0/auth0-java/pull/388) ([jimmyjames](https://github.com/jimmyjames))
- remove warning for untyped requests [\#385](https://github.com/auth0/auth0-java/pull/385) ([pelletier197](https://github.com/pelletier197))


[SDK-2975]: https://auth0team.atlassian.net/browse/SDK-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ