### PR TITLE
Bump `jackson-databind` dependency to 2.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.12.6"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2"
     implementation "com.auth0:java-jwt:3.18.3"
     implementation "net.jodah:failsafe:2.4.1"
 


### PR DESCRIPTION
### Changes

This PR bumps the `jackson-databind` dependency to 2.13.2. This addresses [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) for that dependency.

### References

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
