### PR TITLE
Deprecate setLoggingEnabled on API clients

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -155,11 +155,14 @@ public class AuthAPI {
     }
 
     /**
+     * @deprecated use the logging configuration available in {@link HttpOptions#setLoggingOptions(LoggingOptions)}
+     *
      * Whether to enable or not the current HTTP Logger for every request and response line, body, and headers.
      * <strong>Warning: Enabling logging can leek sensitive information, and should only be done in a controlled, non-production environment.</strong>
      *
      * @param enabled whether to enable the HTTP logger or not.
      */
+    @Deprecated
     public void setLoggingEnabled(boolean enabled) {
         logging.setLevel(enabled ? Level.BODY : Level.NONE);
     }

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -140,11 +140,14 @@ public class ManagementAPI {
     }
 
     /**
+     * @deprecated use the logging configuration available in {@link HttpOptions#setLoggingOptions(LoggingOptions)}
+     *
      * Whether to enable or not the current HTTP Logger for every request and response line, body, and headers.
      * <strong>Warning: Enabling logging can leek sensitive information, and should only be done in a controlled, non-production environment.</strong>
      *
      * @param enabled whether to enable the HTTP logger or not.
      */
+    @Deprecated
     public void setLoggingEnabled(boolean enabled) {
         logging.setLevel(enabled ? Level.BODY : Level.NONE);
     }


### PR DESCRIPTION
Follow-up to the changes introduced in #392, this change deprecates the `setLoggingEnabled(Boolean enabled)` in favor of configuring the HTTP logging via the `HttpOptions` when building the client.