### PR TITLE
Release 1.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.40.1](https://github.com/auth0/auth0-java/tree/1.40.1) (2022-03-30)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/1.40.0...1.40.1)
+
+**Security**
+- Bump java-jwt to 3.19.1 [\#415](https://github.com/auth0/auth0-java/pull/415) ([poovamraj](https://github.com/poovamraj))
+- Security: Bump `jackson-databind` to 2.13.2.2 [\#414](https://github.com/auth0/auth0-java/pull/414) ([evansims](https://github.com/evansims))
+
 ## [1.40.0](https://github.com/auth0/auth0-java/tree/1.40.0) (2022-03-14)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/1.39.0...1.40.0)
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Get Auth0 Java via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>1.40.0</version>
+  <version>1.40.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:1.40.0'
+implementation 'com.auth0:auth0:1.40.1'
 ```
 
 


### PR DESCRIPTION
## [1.40.1](https://github.com/auth0/auth0-java/tree/1.40.1) (2022-03-30)
[Full Changelog](https://github.com/auth0/auth0-java/compare/1.40.0...1.40.1)

**Security**
- Bump java-jwt to 3.19.1 [\#415](https://github.com/auth0/auth0-java/pull/415) ([poovamraj](https://github.com/poovamraj))
- Security: Bump `jackson-databind` to 2.13.2.2 [\#414](https://github.com/auth0/auth0-java/pull/414) ([evansims](https://github.com/evansims))
