### PR TITLE
Security: Bump `jackson-databind` to 2.13.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.1"
     implementation "com.auth0:java-jwt:3.19.0"
     implementation "net.jodah:failsafe:2.4.1"
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.1"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
     implementation "com.auth0:java-jwt:3.19.0"
     implementation "net.jodah:failsafe:2.4.1"
 


### PR DESCRIPTION
This PR bumps the `jackson-databind` dependency to 2.13.2.1 to address [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) in that library

---

~~Re: https://togithub.com/FasterXML/jackson-databind/issues/3428
Build is currently failing due to an upstream issue; holding until resolved.~~

---

A package fix was released as 2.13.2.2. I've updated the PR and marked as ready for review.