### PR TITLE
Bump java-jwt to 3.19.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
-    implementation "com.auth0:java-jwt:3.19.0"
+    implementation "com.auth0:java-jwt:3.19.1"
     implementation "net.jodah:failsafe:2.4.1"
 
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"


### PR DESCRIPTION
This PR bumps the `java-jwt` dependency to 3.19.1 to address [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) due to transitive dependency in `jackson-databind`