### PR TITLE
[SDK-3098] Fix documentation for authorize and logout URL creation

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -228,7 +228,8 @@ public class AuthAPI {
      * }
      * </pre>
      *
-     * @param redirectUri the redirect_uri value to set, white-listed in the Application settings. Must be already URL Encoded.
+     * @param redirectUri the URL to redirect to after authorization has been granted by the user. Your Auth0 application
+     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded HTTP or HTTPS URL.
      * @return a new instance of the {@link AuthorizeUrlBuilder} to configure.
      */
     public AuthorizeUrlBuilder authorizeUrl(String redirectUri) {
@@ -249,8 +250,10 @@ public class AuthAPI {
      * }
      * </pre>
      *
-     * @param returnToUrl the redirect_uri value to set, white-listed in the Application settings. Must be already URL Encoded.
-     * @param setClientId whether the client_id value must be set or not. This affects the white-list that the Auth0's Dashboard uses to validate the returnTo url.
+     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded HTTP or HTTPS URL.
+     * @param setClientId whether the client_id value must be set or not. If {@code true}, the {@code returnToUrl} must
+     *                    be included in your Auth0 Application's Allowed Logout URLs list. If {@code false}, the
+     *                    {@code returnToUrl} must be included in your Auth0's Allowed Logout URLs at the Tenant level.
      * @return a new instance of the {@link LogoutUrlBuilder} to configure.
      */
     public LogoutUrlBuilder logoutUrl(String returnToUrl, boolean setClientId) {

--- a/src/main/java/com/auth0/client/auth/AuthorizeUrlBuilder.java
+++ b/src/main/java/com/auth0/client/auth/AuthorizeUrlBuilder.java
@@ -25,7 +25,8 @@ public class AuthorizeUrlBuilder {
      *
      * @param baseUrl     the base url constructed from a valid domain.
      * @param clientId    the application's client_id value to set
-     * @param redirectUri the redirect_uri value to set. Must be already URL Encoded and must be white-listed in your Auth0's dashboard.
+     * @param redirectUri the redirect_uri value to set. Your Auth0 application must have this URL as one of its Allowed
+     *                    Callback URLs.
      * @return a new instance of the {@link AuthorizeUrlBuilder} to configure.
      */
     static AuthorizeUrlBuilder newInstance(HttpUrl baseUrl, String clientId, String redirectUri) {

--- a/src/main/java/com/auth0/client/auth/LogoutUrlBuilder.java
+++ b/src/main/java/com/auth0/client/auth/LogoutUrlBuilder.java
@@ -23,11 +23,12 @@ public class LogoutUrlBuilder {
     /**
      * Creates a instance of the {@link LogoutUrlBuilder} using the given domain and base parameters.
      *
-     * @param baseUrl     the base url constructed from a valid domain.
+     * @param baseUrl     the base url constructed from a valid domain. Must not be null.
      * @param clientId    the application's client_id value to set
-     * @param returnToUrl the returnTo value to set. Must be already URL Encoded and must be white-listed in your Auth0's dashboard.
-     * @param setClientId whether the client_id value must be set or not. This affects the white-list that the Auth0's Dashboard uses to validate the returnTo url.
-     *                    If the client_id is set, the white-list is read from the Application's settings. If the client_id is not set, the white-list is read from the Tenant's settings.
+     * @param returnToUrl the URL the user should be navigated to upon logout. Must not be null.
+     * @param setClientId whether the client_id value must be set or not. If {@code true}, the {@code returnToUrl} must
+     *                    be included in your Auth0 Application's Allowed Logout URLs list. If {@code false}, the
+     *                    {@code returnToUrl} must be included in your Auth0's Allowed Logout URLs at the Tenant level.
      * @return a new instance of the {@link LogoutUrlBuilder} to configure.
      */
     static LogoutUrlBuilder newInstance(HttpUrl baseUrl, String clientId, String returnToUrl, boolean setClientId) {


### PR DESCRIPTION
As discussed in #390, the documentation for generating the authorize (and logout) URLs is wrong. The docs state that the URLs should be encoded, though the validation will fail when it is encoded.

We may make a change to encode the redirect/returnTo URLs, but that may need to go into the next major release to avoid any unintended consequences of changing the current behavior.