### PR TITLE
Support maxRequests and maxRequestsPerHost client confiugrations

### DIFF
--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -9,6 +9,8 @@ public class HttpOptions {
     private int connectTimeout = 10;
     private int readTimeout = 10;
     private int mgmtApiMaxRetries = 3;
+    private int maxRequests = 64;
+    private int maxRequestsPerHost = 5;
     private LoggingOptions loggingOptions;
 
     /**
@@ -108,5 +110,43 @@ public class HttpOptions {
             throw new IllegalArgumentException("Retries must be between zero and ten.");
         }
         this.mgmtApiMaxRetries = maxRetries;
+    }
+
+    /**
+     * Sets the maximum number of requests for each host to execute concurrently.
+     *
+     * @param maxRequestsPerHost the maximum number of requests for each host to execute concurrently. Must be equal to or greater than one.
+     */
+    public void setMaxRequestsPerHost(int maxRequestsPerHost) {
+        if (maxRequestsPerHost < 1) {
+            throw new IllegalArgumentException("maxRequestsPerHost must be one or greater.");
+        }
+        this.maxRequestsPerHost = maxRequestsPerHost;
+    }
+
+    /**
+     * @return the maximum number of requests for each host to execute concurrently.
+     */
+    public int getMaxRequestsPerHost() {
+        return this.maxRequestsPerHost;
+    }
+
+    /**
+     * Sets the maximum number of requests to execute concurrently.
+     *
+     * @param maxRequests the number of requests to execute concurrently. Must be equal to or greater than one.
+     */
+    public void setMaxRequests(int maxRequests) {
+        if (maxRequests < 1) {
+            throw new IllegalArgumentException("maxRequests must be one or greater.");
+        }
+        this.maxRequests = maxRequests;
+    }
+
+    /**
+     * @return the number of requests to execute concurrently
+     */
+    public int getMaxRequests() {
+        return this.maxRequests;
     }
 }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -130,11 +130,15 @@ public class AuthAPI {
             }
         }
         configureLogging(options.getLoggingOptions());
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequests(options.getMaxRequests());
+        dispatcher.setMaxRequestsPerHost(options.getMaxRequestsPerHost());
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
                 .connectTimeout(options.getConnectTimeout(), TimeUnit.SECONDS)
                 .readTimeout(options.getReadTimeout(), TimeUnit.SECONDS)
+                .dispatcher(dispatcher)
                 .build();
     }
 

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -102,12 +102,16 @@ public class ManagementAPI {
             }
         }
         configureLogging(options.getLoggingOptions());
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequestsPerHost(options.getMaxRequestsPerHost());
+        dispatcher.setMaxRequests(options.getMaxRequests());
         return clientBuilder
                 .addInterceptor(logging)
                 .addInterceptor(telemetry)
                 .addInterceptor(new RateLimitInterceptor(options.getManagementAPIMaxRetries()))
                 .connectTimeout(options.getConnectTimeout(), TimeUnit.SECONDS)
                 .readTimeout(options.getReadTimeout(), TimeUnit.SECONDS)
+                .dispatcher(dispatcher)
                 .build();
     }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -426,6 +426,52 @@ public class AuthAPITest {
         }
     }
 
+    @Test
+    public void shouldUseDefaultMaxRequests() {
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+        assertThat(api.getClient().dispatcher().getMaxRequests(), is(64));
+    }
+
+    @Test
+    public void shouldUseConfiguredMaxRequests() {
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequests(10);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+        assertThat(api.getClient().dispatcher().getMaxRequests(), is(10));
+    }
+
+    @Test
+    public void shouldThrowOnInValidMaxRequestsConfiguration() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("maxRequests must be one or greater.");
+
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequests(0);
+    }
+
+    @Test
+    public void shouldUseDefaultMaxRequestsPerHost() {
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET);
+        assertThat(api.getClient().dispatcher().getMaxRequestsPerHost(), is(5));
+    }
+
+    @Test
+    public void shouldUseConfiguredMaxRequestsPerHost() {
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequestsPerHost(10);
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, options);
+        assertThat(api.getClient().dispatcher().getMaxRequestsPerHost(), is(10));
+    }
+
+    @Test
+    public void shouldThrowOnInValidMaxRequestsPerHostConfiguration() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("maxRequestsPerHost must be one or greater.");
+
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequestsPerHost(0);
+    }
+
     //Authorize
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -506,7 +506,53 @@ public class ManagementAPITest {
         HttpOptions options = new HttpOptions();
         options.setManagementAPIMaxRetries(11);
     }
-    
+
+    @Test
+    public void shouldUseDefaultMaxRequests() {
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
+        assertThat(api.getClient().dispatcher().getMaxRequests(), is(64));
+    }
+
+    @Test
+    public void shouldUseConfiguredMaxRequests() {
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequests(10);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().dispatcher().getMaxRequests(), is(10));
+    }
+
+    @Test
+    public void shouldThrowOnInValidMaxRequestsConfiguration() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("maxRequests must be one or greater.");
+
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequests(0);
+    }
+
+    @Test
+    public void shouldUseDefaultMaxRequestsPerHost() {
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
+        assertThat(api.getClient().dispatcher().getMaxRequestsPerHost(), is(5));
+    }
+
+    @Test
+    public void shouldUseConfiguredMaxRequestsPerHost() {
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequestsPerHost(10);
+        ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN, options);
+        assertThat(api.getClient().dispatcher().getMaxRequestsPerHost(), is(10));
+    }
+
+    @Test
+    public void shouldThrowOnInValidMaxRequestsPerHostConfiguration() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("maxRequestsPerHost must be one or greater.");
+
+        HttpOptions options = new HttpOptions();
+        options.setMaxRequestsPerHost(0);
+    }
+
     //Entities
 
     @Test


### PR DESCRIPTION
This change exposes to new networking client configuration points on the `HttpOptions` class:
* `setMaxRequests(int maxRequests)`, which defines the maximum requests that can be execute concurrently
* `setMaxRequestsPerHost(int max)`, which defines the maximum requests that can be executed per host.

These configurations just delegate to their respective configurations on OkHttp's `Dispatcher`.

_(Note: While these changes are pretty simple to make, as a common configuration point we should consider supporting a pluggable http client later in the next major version of this library)_