### PR TITLE
Update OkHttp to address CVE-2021-0341

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ test {
 }
 
 ext {
-    okhttpVersion = '4.9.0'
+    okhttpVersion = '4.9.3'
     hamcrestVersion = '2.2'
 }
 


### PR DESCRIPTION
Update OkHttp dependency to 4.9.3 to address [CVE-2021-0341](https://nvd.nist.gov/vuln/detail/CVE-2021-0341)