### PR TITLE
Add support for Connection realms

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/Connection.java
@@ -32,6 +32,8 @@ public class Connection {
     private String provisioningTicketUrl;
     @JsonProperty("metadata")
     private Map<String, String> metadata;
+    @JsonProperty("realms")
+    private List<String> realms;
 
     public Connection() {
     }
@@ -160,5 +162,25 @@ public class Connection {
     @JsonProperty("metadata")
     public void setMetadata(Map<String, String> metadata) {
         this.metadata = metadata;
+    }
+
+    /**
+     * Getter for the realms of this connection.
+     *
+     * @return the list of realms.
+     */
+    @JsonProperty("realms")
+    public List<String> getRealms() {
+        return realms;
+    }
+
+    /**
+     * Setter for the realms of this connection.
+     *
+     * @param realms the list of realms.
+     */
+    @JsonProperty("realms")
+    public void setRealms(List<String> realms) {
+        this.realms = realms;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/ConnectionTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ConnectionTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ConnectionTest extends JsonTest<Connection> {
 
-    private static final String json = "{\"name\": \"my-connection\",\"display_name\": \"My cool connection!\",\"strategy\": \"auth0\",\"options\": {},\"enabled_clients\": [\"client1\",\"client2\"],\"metadata\": {\"key\": \"value\"}}";
+    private static final String json = "{\"name\": \"my-connection\",\"display_name\": \"My cool connection!\",\"strategy\": \"auth0\",\"options\": {},\"enabled_clients\": [\"client1\",\"client2\"],\"metadata\": {\"key\": \"value\"},\"realms\": [\"realm1\",\"realm2\"]}";
     private static final String readOnlyJson = "{\"id\":\"connectionId\"}";
 
     private static final String jsonAd = "{\"name\":\"my-ad-connection\",\"strategy\":\"ad\",\"provisioning_ticket_url\":\"https://demo.auth0.com/p/ad/ddQTRlVt\",\"options\":{},\"enabled_clients\":[\"client1\",\"client2\"]}";
@@ -24,6 +24,7 @@ public class ConnectionTest extends JsonTest<Connection> {
         connection.setOptions(new HashMap<String, Object>());
         connection.setEnabledClients(Arrays.asList("client1", "client2"));
         connection.setMetadata(new HashMap<String, String>());
+        connection.setRealms(Arrays.asList("realm1", "realm2"));
 
         String serialized = toJSON(connection);
         assertThat(serialized, is(notNullValue()));
@@ -34,6 +35,7 @@ public class ConnectionTest extends JsonTest<Connection> {
         assertThat(serialized, JsonMatcher.hasEntry("enabled_clients", Arrays.asList("client1", "client2")));
         assertThat(serialized, JsonMatcher.hasEntry("provisioning_ticket_url", null));
         assertThat(serialized, JsonMatcher.hasEntry("metadata", notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("realms", Arrays.asList("realm1", "realm2")));
     }
 
     @Test
@@ -48,6 +50,7 @@ public class ConnectionTest extends JsonTest<Connection> {
         assertThat(connection.getEnabledClients(), contains("client1", "client2"));
         assertThat(connection.getProvisioningTicketUrl(), is(nullValue()));
         assertThat(connection.getMetadata(), is(notNullValue()));
+        assertThat(connection.getRealms(), contains("realm1", "realm2"));
     }
 
     @Test


### PR DESCRIPTION
Updates the `Connection` entity to add support for the `realms` attribute.

https://auth0.com/docs/api/management/v2#!/Connections/post_connections