### PR TITLE
[SDK-3116] Add support for Attack Protection APIs

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/AttackProtectionEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/AttackProtectionEntity.java
@@ -1,0 +1,117 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.json.mgmt.attackprotection.BreachedPassword;
+import com.auth0.json.mgmt.attackprotection.BruteForceConfiguration;
+import com.auth0.json.mgmt.attackprotection.SuspiciousIPThrottlingConfiguration;
+import com.auth0.net.Request;
+import com.auth0.utils.Asserts;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+
+/**
+ * Class that provides an implementation of the Attack Protection methods of the Management API as defined in <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/"></a>
+ * @see ManagementAPI
+ */
+public class AttackProtectionEntity extends BaseManagementEntity {
+    AttackProtectionEntity(OkHttpClient client, HttpUrl baseUrl, String apiToken) {
+        super(client, baseUrl, apiToken);
+    }
+
+    /**
+     * Gets the breached password detection settings.
+     * @return the breached password detection settings.
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection"></a>
+     */
+    public Request<BreachedPassword> getBreachedPasswordSettings() {
+        return request(
+            "GET",
+            new TypeReference<BreachedPassword>() {},
+            (builder) -> builder
+                .withPathSegments("api/v2/attack-protection/breached-password-detection")
+
+        );
+    }
+
+    /**
+     * Update the breached password detection settings.
+     * @param breachedPassword the updated breached password detection settings.
+     * @return the updated breached password detection settings.
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_breached_password_detection"></a>
+     */
+    public Request<BreachedPassword> updateBreachedPasswordSettings(BreachedPassword breachedPassword) {
+        Asserts.assertNotNull(breachedPassword, "breached password");
+
+        return request(
+            "PATCH",
+            new TypeReference<BreachedPassword>() {},
+            (builder) -> builder
+                .withPathSegments("api/v2/attack-protection/breached-password-detection")
+                .withBody(breachedPassword)
+        );
+    }
+
+    /**
+     * Gets the brute force configuration
+     * @return the brute force configuration
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_brute_force_protection"></a>
+     */
+    public Request<BruteForceConfiguration> getBruteForceConfiguration() {
+        return request(
+            "GET",
+            new TypeReference<BruteForceConfiguration>() {},
+            (builder) -> builder
+                .withPathSegments("api/v2/attack-protection/brute-force-protection")
+        );
+    }
+
+    /**
+     * Update the brute force configuration
+     * @param configuration the updated brute force configuration
+     * @return the updated brute force configuration
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_brute_force_protection"></a>
+     */
+    public Request<BruteForceConfiguration> updateBruteForceConfiguration(BruteForceConfiguration configuration) {
+        Asserts.assertNotNull(configuration, "configuration");
+
+        return request(
+            "PATCH",
+            new TypeReference<BruteForceConfiguration>() {},
+            (builder) -> builder
+                .withPathSegments("api/v2/attack-protection/brute-force-protection")
+                .withBody(configuration)
+        );
+    }
+
+    /**
+     * Gets the suspicious IP throttling configuration
+     * @return the suspicious IP throttling configuration
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_suspicious_ip_throttling"></a>
+     */
+    public Request<SuspiciousIPThrottlingConfiguration> getSuspiciousIPThrottlingConfiguration() {
+        return request(
+            "GET",
+            new TypeReference<SuspiciousIPThrottlingConfiguration>() {},
+            (builder) -> builder
+                .withPathSegments("api/v2/attack-protection/suspicious-ip-throttling")
+        );
+    }
+
+    /**
+     * Update the suspicious IP throttling configuration
+     * @param configuration the updated suspicious IP throttling configuration
+     * @return the updated suspicious IP throttling configuration
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_suspicious_ip_throttling"></a>
+     */
+    public Request<SuspiciousIPThrottlingConfiguration> updateSuspiciousIPThrottlingConfiguration(SuspiciousIPThrottlingConfiguration configuration) {
+        Asserts.assertNotNull(configuration, "configuration");
+
+        return request(
+            "PATCH",
+            new TypeReference<SuspiciousIPThrottlingConfiguration>() {},
+            (builder) -> builder
+                .withPathSegments("api/v2/attack-protection/suspicious-ip-throttling")
+                .withBody(configuration)
+        );
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -413,4 +413,13 @@ public class ManagementAPI {
     public ActionsEntity actions() {
         return new ActionsEntity(client, baseUrl, apiToken);
     }
+
+    /**
+     * Getter for the Attack Protection Entity
+     *
+     * @return the Attack Protection Entity
+     */
+    public AttackProtectionEntity attackProtection() {
+        return new AttackProtectionEntity(client, baseUrl, apiToken);
+    }
 }

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPassword.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPassword.java
@@ -1,0 +1,88 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the Breached Password entity.
+ *
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BreachedPassword {
+
+    @JsonProperty("enabled")
+    private Boolean enabled;
+    @JsonProperty("method")
+    private String method;
+    @JsonProperty("shields")
+    private List<String> shields;
+    @JsonProperty("admin_notification_frequency")
+    private List<String> adminNotificationFrequency;
+
+    /**
+     * @return whether or not breached password detection is active.
+     */
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether or not breached password detection is active.
+     * @param enabled whether or not breached password detection is active.
+     */
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return the subscription level for breached password detection methods.
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Sets the subscription level for breached password detection methods.
+     * @param method the subscription level for breached password detection methods.
+     */
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    /**
+     * @return the action to take when a breached password is detected.
+     */
+    public List<String> getShields() {
+        return shields;
+    }
+
+    /**
+     * Sets the action to take when a breached password is detected.
+     * @param shields the action to take when a breached password is detected.
+     */
+    public void setShields(List<String> shields) {
+        this.shields = shields;
+    }
+
+    /**
+     * @return the frequency email notifications are sent.
+     */
+    public List<String> getAdminNotificationFrequency() {
+        return adminNotificationFrequency;
+    }
+
+    /**
+     * Sets the frequency email notifications are sent.
+     * @param adminNotificationFrequency the frequency email notifications are sent.
+     */
+    public void setAdminNotificationFrequency(List<String> adminNotificationFrequency) {
+        this.adminNotificationFrequency = adminNotificationFrequency;
+    }
+
+
+}

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/BruteForceConfiguration.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/BruteForceConfiguration.java
@@ -1,0 +1,103 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the Brute Force Configuration
+ *
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BruteForceConfiguration {
+
+    @JsonProperty("enabled")
+    Boolean enabled;
+    @JsonProperty("shields")
+    List<String> shields;
+    @JsonProperty("allowlist")
+    List<String> allowList;
+    @JsonProperty("mode")
+    String mode;
+    @JsonProperty("max_attempts")
+    Integer maxAttempts;
+
+    /**
+     * @return whether or not brute force protections are active.
+     */
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether or not brute force protections are active.
+     * @param enabled whether or not brute force protections are active.
+     */
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return the action to take when a brute force configuration threshold is violated.
+     */
+    public List<String> getShields() {
+        return shields;
+    }
+
+    /**
+     * Sets the action to take when a brute force configuration threshold is violated.
+     * @param shields the action to take when a brute force configuration threshold is violated.
+     */
+    public void setShields(List<String> shields) {
+        this.shields = shields;
+    }
+
+    /**
+     * @return the list of trusted IP addresses that will not have attack protection enforced against them.
+     */
+    public List<String> getAllowList() {
+        return allowList;
+    }
+
+    /**
+     * Sets the list of trusted IP addresses that will not have attack protection enforced against them.
+     * @param allowList the list of trusted IP addresses that will not have attack protection enforced against them.
+     */
+    public void setAllowList(List<String> allowList) {
+        this.allowList = allowList;
+    }
+
+    /**
+     * @return gets the account lockout mode; determines whether or not IP address is used when counting failed attempts.
+     */
+    public String getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets the account lockout mode; determines whether or not IP address is used when counting failed attempts.
+     * @param mode the account lockout mode; determines whether or not IP address is used when counting failed attempts.
+     */
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    /**
+     * @return the maximum number of unsuccessful attempts.
+     */
+    public Integer getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * Sets the maximum number of unsuccessful attempts.
+     * @param maxAttempts the maximum number of unsuccessful attempts.
+     */
+    public void setMaxAttempts(Integer maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/Stage.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/Stage.java
@@ -1,0 +1,52 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the stage configuration options
+ *
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Stage {
+
+    @JsonProperty("pre-login")
+    StageEntry preLoginStage;
+    @JsonProperty("pre-user-registration")
+    StageEntry preUserRegistrationStage;
+
+    /**
+     * Get the pre-login stage entry.
+     * @return the pre-login stage entry.
+     */
+    public StageEntry getPreLoginStage() {
+        return preLoginStage;
+    }
+
+    /**
+     * Sets the pre-login stage entry.
+     * @param preLoginStage the pre-login stage entry.
+     */
+    public void setPreLoginStage(StageEntry preLoginStage) {
+        this.preLoginStage = preLoginStage;
+    }
+
+    /**
+     * Get the pre-user-registration stage entry.
+     * @return the pre-user-registration stage entry.
+     */
+    public StageEntry getPreUserRegistrationStage() {
+        return preUserRegistrationStage;
+    }
+
+    /**
+     * Set the pre-user-registration stage entry.
+     * @param preUserRegistrationStage the pre-user-registration stage entry.
+     */
+    public void setPreUserRegistrationStage(StageEntry preUserRegistrationStage) {
+        this.preUserRegistrationStage = preUserRegistrationStage;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/StageEntry.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/StageEntry.java
@@ -1,0 +1,51 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the per-stage configuration options
+ *
+ * @see Stage
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StageEntry {
+    @JsonProperty("max_attempts")
+    Integer maxAttempts;
+    @JsonProperty("rate")
+    Integer rate;
+
+    /**
+     * @return the max attempts for this Stage entry
+     */
+    public Integer getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * Set the max attempts for this Stage entry
+     * @param maxAttempts the max attempts for this Stage entry
+     */
+    public void setMaxAttempts(Integer maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    /**
+     * Get the rate for this Stage entry
+     * @return the rate for this Stage entry
+     */
+    public Integer getRate() {
+        return rate;
+    }
+
+    /**
+     * Sets the rate for this Stage entry
+     * @param rate the rate for this Stage entry
+     */
+    public void setRate(Integer rate) {
+        this.rate = rate;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/SuspiciousIPThrottlingConfiguration.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/SuspiciousIPThrottlingConfiguration.java
@@ -1,0 +1,86 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the Suspicious IP Throttling Configuration
+ *
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuspiciousIPThrottlingConfiguration {
+
+    @JsonProperty("enabled")
+    Boolean enabled;
+    @JsonProperty("shields")
+    private List<String> shields;
+    @JsonProperty("allowlist")
+    List<String> allowList;
+    @JsonProperty("stage")
+    Stage stage;
+
+    /**
+     * @return whether or not suspicious  IP throttling attack protections are active.
+     */
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether or not suspicious  IP throttling attack protections are active.
+     * @param enabled whether or not suspicious  IP throttling attack protections are active.
+     */
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return the action to take when a suspicious IP throttling threshold is violated.
+     */
+    public List<String> getShields() {
+        return shields;
+    }
+
+    /**
+     * Sets the action to take when a suspicious IP throttling threshold is violated.
+     * @param shields the action to take when a suspicious IP throttling threshold is violated.
+     */
+    public void setShields(List<String> shields) {
+        this.shields = shields;
+    }
+
+    /**
+     * @return the per-stage configuration options.
+     */
+    public Stage getStage() {
+        return stage;
+    }
+
+    /**
+     * Sets the per-stage configuration options.
+     * @param stage the per-stage configuration options.
+     */
+    public void setStage(Stage stage) {
+        this.stage = stage;
+    }
+
+    /**
+     * @return the list of trusted IP addresses that will not have attack protection enforced against them.
+     */
+    public List<String> getAllowList() {
+        return allowList;
+    }
+
+    /**
+     * Sets the list of trusted IP addresses that will not have attack protection enforced against them.
+     * @param allowList the list of trusted IP addresses that will not have attack protection enforced against them.
+     */
+    public void setAllowList(List<String> allowList) {
+        this.allowList = allowList;
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -3,8 +3,6 @@ package com.auth0.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.MapType;
-import java.util.ArrayList;
-import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -13,7 +11,9 @@ import okio.Buffer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MockServer {
@@ -124,6 +124,9 @@ public class MockServer {
     public static final String ACTIONS_LIST = "src/test/resources/mgmt/actions_list.json";
     public static final String ACTION_VERSIONS_LIST = "src/test/resources/mgmt/action_versions_list.json";
     public static final String ACTION_TRIGGER_BINDINGS = "src/test/resources/mgmt/action_trigger_bindings.json";
+    public static final String BREACHED_PASSWORD_SETTINGS = "src/test/resources/mgmt/breached_password_settings.json";
+    public static final String BRUTE_FORCE_CONFIGURATION = "src/test/resources/mgmt/brute_force_configuration.json";
+    public static final String SUSPICIOUS_IP_THROTTLING_CONFIGURATION = "src/test/resources/mgmt/suspicious_ip_throttling_configuration.json";
 
     private final MockWebServer server;
 

--- a/src/test/java/com/auth0/client/mgmt/AttackProtectionEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/AttackProtectionEntityTest.java
@@ -1,0 +1,231 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.json.mgmt.attackprotection.*;
+import com.auth0.net.Request;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.auth0.client.MockServer.*;
+import static com.auth0.client.RecordedRequestMatcher.hasHeader;
+import static com.auth0.client.RecordedRequestMatcher.hasMethodAndPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
+
+    @Test
+    public void shouldListBreachedPasswordSettings() throws Exception {
+        Request<BreachedPassword> request = api.attackProtection().getBreachedPasswordSettings();
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(BREACHED_PASSWORD_SETTINGS, 200);
+        BreachedPassword response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/attack-protection/breached-password-detection"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getEnabled(), is(true));
+        assertThat(response.getMethod(), is("standard"));
+        assertThat(response.getShields(), is(notNullValue()));
+        assertThat(response.getShields().size(), is(2));
+        assertThat(response.getShields(), contains("block", "admin_notification"));
+        assertThat(response.getAdminNotificationFrequency(), is(notNullValue()));
+        assertThat(response.getAdminNotificationFrequency().size(), is(2));
+        assertThat(response.getAdminNotificationFrequency(), contains("immediately", "weekly"));
+    }
+
+    @Test
+    public void shouldUpdateBreachedPasswordSettings() throws Exception {
+        BreachedPassword breachedPassword = new BreachedPassword();
+        breachedPassword.setEnabled(true);
+        breachedPassword.setMethod("standard");
+        breachedPassword.setAdminNotificationFrequency(Arrays.asList("immediately", "daily"));
+        breachedPassword.setShields(Arrays.asList("admin_notification", "block"));
+
+        Request<BreachedPassword> request = api.attackProtection().updateBreachedPasswordSettings(breachedPassword);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(BREACHED_PASSWORD_SETTINGS, 200);
+        BreachedPassword response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/attack-protection/breached-password-detection"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        System.out.println(body);
+
+        assertThat(body.size(), is(4));
+        assertThat(body.get("method"), is("standard"));
+        assertThat(body.get("enabled"), is(true));
+        assertThat(((List<?>)body.get("shields")).size(), is(2));
+        assertThat((List<?>) body.get("shields"), contains("admin_notification", "block"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetBruteForceConfiguration() throws Exception {
+        Request<BruteForceConfiguration> request = api.attackProtection().getBruteForceConfiguration();
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(BRUTE_FORCE_CONFIGURATION, 200);
+        BruteForceConfiguration response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/attack-protection/brute-force-protection"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getEnabled(), is(false));
+        assertThat(response.getMode(), is("count_per_identifier_and_ip"));
+        assertThat(response.getMaxAttempts(), is(10));
+        assertThat(response.getShields(), is(notNullValue()));
+        assertThat(response.getShields().size(), is(2));
+        assertThat(response.getShields(), contains("block", "user_notification"));
+        assertThat(response.getAllowList(), is(notNullValue()));
+        assertThat(response.getAllowList().size(), is(2));
+        assertThat(response.getAllowList(), contains("143.204.0.105",
+            "2600:9000:208f:ca00:d:f5f5:b40:93a1"));
+    }
+
+    @Test
+    public void shouldUpdateBruteForceConfiguration() throws Exception {
+        List<String> allowList = Arrays.asList("123", "456");
+        List<String> shields = Arrays.asList("block", "user_notification");
+        String mode = "count_per_identifier_and_ip";
+
+        BruteForceConfiguration configuration = new BruteForceConfiguration();
+        configuration.setEnabled(true);
+        configuration.setMaxAttempts(5);
+        configuration.setMode(mode);
+        configuration.setAllowList(allowList);
+        configuration.setShields(shields);
+
+        Request<BruteForceConfiguration> request = api.attackProtection().updateBruteForceConfiguration(configuration);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(BRUTE_FORCE_CONFIGURATION, 200);
+        BruteForceConfiguration response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/attack-protection/brute-force-protection"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+
+        assertThat(body.size(), is(5));
+        assertThat(body.get("enabled"), is(true));
+        assertThat(body.get("max_attempts"), is(5));
+        assertThat(body.get("mode"), is(mode));
+        assertThat(body.get("shields"), is(shields));
+        assertThat(body.get("allowlist"), is(allowList));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetSuspiciousIPThrottlingConfig() throws Exception {
+        Request<SuspiciousIPThrottlingConfiguration> request = api.attackProtection().getSuspiciousIPThrottlingConfiguration();
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(SUSPICIOUS_IP_THROTTLING_CONFIGURATION, 200);
+        SuspiciousIPThrottlingConfiguration response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/attack-protection/suspicious-ip-throttling"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getEnabled(), is(false));
+        assertThat(response.getShields(), is(notNullValue()));
+        assertThat(response.getShields().size(), is(2));
+        assertThat(response.getShields(), contains("block", "admin_notification"));
+        assertThat(response.getAllowList(), is(notNullValue()));
+        assertThat(response.getAllowList().size(), is(2));
+        assertThat(response.getAllowList(), contains("143.204.0.105",
+            "2600:9000:208f:ca00:d:f5f5:b40:93a1"));
+        assertThat(response.getStage(), is(notNullValue()));
+        assertThat(response.getStage().getPreLoginStage(), is(notNullValue()));
+        assertThat(response.getStage().getPreLoginStage().getMaxAttempts(), is(100));
+        assertThat(response.getStage().getPreLoginStage().getRate(), is(864000));
+        assertThat(response.getStage().getPreUserRegistrationStage(), is(notNullValue()));
+        assertThat(response.getStage().getPreUserRegistrationStage().getMaxAttempts(), is(50));
+        assertThat(response.getStage().getPreUserRegistrationStage().getRate(), is(1728000));
+    }
+
+    @Test
+    public void shouldUpdateSuspiciousIPTThrottlingConfig() throws Exception {
+        List<String> allowList = Arrays.asList("123", "456");
+        List<String> shields = Arrays.asList("block", "user_notification");
+
+        Stage stage = new Stage();
+        StageEntry preLogin = new StageEntry();
+        preLogin.setRate(10);
+        preLogin.setMaxAttempts(11);
+        StageEntry preReg = new StageEntry();
+        preReg.setRate(12);
+        preReg.setMaxAttempts(13);
+        stage.setPreLoginStage(preLogin);
+        stage.setPreUserRegistrationStage(preLogin);
+
+        SuspiciousIPThrottlingConfiguration configuration = new SuspiciousIPThrottlingConfiguration();
+        configuration.setEnabled(true);
+        configuration.setAllowList(allowList);
+        configuration.setShields(shields);
+        configuration.setStage(stage);
+
+        Request<SuspiciousIPThrottlingConfiguration> request = api.attackProtection().updateSuspiciousIPThrottlingConfiguration(configuration);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(BRUTE_FORCE_CONFIGURATION, 200);
+        SuspiciousIPThrottlingConfiguration response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/attack-protection/suspicious-ip-throttling"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+
+        assertThat(body.size(), is(4));
+        assertThat(body.get("enabled"), is(true));
+        assertThat(body.get("shields"), is(shields));
+        assertThat(body.get("allowlist"), is(allowList));
+        assertThat(body.get("stage"), is(notNullValue()));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateBreachedPasswordSettingsShouldThrowWithNullParam() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("breached password");
+        api.attackProtection().updateBreachedPasswordSettings(null);
+    }
+
+    @Test
+    public void updateBruteForceConfigurationShouldThrowWithNullParam() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("configuration");
+        api.attackProtection().updateBruteForceConfiguration(null);
+    }
+
+    @Test
+    public void updateSuspiciousIPThrottlingConfigurationShouldThrowWithNullParam() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("configuration");
+        api.attackProtection().updateSuspiciousIPThrottlingConfiguration(null);
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/attackprotection/BreachedPasswordTest.java
+++ b/src/test/java/com/auth0/json/mgmt/attackprotection/BreachedPasswordTest.java
@@ -1,0 +1,56 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class BreachedPasswordTest extends JsonTest<BreachedPassword> {
+
+    private String json = "{\n" +
+        "  \"enabled\": true,\n" +
+        "  \"shields\": [\n" +
+        "    \"block\",\n" +
+        "    \"admin_notification\"\n" +
+        "  ],\n" +
+        "  \"admin_notification_frequency\": [\n" +
+        "    \"immediately\",\n" +
+        "    \"weekly\"\n" +
+        "  ],\n" +
+        "  \"method\": \"standard\"\n" +
+        "}";
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        BreachedPassword breachedPassword = new BreachedPassword();
+        breachedPassword.setAdminNotificationFrequency(Arrays.asList("immediately", "daily"));
+        breachedPassword.setShields(Arrays.asList("admin_notification", "block"));
+        breachedPassword.setMethod("standard");
+        breachedPassword.setEnabled(true);
+
+        String json = toJSON(breachedPassword);
+
+        assertThat(json, JsonMatcher.hasEntry("enabled", true));
+        assertThat(json, JsonMatcher.hasEntry("method", "standard"));
+        assertThat(json, JsonMatcher.hasEntry("admin_notification_frequency", Arrays.asList("immediately", "daily")));
+        assertThat(json, JsonMatcher.hasEntry("shields", Arrays.asList("admin_notification", "block")));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        BreachedPassword breachedPassword = fromJSON(json, BreachedPassword.class);
+        assertThat(breachedPassword, notNullValue());
+        assertThat(breachedPassword.getEnabled(), is(true));
+        assertThat(breachedPassword.getMethod(), is("standard"));
+        assertThat(breachedPassword.getShields(), is(notNullValue()));
+        assertThat(breachedPassword.getShields().size(), is(2));
+        assertThat(breachedPassword.getShields(), contains("block", "admin_notification"));
+        assertThat(breachedPassword.getAdminNotificationFrequency(), is(notNullValue()));
+        assertThat(breachedPassword.getAdminNotificationFrequency().size(), is(2));
+        assertThat(breachedPassword.getAdminNotificationFrequency(), contains("immediately", "weekly"));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/attackprotection/BruteForceConfigurationTest.java
+++ b/src/test/java/com/auth0/json/mgmt/attackprotection/BruteForceConfigurationTest.java
@@ -1,0 +1,60 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class BruteForceConfigurationTest extends JsonTest<BruteForceConfiguration> {
+
+    String json = "{\n" +
+        "  \"enabled\": false,\n" +
+        "  \"shields\": [\n" +
+        "    \"block\",\n" +
+        "    \"user_notification\"\n" +
+        "  ],\n" +
+        "  \"allowlist\": [\n" +
+        "    \"143.204.0.105\",\n" +
+        "    \"2600:9000:208f:ca00:d:f5f5:b40:93a1\"\n" +
+        "  ],\n" +
+        "  \"mode\": \"count_per_identifier_and_ip\",\n" +
+        "  \"max_attempts\": 10\n" +
+        "}";
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        BruteForceConfiguration bruteForceConfiguration = new BruteForceConfiguration();
+        bruteForceConfiguration.setEnabled(true);
+        bruteForceConfiguration.setMaxAttempts(10);
+        bruteForceConfiguration.setMode("count_per_identifier_and_ip");
+        bruteForceConfiguration.setAllowList(Arrays.asList("123", "456"));
+        bruteForceConfiguration.setShields(Arrays.asList("user_notification", "block"));
+
+        String json = toJSON(bruteForceConfiguration);
+        assertThat(json, JsonMatcher.hasEntry("enabled", true));
+        assertThat(json, JsonMatcher.hasEntry("max_attempts", 10));
+        assertThat(json, JsonMatcher.hasEntry("mode", "count_per_identifier_and_ip"));
+        assertThat(json, JsonMatcher.hasEntry("allowlist", Arrays.asList("123", "456")));
+        assertThat(json, JsonMatcher.hasEntry("shields", Arrays.asList("user_notification", "block")));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        BruteForceConfiguration bruteForceConfiguration = fromJSON(json, BruteForceConfiguration.class);
+
+        assertThat(bruteForceConfiguration, notNullValue());
+        assertThat(bruteForceConfiguration.getEnabled(), is(false));
+        assertThat(bruteForceConfiguration.getMode(), is("count_per_identifier_and_ip"));
+        assertThat(bruteForceConfiguration.getMaxAttempts(), is(10));
+        assertThat(bruteForceConfiguration.getShields(), is(notNullValue()));
+        assertThat(bruteForceConfiguration.getShields().size(), is(2));
+        assertThat(bruteForceConfiguration.getShields(), contains("block", "user_notification"));
+        assertThat(bruteForceConfiguration.getAllowList(), is(notNullValue()));
+        assertThat(bruteForceConfiguration.getAllowList().size(), is(2));
+        assertThat(bruteForceConfiguration.getAllowList(), contains("143.204.0.105", "2600:9000:208f:ca00:d:f5f5:b40:93a1"));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/attackprotection/SuspiciousIPThrottlingConfigurationTest.java
+++ b/src/test/java/com/auth0/json/mgmt/attackprotection/SuspiciousIPThrottlingConfigurationTest.java
@@ -1,0 +1,86 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class SuspiciousIPThrottlingConfigurationTest extends JsonTest<SuspiciousIPThrottlingConfiguration> {
+
+    private final String json = "{\n" +
+        "  \"enabled\": false,\n" +
+        "  \"shields\": [\n" +
+        "    \"block\",\n" +
+        "    \"admin_notification\"\n" +
+        "  ],\n" +
+        "  \"allowlist\": [\n" +
+        "    \"143.204.0.105\",\n" +
+        "    \"2600:9000:208f:ca00:d:f5f5:b40:93a1\"\n" +
+        "  ],\n" +
+        "  \"stage\": {\n" +
+        "    \"pre-login\": {\n" +
+        "      \"max_attempts\": 100,\n" +
+        "      \"rate\": 864000\n" +
+        "    },\n" +
+        "    \"pre-user-registration\": {\n" +
+        "      \"max_attempts\": 50,\n" +
+        "      \"rate\": 1728000\n" +
+        "    }\n" +
+        "  }\n" +
+        "}";
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        SuspiciousIPThrottlingConfiguration config = fromJSON(json, SuspiciousIPThrottlingConfiguration.class);
+
+        assertThat(config, is(notNullValue()));
+        assertThat(config.getEnabled(), is(false));
+        assertThat(config.getShields(), is(Arrays.asList("block", "admin_notification")));
+        assertThat(config.getAllowList(), is(Arrays.asList("143.204.0.105", "2600:9000:208f:ca00:d:f5f5:b40:93a1")));
+        assertThat(config.getStage(), is(notNullValue()));
+        assertThat(config.getStage().getPreLoginStage(), is(notNullValue()));
+        assertThat(config.getStage().getPreLoginStage().getMaxAttempts(), is(100));
+        assertThat(config.getStage().getPreLoginStage().getRate(), is(864000));
+        assertThat(config.getStage().getPreUserRegistrationStage(), is(notNullValue()));
+        assertThat(config.getStage().getPreUserRegistrationStage().getMaxAttempts(), is(50));
+        assertThat(config.getStage().getPreUserRegistrationStage().getRate(), is(1728000));
+
+    }
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        List<String> allowList = Arrays.asList("123", "456");
+        List<String> shields = Arrays.asList("block", "user_notification");
+
+        StageEntry preLogin = new StageEntry();
+        preLogin.setMaxAttempts(100);
+        preLogin.setRate(864000);
+
+        StageEntry preRegistration = new StageEntry();
+        preLogin.setMaxAttempts(50);
+        preLogin.setRate(1728000);
+
+        Stage stage = new Stage();
+        stage.setPreLoginStage(preLogin);
+        stage.setPreUserRegistrationStage(preRegistration);
+
+        SuspiciousIPThrottlingConfiguration config = new SuspiciousIPThrottlingConfiguration();
+        config.setEnabled(true);
+        config.setAllowList(allowList);
+        config.setShields(shields);
+        config.setStage(stage);
+
+        String json = toJSON(config);
+
+        assertThat(json, JsonMatcher.hasEntry("enabled", true));
+        assertThat(json, JsonMatcher.hasEntry("shields", shields));
+        assertThat(json, JsonMatcher.hasEntry("allowlist", allowList));
+        assertThat(json, JsonMatcher.hasEntry("stage", is(notNullValue())));
+    }
+}

--- a/src/test/resources/mgmt/breached_password_settings.json
+++ b/src/test/resources/mgmt/breached_password_settings.json
@@ -1,0 +1,12 @@
+{
+  "enabled": true,
+  "shields": [
+    "block",
+    "admin_notification"
+  ],
+  "admin_notification_frequency": [
+    "immediately",
+    "weekly"
+  ],
+  "method": "standard"
+}

--- a/src/test/resources/mgmt/brute_force_configuration.json
+++ b/src/test/resources/mgmt/brute_force_configuration.json
@@ -1,0 +1,13 @@
+{
+  "enabled": false,
+  "shields": [
+    "block",
+    "user_notification"
+  ],
+  "allowlist": [
+    "143.204.0.105",
+    "2600:9000:208f:ca00:d:f5f5:b40:93a1"
+  ],
+  "mode": "count_per_identifier_and_ip",
+  "max_attempts": 10
+}

--- a/src/test/resources/mgmt/suspicious_ip_throttling_configuration.json
+++ b/src/test/resources/mgmt/suspicious_ip_throttling_configuration.json
@@ -1,0 +1,21 @@
+{
+  "enabled": false,
+  "shields": [
+    "block",
+    "admin_notification"
+  ],
+  "allowlist": [
+    "143.204.0.105",
+    "2600:9000:208f:ca00:d:f5f5:b40:93a1"
+  ],
+  "stage": {
+    "pre-login": {
+      "max_attempts": 100,
+      "rate": 864000
+    },
+    "pre-user-registration": {
+      "max_attempts": 50,
+      "rate": 1728000
+    }
+  }
+}


### PR DESCRIPTION
Adds support for the Attack Protection endpoints, as documented here: https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection