### PR TITLE
Update jackson dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.1"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.6"
     implementation "com.auth0:java-jwt:3.14.0"
     implementation "net.jodah:failsafe:2.4.1"
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.6"
-    implementation "com.auth0:java-jwt:3.14.0"
+    implementation "com.auth0:java-jwt:3.18.3"
     implementation "net.jodah:failsafe:2.4.1"
 
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"


### PR DESCRIPTION
### Changes

We are upgrading Jackson dependency to 12.6 due to vulnerability in the current version

### References
[Link](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698)

### Testing
Since this is a dependency upgrade, we checked it using our existing unit tests
