### PR TITLE
Fix double-encoding of log event filter query param

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -1,9 +1,6 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.client.mgmt.filter.FieldsFilter;
-import com.auth0.client.mgmt.filter.LogEventFilter;
-import com.auth0.client.mgmt.filter.PageFilter;
-import com.auth0.client.mgmt.filter.UserFilter;
+import com.auth0.client.mgmt.filter.*;
 import com.auth0.json.mgmt.Permission;
 import com.auth0.json.mgmt.PermissionsPage;
 import com.auth0.json.mgmt.RolesPage;
@@ -86,6 +83,15 @@ public class UsersEntity extends BaseManagementEntity {
         HttpUrl.Builder builder = baseUrl
                 .newBuilder()
                 .addPathSegments("api/v2/users");
+        encodeAndAddQueryParam(builder, filter);
+        String url = builder.build().toString();
+        CustomRequest<UsersPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<UsersPage>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    private static void encodeAndAddQueryParam(HttpUrl.Builder builder, BaseFilter filter) {
         if (filter != null) {
             for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
                 if (KEY_QUERY.equals(e.getKey())) {
@@ -95,11 +101,6 @@ public class UsersEntity extends BaseManagementEntity {
                 }
             }
         }
-        String url = builder.build().toString();
-        CustomRequest<UsersPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<UsersPage>() {
-        });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -245,11 +246,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users")
                 .addPathSegment(userId)
                 .addPathSegment("logs");
-        if (filter != null) {
-            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
-                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
-            }
-        }
+
+        encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
         CustomRequest<LogEventsPage> request = new CustomRequest<>(client, url, "GET", new TypeReference<LogEventsPage>() {
         });

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -91,18 +91,6 @@ public class UsersEntity extends BaseManagementEntity {
         return request;
     }
 
-    private static void encodeAndAddQueryParam(HttpUrl.Builder builder, BaseFilter filter) {
-        if (filter != null) {
-            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
-                if (KEY_QUERY.equals(e.getKey())) {
-                    builder.addEncodedQueryParameter(e.getKey(), String.valueOf(e.getValue()));
-                } else {
-                    builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
-                }
-            }
-        }
-    }
-
     /**
      * Request a User.
      * A token with scope read:users is needed.
@@ -604,5 +592,17 @@ public class UsersEntity extends BaseManagementEntity {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
+    }
+
+    private static void encodeAndAddQueryParam(HttpUrl.Builder builder, BaseFilter filter) {
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                if (KEY_QUERY.equals(e.getKey())) {
+                    builder.addEncodedQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                } else {
+                    builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Log event filter query params are being double-encoded as demonstrated in #419. This change doesn't double-encode the filter query, similar to how we do not encode it in `UsersEntity#list`.