### PR TITLE
Add session idle lifetime and make session lifetime doubles

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
@@ -38,7 +38,10 @@ public class Tenant {
     @JsonProperty("allowed_logout_urls")
     private List<String> allowedLogoutUrls;
     @JsonProperty("session_lifetime")
-    private Integer sessionLifetime;
+    private Double sessionLifetime;
+
+    @JsonProperty("idle_session_lifetime")
+    private Double idleSessionLifetime;
 
     /**
      * Getter for the change password page customization.
@@ -263,20 +266,40 @@ public class Tenant {
     /**
      * Getter for the login session lifetime. This is how long the session will stay valid. Value is in hours.
      *
-     * @return the session life time in hours.
+     * @return the session lifetime in hours.
      */
     @JsonProperty("session_lifetime")
-    public Integer getSessionLifetime() {
+    public Double getSessionLifetime() {
         return sessionLifetime;
     }
 
     /**
      * Setter for the login session lifetime. This is how long the session will stay valid. Value is in hours.
      *
-     * @param sessionLifetime the session life time in hours to set.
+     * @param sessionLifetime the session lifetime in hours to set.
      */
     @JsonProperty("session_lifetime")
-    public void setSessionLifetime(Integer sessionLifetime) {
+    public void setSessionLifetime(Double sessionLifetime) {
         this.sessionLifetime = sessionLifetime;
+    }
+
+    /**
+     * Getter for the login session idle lifetime. This is how long the session will stay valid without user activity. Value is in hours.
+     *
+     * @return the session idle lifetime in hours.
+     */
+    @JsonProperty("idle_session_lifetime")
+    public Double getIdleSessionLifetime() {
+        return idleSessionLifetime;
+    }
+
+    /**
+     * Setter for the login session idle lifetime. This is how long the session will stay valid without user activity. Value is in hours, and decimals are allowed (for 30 minutes, use 0.5).
+     *
+     * @param idleSessionLifetime the session lifetime in hours to set.
+     */
+    @JsonProperty("idle_session_lifetime")
+    public void setIdleSessionLifetime(Double idleSessionLifetime) {
+        this.idleSessionLifetime = idleSessionLifetime;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
@@ -28,7 +28,8 @@ public class TenantTest extends JsonTest<Tenant> {
         tenant.setSupportEmail("support@auth0.com");
         tenant.setSupportUrl("https://support.auth0.com");
         tenant.setAllowedLogoutUrls(Collections.singletonList("https://domain.auth0.com/logout"));
-        tenant.setSessionLifetime(48);
+        tenant.setSessionLifetime(48.0);
+        tenant.setIdleSessionLifetime(0.5);
 
         String serialized = toJSON(tenant);
         assertThat(serialized, is(notNullValue()));

--- a/src/test/resources/mgmt/tenant.json
+++ b/src/test/resources/mgmt/tenant.json
@@ -22,6 +22,8 @@
     "enable_dynamic_client_registration": false
   },
   "friendly_name": "My Company",
+  "idle_session_lifetime": 0.5,
+  "session_lifetime": 0.75,
   "picture_url": "https://mycompany.org/logo.png",
   "support_email": "support@mycompany.org",
   "support_url": "https://mycompany.org/support",


### PR DESCRIPTION
### Changes

- Added session idle lifetime for tenant management
- converted session lifetime into doubles (to allow setting less than an hour)

### References

Here is an example on my tenant that session lifetime and idle session lifetime can be double

![image](https://user-images.githubusercontent.com/24528884/164080560-28723ad9-6400-4617-8b5d-b88bb2b7ec49.png)

### Testing

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of the platform/language or why not


Sample code
```java
public class Main {
    public static void main(String[] args) throws Auth0Exception {
        ManagementAPI api = new ManagementAPI("<>", "<>");
        Tenant tenant = api.tenants().get(null).execute();
        System.out.println("Session:" + tenant.getSessionLifetime());
        System.out.println("Idle:" + tenant.getIdleSessionLifetime());

        Tenant newTenant = new Tenant();
        newTenant.setIdleSessionLifetime(0.5);
        newTenant.setSessionLifetime(12.0);
        api.tenants().update(newTenant).execute();

        Tenant updatedTenant = api.tenants().get(null).execute();
        System.out.println("Updated Session:" + updatedTenant.getSessionLifetime());
        System.out.println("Updated Idle:" + updatedTenant.getIdleSessionLifetime());
    }
}
```

Should output 
```
Session:72.0
Idle:48.0
Updated Session:12.0
Updated Idle:0.5
```

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
