### PR TITLE
Improve logging

### DIFF
--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -9,6 +9,7 @@ public class HttpOptions {
     private int connectTimeout = 10;
     private int readTimeout = 10;
     private int mgmtApiMaxRetries = 3;
+    private LoggingOptions loggingOptions;
 
     /**
      * Getter for the Proxy configuration options
@@ -66,6 +67,21 @@ public class HttpOptions {
             readTimeout = 0;
         }
         this.readTimeout = readTimeout;
+    }
+
+    /**
+     * Set the HTTP logging configuration options. If not set, no logs will be captured.
+     * @param loggingOptions the Logging configuration options
+     */
+    public void setLoggingOptions(LoggingOptions loggingOptions) {
+        this.loggingOptions = loggingOptions;
+    }
+
+    /**
+     * @return the Logging configurration options if set, null otherwise.
+     */
+    public LoggingOptions getLoggingOptions() {
+        return this.loggingOptions;
     }
 
     /**

--- a/src/main/java/com/auth0/client/LoggingOptions.java
+++ b/src/main/java/com/auth0/client/LoggingOptions.java
@@ -1,0 +1,77 @@
+package com.auth0.client;
+
+import com.auth0.utils.Asserts;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Used to configure the HTTP Logging options.
+ */
+public class LoggingOptions {
+
+    public enum LogLevel {
+
+        /**
+         * No logging.
+         */
+        NONE,
+
+        /**
+         * Logs request and response lines.
+         */
+        BASIC,
+
+        /**
+         * Logs request and response lines, along with their respective headers. Note that headers may contain
+         * sensitive information; see {@linkplain #headersToRedact}
+         */
+        HEADERS,
+
+        /**
+         * Logs request and response lines, along with their respective headers and bodies. Note that headers and bodies
+         * may contain sensitive information; see {@linkplain #headersToRedact} for header redaction, but that only
+         * applies to headers. This should only be used in controlled or non-production environments.
+         */
+        BODY
+    }
+
+    private LogLevel logLevel;
+    private Set<String> headersToRedact = Collections.emptySet();
+
+    /**
+     * Create a new instance using the specified {@linkplain LogLevel}
+     * @param logLevel the log level to set. Must not be null.
+     */
+    public LoggingOptions(LogLevel logLevel) {
+        Asserts.assertNotNull(logLevel, "logLevel");
+        this.logLevel = logLevel;
+    }
+
+    /**
+     * @return the log level of this instance.
+     */
+    public LogLevel getLogLevel() {
+        return this.logLevel;
+    }
+
+    /**
+     * @return the headers that should be redacted from the output log.
+     */
+    public Set<String> getHeadersToRedact() {
+        return headersToRedact;
+    }
+
+    /**
+     * Sets the headers to redact from the log. When using {@code HEADERS} or {@code BODY} logging levels, there is the
+     * potential of leaking sensitive information such as "Authorization" or "Cookie" headers. Note that this does not
+     * redact any of the body contents from being logged, so care must always be taken with {@code HEADERS} or {@code BODY}
+     * log levels.
+     *
+     * @param headersToRedact the Set of headers to redact.
+     */
+    public void setHeadersToRedact(Set<String> headersToRedact) {
+        this.headersToRedact = headersToRedact;
+    }
+
+}

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -155,13 +155,9 @@ public class AuthAPI {
     }
 
     /**
-     * @deprecated use the logging configuration available in {@link HttpOptions#setLoggingOptions(LoggingOptions)}
-     *
      * Whether to enable or not the current HTTP Logger for every Request, Response and other sensitive information.
      *
      * @param enabled whether to enable the HTTP logger or not.
-     *
-     * @see HttpOptions#setLoggingOptions(LoggingOptions)
      */
     @Deprecated
     public void setLoggingEnabled(boolean enabled) {

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1,6 +1,7 @@
 package com.auth0.client.auth;
 
 import com.auth0.client.HttpOptions;
+import com.auth0.client.LoggingOptions;
 import com.auth0.client.ProxyOptions;
 import com.auth0.json.auth.PasswordlessEmailResponse;
 import com.auth0.json.auth.PasswordlessSmsResponse;
@@ -81,7 +82,6 @@ public class AuthAPI {
 
         telemetry = new TelemetryInterceptor();
         logging = new HttpLoggingInterceptor();
-        logging.setLevel(Level.NONE);
         client = buildNetworkingClient(options);
     }
 
@@ -129,6 +129,7 @@ public class AuthAPI {
                 });
             }
         }
+        configureLogging(options.getLoggingOptions());
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
@@ -154,12 +155,41 @@ public class AuthAPI {
     }
 
     /**
+     * @deprecated use the logging configuration available in {@link HttpOptions#setLoggingOptions(LoggingOptions)}
+     *
      * Whether to enable or not the current HTTP Logger for every Request, Response and other sensitive information.
      *
      * @param enabled whether to enable the HTTP logger or not.
+     *
+     * @see HttpOptions#setLoggingOptions(LoggingOptions)
      */
+    @Deprecated
     public void setLoggingEnabled(boolean enabled) {
         logging.setLevel(enabled ? Level.BODY : Level.NONE);
+    }
+
+    private void configureLogging(LoggingOptions loggingOptions) {
+        if (loggingOptions == null) {
+            logging.setLevel(Level.NONE);
+            return;
+        }
+        switch (loggingOptions.getLogLevel()) {
+            case BASIC:
+                logging.setLevel(Level.BASIC);
+                break;
+            case HEADERS:
+                logging.setLevel(Level.HEADERS);
+                break;
+            case BODY:
+                logging.setLevel(Level.BODY);
+                break;
+            case NONE:
+            default:
+                logging.setLevel(Level.NONE);
+        }
+        for (String header : loggingOptions.getHeadersToRedact()) {
+            logging.redactHeader(header);
+        }
     }
 
     //Visible for Testing

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -155,11 +155,11 @@ public class AuthAPI {
     }
 
     /**
-     * Whether to enable or not the current HTTP Logger for every Request, Response and other sensitive information.
+     * Whether to enable or not the current HTTP Logger for every request and response line, body, and headers.
+     * <strong>Warning: Enabling logging can leek sensitive information, and should only be done in a controlled, non-production environment.</strong>
      *
      * @param enabled whether to enable the HTTP logger or not.
      */
-    @Deprecated
     public void setLoggingEnabled(boolean enabled) {
         logging.setLevel(enabled ? Level.BODY : Level.NONE);
     }

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -159,9 +159,6 @@ public class ManagementAPI {
             return;
         }
         switch (loggingOptions.getLogLevel()) {
-            case NONE:
-                logging.setLevel(Level.NONE);
-                break;
             case BASIC:
                 logging.setLevel(Level.BASIC);
                 break;
@@ -171,6 +168,9 @@ public class ManagementAPI {
             case BODY:
                 logging.setLevel(Level.BODY);
                 break;
+            case NONE:
+            default:
+                logging.setLevel(Level.NONE);
         }
         for (String header : loggingOptions.getHeadersToRedact()) {
             logging.redactHeader(header);

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -140,13 +140,9 @@ public class ManagementAPI {
     }
 
     /**
-     * @deprecated use the logging configuration available in {@link HttpOptions#setLoggingOptions(LoggingOptions)}
-     *
      * Whether to enable or not the current HTTP Logger for every Request, Response and other sensitive information.
      *
      * @param enabled whether to enable the HTTP logger or not.
-     *
-     * @see HttpOptions#setLoggingOptions(LoggingOptions)
      */
     @Deprecated
     public void setLoggingEnabled(boolean enabled) {

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -140,11 +140,11 @@ public class ManagementAPI {
     }
 
     /**
-     * Whether to enable or not the current HTTP Logger for every Request, Response and other sensitive information.
+     * Whether to enable or not the current HTTP Logger for every request and response line, body, and headers.
+     * <strong>Warning: Enabling logging can leek sensitive information, and should only be done in a controlled, non-production environment.</strong>
      *
      * @param enabled whether to enable the HTTP logger or not.
      */
-    @Deprecated
     public void setLoggingEnabled(boolean enabled) {
         logging.setLevel(enabled ? Level.BODY : Level.NONE);
     }

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -1,6 +1,7 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.HttpOptions;
+import com.auth0.client.LoggingOptions;
 import com.auth0.client.ProxyOptions;
 import com.auth0.net.RateLimitInterceptor;
 import com.auth0.net.Telemetry;
@@ -53,7 +54,6 @@ public class ManagementAPI {
 
         telemetry = new TelemetryInterceptor();
         logging = new HttpLoggingInterceptor();
-        logging.setLevel(Level.NONE);
         client = buildNetworkingClient(options);
     }
 
@@ -101,6 +101,7 @@ public class ManagementAPI {
                 });
             }
         }
+        configureLogging(options.getLoggingOptions());
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
@@ -139,12 +140,41 @@ public class ManagementAPI {
     }
 
     /**
+     * @deprecated use the logging configuration available in {@link HttpOptions#setLoggingOptions(LoggingOptions)}
+     *
      * Whether to enable or not the current HTTP Logger for every Request, Response and other sensitive information.
      *
      * @param enabled whether to enable the HTTP logger or not.
+     *
+     * @see HttpOptions#setLoggingOptions(LoggingOptions)
      */
+    @Deprecated
     public void setLoggingEnabled(boolean enabled) {
         logging.setLevel(enabled ? Level.BODY : Level.NONE);
+    }
+
+    private void configureLogging(LoggingOptions loggingOptions) {
+        if (loggingOptions == null) {
+            logging.setLevel(Level.NONE);
+            return;
+        }
+        switch (loggingOptions.getLogLevel()) {
+            case NONE:
+                logging.setLevel(Level.NONE);
+                break;
+            case BASIC:
+                logging.setLevel(Level.BASIC);
+                break;
+            case HEADERS:
+                logging.setLevel(Level.HEADERS);
+                break;
+            case BODY:
+                logging.setLevel(Level.BODY);
+                break;
+        }
+        for (String header : loggingOptions.getHeadersToRedact()) {
+            logging.redactHeader(header);
+        }
     }
 
     //Visible for testing

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1,6 +1,7 @@
 package com.auth0.client.auth;
 
 import com.auth0.client.HttpOptions;
+import com.auth0.client.LoggingOptions;
 import com.auth0.client.MockServer;
 import com.auth0.client.ProxyOptions;
 import com.auth0.exception.APIException;
@@ -13,25 +14,26 @@ import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.io.FileReader;
 import java.net.Proxy;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.auth0.client.MockServer.*;
 import static com.auth0.client.RecordedRequestMatcher.hasHeader;
 import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
 import static com.auth0.client.UrlMatcher.hasQueryParameter;
 import static com.auth0.client.UrlMatcher.isUrl;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AuthAPITest {
 
@@ -319,6 +321,7 @@ public class AuthAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldEnableLoggingInterceptor() {
         AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
         assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
@@ -333,6 +336,7 @@ public class AuthAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldDisableLoggingInterceptor() {
         AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
         assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
@@ -342,6 +346,82 @@ public class AuthAPITest {
             if (i instanceof HttpLoggingInterceptor) {
                 HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
                 assertThat(logging.getLevel(), is(Level.NONE));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureNoneLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.NONE);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.NONE));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureBasicLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.BASIC);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.BASIC));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureHeaderLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.HEADERS);
+        Set<String> headersToRedact = new HashSet<>();
+        headersToRedact.add("Authorization");
+        headersToRedact.add("Cookie");
+        loggingOptions.setHeadersToRedact(headersToRedact);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.HEADERS));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureBodyLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.BODY);
+        Set<String> headersToRedact = new HashSet<>();
+        headersToRedact.add("Authorization");
+        headersToRedact.add("Cookie");
+        loggingOptions.setHeadersToRedact(headersToRedact);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.BODY));
             }
         }
     }

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -1,6 +1,7 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.HttpOptions;
+import com.auth0.client.LoggingOptions;
 import com.auth0.client.MockServer;
 import com.auth0.client.ProxyOptions;
 import com.auth0.net.RateLimitInterceptor;
@@ -16,11 +17,13 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.net.Proxy;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.auth0.client.UrlMatcher.isUrl;
 import static okhttp3.logging.HttpLoggingInterceptor.Level;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class ManagementAPITest {
 
@@ -353,6 +356,7 @@ public class ManagementAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldEnableLoggingInterceptor() {
         ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
         assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
@@ -367,6 +371,7 @@ public class ManagementAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldDisableLoggingInterceptor() {
         ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
         assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
@@ -376,6 +381,82 @@ public class ManagementAPITest {
             if (i instanceof HttpLoggingInterceptor) {
                 HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
                 assertThat(logging.getLevel(), is(Level.NONE));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureNoneLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.NONE);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.NONE));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureBasicLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.BASIC);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.BASIC));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureHeaderLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.HEADERS);
+        Set<String> headersToRedact = new HashSet<>();
+        headersToRedact.add("Authorization");
+        headersToRedact.add("Cookie");
+        loggingOptions.setHeadersToRedact(headersToRedact);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.HEADERS));
+            }
+        }
+    }
+
+    @Test
+    public void shouldConfigureBodyLoggingFromOptions() {
+        LoggingOptions loggingOptions = new LoggingOptions(LoggingOptions.LogLevel.BODY);
+        Set<String> headersToRedact = new HashSet<>();
+        headersToRedact.add("Authorization");
+        headersToRedact.add("Cookie");
+        loggingOptions.setHeadersToRedact(headersToRedact);
+        HttpOptions options = new HttpOptions();
+        options.setLoggingOptions(loggingOptions);
+
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().interceptors(), hasItem(isA(HttpLoggingInterceptor.class)));
+
+        for (Interceptor i : api.getClient().interceptors()) {
+            if (i instanceof HttpLoggingInterceptor) {
+                HttpLoggingInterceptor logging = (HttpLoggingInterceptor) i;
+                assertThat(logging.getLevel(), is(Level.BODY));
             }
         }
     }


### PR DESCRIPTION
Currently, logging of HTTP request/response information is only enabled through the `setLoggingEnabled(boolean enabled)` method on the `ManagementAPI` and `AuthAPI` API clients. While this does allow for enabling or disabling logging (disabled by default), as discussed in #389 the configurability of the logging can be improved.

This PR adds a new configuration point to our existing `HttpOptions` config object. It does so by exposing a new method, `HttpOptions#setLoggingOptions(LoggingOptions loggingOptions)`. 

The `LoggingOptions` class exposes the ability to customize the logging level to any of OkHttp's supported levels, as well as the ability to specify headers that should be redacted from the logs (it does not expose any of the OkHttp functionality publicly). 

A follow-up PR will be made to deprecate the existing `setLoggingEnabled` in favor of this new customization point.