### PR TITLE
Add enabled connections on organization

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/organizations/Organization.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Organization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -25,6 +26,8 @@ public class Organization {
     private Map<String, Object> metadata;
     @JsonProperty("branding")
     private Branding branding;
+    @JsonProperty("enabled_connections")
+    private List<EnabledConnection> enabledConnections;
 
     public Organization() {}
 
@@ -107,5 +110,21 @@ public class Organization {
      */
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    /**
+     * @return the enabled connections of this Organization.
+     */
+    public List<EnabledConnection> getEnabledConnections() {
+        return enabledConnections;
+    }
+
+    /**
+     * Sets the enabled connections of this Organization.
+     *
+     * @param enabledConnections the metadata of this Organization.
+     */
+    public void setEnabledConnections(List<EnabledConnection> enabledConnections) {
+        this.enabledConnections = enabledConnections;
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -167,6 +167,14 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         metadata.put("key1", "val1");
         orgToCreate.setMetadata(metadata);
 
+        Connection connection = new Connection();
+        connection.setName("con-1");
+        EnabledConnection enabledConnection = new EnabledConnection();
+        enabledConnection.setConnection(connection);
+        List<EnabledConnection> enabledConnections = new ArrayList<>();
+        enabledConnections.add(enabledConnection);
+        orgToCreate.setEnabledConnections(enabledConnections);
+
         Request<Organization> request = api.organizations().create(orgToCreate);
         assertThat(request, is(notNullValue()));
 
@@ -183,6 +191,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(body, hasEntry("name", "test-org"));
         assertThat(body, hasEntry("display_name", "display name"));
         assertThat(body, hasEntry("metadata", metadata));
+        assertThat(body, hasEntry("enabled_connections", enabledConnections));
         assertThat(body, hasEntry(is("branding"), is(notNullValue())));
 
         assertThat(response, is(notNullValue()));

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -167,10 +167,9 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         metadata.put("key1", "val1");
         orgToCreate.setMetadata(metadata);
 
-        Connection connection = new Connection();
-        connection.setName("con-1");
         EnabledConnection enabledConnection = new EnabledConnection();
-        enabledConnection.setConnection(connection);
+        enabledConnection.setConnectionId("con-1");
+        enabledConnection.setAssignMembershipOnLogin(false);
         List<EnabledConnection> enabledConnections = new ArrayList<>();
         enabledConnections.add(enabledConnection);
         orgToCreate.setEnabledConnections(enabledConnections);
@@ -187,11 +186,11 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body, aMapWithSize(4));
+        assertThat(body, aMapWithSize(5));
         assertThat(body, hasEntry("name", "test-org"));
         assertThat(body, hasEntry("display_name", "display name"));
         assertThat(body, hasEntry("metadata", metadata));
-        assertThat(body, hasEntry("enabled_connections", enabledConnections));
+        assertThat(body, hasEntry(is("enabled_connections"), is(notNullValue())));
         assertThat(body, hasEntry(is("branding"), is(notNullValue())));
 
         assertThat(response, is(notNullValue()));

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsTest.java
@@ -4,7 +4,9 @@ import com.auth0.json.JsonMatcher;
 import com.auth0.json.JsonTest;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,7 +29,13 @@ public class OrganizationsTest extends JsonTest<Organization> {
             "        },\n" +
             "        \"metadata\": {\n" +
             "            \"key1\": \"val1\"\n" +
-            "        }\n" +
+            "        },\n" +
+            "        \"enabled_connections\": [\n" +
+            "            {\n" +
+            "               \"connection_id\": \"con-1\",\n" +
+            "               \"assign_membership_on_login\": \"false\"\n" +
+            "            }\n" +
+            "        ]\n" +
             "    }";
 
         Organization org = fromJSON(orgJson, Organization.class);
@@ -42,6 +50,8 @@ public class OrganizationsTest extends JsonTest<Organization> {
         assertThat(org.getBranding().getColors().getPageBackground(), is("#FF0000"));
         assertThat(org.getMetadata(), is(notNullValue()));
         assertThat(org.getMetadata().get("key1"), is("val1"));
+        assertThat(org.getEnabledConnections().get(0).getConnectionId(), is("con-1"));
+        assertThat(org.getEnabledConnections().get(0).isAssignMembershipOnLogin(), is(false));
     }
 
     @Test
@@ -60,11 +70,19 @@ public class OrganizationsTest extends JsonTest<Organization> {
         organization.setBranding(branding);
         organization.setMetadata(metadata);
 
+        EnabledConnection enabledConnection = new EnabledConnection();
+        enabledConnection.setConnectionId("con-1");
+        enabledConnection.setAssignMembershipOnLogin(false);
+        List<EnabledConnection> enabledConnections = new ArrayList<>();
+        enabledConnections.add(enabledConnection);
+        organization.setEnabledConnections(enabledConnections);
+
         String serialized = toJSON(organization);
         assertThat(serialized, is(notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("name", "org-name"));
         assertThat(serialized, JsonMatcher.hasEntry("display_name", "display name"));
         assertThat(serialized, JsonMatcher.hasEntry("metadata", metadata));
+        assertThat(serialized, JsonMatcher.hasEntry("enabled_connections", is(notNullValue())));
         assertThat(serialized, JsonMatcher.hasEntry("branding", is(notNullValue())));
     }
 }

--- a/src/test/resources/mgmt/organization.json
+++ b/src/test/resources/mgmt/organization.json
@@ -11,5 +11,11 @@
   },
   "metadata": {
     "key1": "val1"
-  }
+  },
+  "enabled_connections": [
+    {
+      "connection_id": "con-1",
+      "assign_membership_on_login": false
+    }
+  ]
 }


### PR DESCRIPTION
### Changes
This PR adds the possibility to set Enabled Connections on an Organization on create, which so far could only be done after creating the organization and only one connection at a time. Changes:

- Added enabled_connections property on Organization
- Fixed tests to include enabled_connections

### References
https://github.com/auth0/auth0-java/issues/425
https://auth0.com/changelog#6BBzbWOwkhEZdzauu2s0Bg


### Testing
This can be tested by adding enabled connections when creating an organization. I have modified some tests to check for enabled_connections. I have not added tests specific to enabled_connections, I have only modified shouldCreateOrganization, shouldSerialize and shouldDeserialize.

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of the platform/language

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors (TelemetryTest not working on master)
