### PR TITLE
Do not cast error values to String

### DIFF
--- a/src/main/java/com/auth0/exception/APIException.java
+++ b/src/main/java/com/auth0/exception/APIException.java
@@ -19,6 +19,13 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class APIException extends Auth0Exception {
 
+    private static final String ERROR_DESCRIPTION = "error_description";
+    private static final String DESCRIPTION = "description";
+    private static final String MESSAGE = "message";
+    private static final String ERROR = "error";
+    private static final String ERROR_CODE = "errorCode";
+    private static final String CODE = "code";
+
     private String error;
     private final String description;
     private final int statusCode;
@@ -129,11 +136,11 @@ public class APIException extends Auth0Exception {
     }
 
     private static String obtainExceptionMessage(Map<String, Object> values) {
-        if (values.containsKey("error_description")) {
-            return (String) values.get("error_description");
+        if (values.containsKey(ERROR_DESCRIPTION)) {
+            return toStringOrNull(values.get(ERROR_DESCRIPTION));
         }
-        if (values.containsKey("description")) {
-            Object description = values.get("description");
+        if (values.containsKey(DESCRIPTION)) {
+            Object description = values.get(DESCRIPTION);
             if (description instanceof String) {
                 return (String) description;
             } else if (description instanceof Map){
@@ -142,25 +149,29 @@ public class APIException extends Auth0Exception {
                 return policy.getDescription();
             }
         }
-        if (values.containsKey("message")) {
-            return (String) values.get("message");
+        if (values.containsKey(MESSAGE)) {
+            return toStringOrNull(values.get(MESSAGE));
         }
-        if (values.containsKey("error")) {
-            return (String) values.get("error");
+        if (values.containsKey(ERROR)) {
+            return toStringOrNull(values.get(ERROR));
         }
         return "Unknown exception";
     }
 
     private static String obtainExceptionError(Map<String, Object> values) {
-        if (values.containsKey("errorCode")) {
-            return (String) values.get("errorCode");
+        if (values.containsKey(ERROR_CODE)) {
+            return toStringOrNull(values.get(ERROR_CODE));
         }
-        if (values.containsKey("error")) {
-            return (String) values.get("error");
+        if (values.containsKey(ERROR)) {
+            return toStringOrNull(values.get(ERROR));
         }
-        if (values.containsKey("code")) {
-            return (String) values.get("code");
+        if (values.containsKey(CODE)) {
+            return toStringOrNull(values.get(CODE));
         }
         return "Unknown error";
+    }
+
+    private static String toStringOrNull(Object obj) {
+        return obj != null ? obj.toString() : null;
     }
 }

--- a/src/test/java/com/auth0/exception/APIExceptionTest.java
+++ b/src/test/java/com/auth0/exception/APIExceptionTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class APIExceptionTest {
@@ -183,6 +184,86 @@ public class APIExceptionTest {
         assertThat(apiException.isMultifactorEnrollRequired(), is(false));
         assertThat(apiException.isMultifactorTokenInvalid(), is(false));
         assertThat(apiException.isVerificationRequired(), is(false));
+    }
 
+    // error description non-string and null
+
+    @Test
+    public void shouldHandleNonStringMessageForMessageError() {
+        Map<String, Object> vals = Collections.singletonMap("error", 42);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getDescription(), is("42"));
+    }
+
+    @Test
+    public void shouldHandleNonStringMessageForMessageErrorDescription() {
+        Map<String, Object> vals = Collections.singletonMap("error_description", 42);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getDescription(), is("42"));
+    }
+
+    @Test
+    public void shouldHandleNonStringMessageForErrorMessageMessage() {
+        Map<String, Object> vals = Collections.singletonMap("message", 42);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getDescription(), is("42"));
+    }
+
+    @Test
+    public void shouldHandleNullMessageForMessageErrorDescription() {
+        Map<String, Object> vals = Collections.singletonMap("error_description", null);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getDescription(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNullMessageForMessageVal() {
+        Map<String, Object> vals = Collections.singletonMap("message", null);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getDescription(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNullMessageForErrorVal() {
+        Map<String, Object> vals = Collections.singletonMap("error", null);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getDescription(), is(nullValue()));
+    }
+
+    // error code non-string and null
+
+    @Test
+    public void shouldHandleNonStringMessageForError() {
+        Map<String, Object> vals = Collections.singletonMap("errorCode", 42);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getError(), is("42"));
+    }
+
+    @Test
+    public void shouldHandleNonStringMessageForErrorDescription() {
+        Map<String, Object> vals = Collections.singletonMap("error", 42);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getError(), is("42"));
+    }
+
+    @Test
+    public void shouldHandleNonStringMessageForMessage() {
+        Map<String, Object> vals = Collections.singletonMap("code", 42);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getError(), is("42"));
+    }
+
+    @Test
+    public void shouldHandleNullMessageForMessage() {
+        Map<String, Object> vals = Collections.singletonMap("error", null);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNullMessageForError() {
+        Map<String, Object> vals = Collections.singletonMap("code", null);
+        APIException apiException = new APIException(vals, ERROR_CODE);
+        assertThat(apiException.getError(), is(nullValue()));
     }
 }


### PR DESCRIPTION
As raised in #410, there are (rare) occasions when the Auth0 error responses are not strings. We construct an `APIException` from the response when there is a response body ([see here](https://github.com/auth0/auth0-java/blob/master/src/main/java/com/auth0/net/ExtendedBaseRequest.java#L127)), passing in a map of `<String, Object>` values parsed from the response.

When constructing the `APIException`, we set the description and error using the values, but casting them to a String ([see here](https://github.com/auth0/auth0-java/blob/master/src/main/java/com/auth0/exception/APIException.java#L131)).

This change sets the description and error by calling `toString()` on the object if not null, else sets it to `null`.

Fixes #410.