### PR TITLE
Update validation currently used by AuthApi#authorizeUrl and AuthApi#…

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -229,11 +229,11 @@ public class AuthAPI {
      * </pre>
      *
      * @param redirectUri the URL to redirect to after authorization has been granted by the user. Your Auth0 application
-     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded  URI.
+     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded URL.
      * @return a new instance of the {@link AuthorizeUrlBuilder} to configure.
      */
     public AuthorizeUrlBuilder authorizeUrl(String redirectUri) {
-        Asserts.assertValidUri(redirectUri, "redirect uri");
+        Asserts.assertValidUrl(redirectUri, "redirect uri");
 
         return AuthorizeUrlBuilder.newInstance(baseUrl, clientId, redirectUri);
     }
@@ -250,14 +250,14 @@ public class AuthAPI {
      * }
      * </pre>
      *
-     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded  URI.
+     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded URL.
      * @param setClientId whether the client_id value must be set or not. If {@code true}, the {@code returnToUrl} must
      *                    be included in your Auth0 Application's Allowed Logout URLs list. If {@code false}, the
      *                    {@code returnToUrl} must be included in your Auth0's Allowed Logout URLs at the Tenant level.
      * @return a new instance of the {@link LogoutUrlBuilder} to configure.
      */
     public LogoutUrlBuilder logoutUrl(String returnToUrl, boolean setClientId) {
-        Asserts.assertValidUri(returnToUrl, "return to url");
+        Asserts.assertValidUrl(returnToUrl, "return to url");
 
         return LogoutUrlBuilder.newInstance(baseUrl, clientId, returnToUrl, setClientId);
     }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -229,11 +229,11 @@ public class AuthAPI {
      * </pre>
      *
      * @param redirectUri the URL to redirect to after authorization has been granted by the user. Your Auth0 application
-     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded HTTP or HTTPS URL.
+     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded  URI.
      * @return a new instance of the {@link AuthorizeUrlBuilder} to configure.
      */
     public AuthorizeUrlBuilder authorizeUrl(String redirectUri) {
-        Asserts.assertValidUrl(redirectUri, "redirect uri");
+        Asserts.assertValidUri(redirectUri, "redirect uri");
 
         return AuthorizeUrlBuilder.newInstance(baseUrl, clientId, redirectUri);
     }
@@ -250,14 +250,14 @@ public class AuthAPI {
      * }
      * </pre>
      *
-     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded HTTP or HTTPS URL.
+     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded  URI.
      * @param setClientId whether the client_id value must be set or not. If {@code true}, the {@code returnToUrl} must
      *                    be included in your Auth0 Application's Allowed Logout URLs list. If {@code false}, the
      *                    {@code returnToUrl} must be included in your Auth0's Allowed Logout URLs at the Tenant level.
      * @return a new instance of the {@link LogoutUrlBuilder} to configure.
      */
     public LogoutUrlBuilder logoutUrl(String returnToUrl, boolean setClientId) {
-        Asserts.assertValidUrl(returnToUrl, "return to url");
+        Asserts.assertValidUri(returnToUrl, "return to url");
 
         return LogoutUrlBuilder.newInstance(baseUrl, clientId, returnToUrl, setClientId);
     }

--- a/src/main/java/com/auth0/utils/Asserts.java
+++ b/src/main/java/com/auth0/utils/Asserts.java
@@ -20,21 +20,17 @@ public abstract class Asserts {
     }
 
     /**
-     * Asserts that a value is a valid URI.
+     * Asserts that a value is a valid URL.
      *
      * @param value the value to check.
      * @param name the name of the parameter, used when creating the exception message.
-     * @throws IllegalArgumentException if the value is null or is not a valid URI.
+     * @throws IllegalArgumentException if the value is null or is not a valid URL.
      */
-    public static void assertValidUri(String value, String name) {
-        if (value == null) {
-            throw new IllegalArgumentException(String.format("'%s' cannot be null!", name));
-        }
-
+    public static void assertValidUrl(String value, String name) {
         try {
             new URI(value);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(String.format("'%s' must be a valid URI!", name));
+        } catch (URISyntaxException | NullPointerException e) {
+            throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name), e);
         }
     }
 

--- a/src/main/java/com/auth0/utils/Asserts.java
+++ b/src/main/java/com/auth0/utils/Asserts.java
@@ -1,7 +1,8 @@
 package com.auth0.utils;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
-import okhttp3.HttpUrl;
 
 public abstract class Asserts {
 
@@ -19,15 +20,21 @@ public abstract class Asserts {
     }
 
     /**
-     * Asserts that a value is a valid URL.
+     * Asserts that a value is a valid URI.
      *
      * @param value the value to check.
      * @param name the name of the parameter, used when creating the exception message.
-     * @throws IllegalArgumentException if the value is null or is not a valid URL.
+     * @throws IllegalArgumentException if the value is null or is not a valid URI.
      */
-    public static void assertValidUrl(String value, String name) {
-        if (value == null || HttpUrl.parse(value) == null) {
-            throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
+    public static void assertValidUri(String value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(String.format("'%s' cannot be null!", name));
+        }
+
+        try {
+            new URI(value);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(String.format("'%s' must be a valid URI!", name));
         }
     }
 

--- a/src/main/java/com/auth0/utils/Asserts.java
+++ b/src/main/java/com/auth0/utils/Asserts.java
@@ -29,9 +29,10 @@ public abstract class Asserts {
         if (value == null) {
             throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
         }
+        boolean isValidUrl = HttpUrl.parse(value) != null;
         boolean isValidCustomSchemeUrl = value.contains(":") &&
             HttpUrl.parse(value.replaceFirst(value.substring(0, value.indexOf(":")), "https")) != null;
-        if (HttpUrl.parse(value) == null && !isValidCustomSchemeUrl) {
+        if (!isValidUrl && !isValidCustomSchemeUrl) {
             throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
         }
     }

--- a/src/main/java/com/auth0/utils/Asserts.java
+++ b/src/main/java/com/auth0/utils/Asserts.java
@@ -1,8 +1,7 @@
 package com.auth0.utils;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
+import okhttp3.HttpUrl;
 
 public abstract class Asserts {
 
@@ -23,14 +22,17 @@ public abstract class Asserts {
      * Asserts that a value is a valid URL.
      *
      * @param value the value to check.
-     * @param name the name of the parameter, used when creating the exception message.
+     * @param name  the name of the parameter, used when creating the exception message.
      * @throws IllegalArgumentException if the value is null or is not a valid URL.
      */
     public static void assertValidUrl(String value, String name) {
-        try {
-            new URI(value);
-        } catch (URISyntaxException | NullPointerException e) {
-            throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name), e);
+        if (value == null) {
+            throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
+        }
+        boolean isValidCustomSchemeUrl = value.contains(":") &&
+            HttpUrl.parse(value.replaceFirst(value.substring(0, value.indexOf(":")), "https")) != null;
+        if (HttpUrl.parse(value) == null && !isValidCustomSchemeUrl) {
+            throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
         }
     }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -477,15 +477,15 @@ public class AuthAPITest {
     @Test
     public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNull() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'redirect uri' must be a valid URL!");
+        exception.expectMessage("'redirect uri' cannot be null!");
         api.authorizeUrl(null);
     }
 
     @Test
-    public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNotValidURL() {
+    public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNotValidURI() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'redirect uri' must be a valid URL!");
-        api.authorizeUrl("notvalid.url");
+        exception.expectMessage("'redirect uri' must be a valid URI!");
+        api.authorizeUrl("http://test/this is invalid");
     }
 
     @Test
@@ -512,15 +512,15 @@ public class AuthAPITest {
     @Test
     public void shouldThrowWhenLogoutUrlBuilderReturnToUrlIsNull() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'return to url' must be a valid URL!");
+        exception.expectMessage("'return to url' cannot be null!");
         api.logoutUrl(null, true);
     }
 
     @Test
-    public void shouldThrowWhenLogoutUrlBuilderRedirectUriIsNotValidURL() {
+    public void shouldThrowWhenLogoutUrlBuilderRedirectUriIsNotValidURI() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'return to url' must be a valid URL!");
-        api.logoutUrl("notvalid.url", true);
+        exception.expectMessage("'return to url' must be a valid URI!");
+        api.logoutUrl("http://test/this is invalid", true);
     }
 
     @Test

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -477,14 +477,14 @@ public class AuthAPITest {
     @Test
     public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNull() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'redirect uri' cannot be null!");
+        exception.expectMessage("'redirect uri' must be a valid URL!");
         api.authorizeUrl(null);
     }
 
     @Test
-    public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNotValidURI() {
+    public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNotValidURL() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'redirect uri' must be a valid URI!");
+        exception.expectMessage("'redirect uri' must be a valid URL!");
         api.authorizeUrl("http://test/this is invalid");
     }
 
@@ -512,14 +512,14 @@ public class AuthAPITest {
     @Test
     public void shouldThrowWhenLogoutUrlBuilderReturnToUrlIsNull() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'return to url' cannot be null!");
+        exception.expectMessage("'return to url' must be a valid URL!");
         api.logoutUrl(null, true);
     }
 
     @Test
-    public void shouldThrowWhenLogoutUrlBuilderRedirectUriIsNotValidURI() {
+    public void shouldThrowWhenLogoutUrlBuilderRedirectUriIsNotValidURL() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'return to url' must be a valid URI!");
+        exception.expectMessage("'return to url' must be a valid URL!");
         api.logoutUrl("http://test/this is invalid", true);
     }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -485,7 +485,7 @@ public class AuthAPITest {
     public void shouldThrowWhenAuthorizeUrlBuilderRedirectUriIsNotValidURL() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'redirect uri' must be a valid URL!");
-        api.authorizeUrl("http://test/this is invalid");
+        api.authorizeUrl("notvalid.url");
     }
 
     @Test
@@ -520,7 +520,7 @@ public class AuthAPITest {
     public void shouldThrowWhenLogoutUrlBuilderRedirectUriIsNotValidURL() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'return to url' must be a valid URL!");
-        api.logoutUrl("http://test/this is invalid", true);
+        api.logoutUrl("notvalid.url", true);
     }
 
     @Test

--- a/src/test/java/com/auth0/utils/AssertsTest.java
+++ b/src/test/java/com/auth0/utils/AssertsTest.java
@@ -1,5 +1,6 @@
 package com.auth0.utils;
 
+import okhttp3.HttpUrl;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -13,51 +14,51 @@ public class AssertsTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void assertValidUri_succeedsForHttps() {
-        Asserts.assertValidUri("https://me.auth0.com", URI_NAME);
+    public void succeedsForHttps() {
+        Asserts.assertValidUrl("https://me.auth0.com", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_succeedsForHttp() {
-        Asserts.assertValidUri("http://me.auth0.com", URI_NAME);
+    public void succeedsForHttp() {
+        Asserts.assertValidUrl("http://me.auth0.com", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_succeedsWithPath() {
-        Asserts.assertValidUri("https://me.auth0.com/path", URI_NAME);
+    public void succeedsWithPath() {
+        Asserts.assertValidUrl("https://me.auth0.com/path", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_succeedsWithQueryParams() {
-        Asserts.assertValidUri("https://me.auth0.com?query=params&moreQuery=params", URI_NAME);
+    public void succeedsWithQueryParams() {
+        Asserts.assertValidUrl("https://me.auth0.com?query=params&moreQuery=params", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_succeedsWithCustomDomain() {
-        Asserts.assertValidUri("https://a.custom.domain", URI_NAME);
+    public void succeedsWithCustomDomain() {
+        Asserts.assertValidUrl("https://a.custom.domain", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_succeedsWithCustomAppScheme() {
-        Asserts.assertValidUri("custom.app.scheme://custom.domain.com/path/callback", URI_NAME);
+    public void succeedsWithCustomAppScheme() {
+        Asserts.assertValidUrl("custom.app.scheme://custom.domain.com/path/callback", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_succeedsWithCustomAppSchemeWithQueryParams() {
-        Asserts.assertValidUri("custom.app.scheme://custom.domain.com/path/callback?query=params&moreQuery=params", URI_NAME);
+    public void succeedsWithCustomAppSchemeWithQueryParams() {
+        Asserts.assertValidUrl("custom.app.scheme://custom.domain.com/path/callback?query=params&moreQuery=params", URI_NAME);
     }
 
     @Test
-    public void assertValidUri_throwsIllegalArgumentExceptionWhenValueIsNull() {
+    public void throwsIllegalArgumentExceptionWhenValueIsNull() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(String.format("'%s' cannot be null!", URI_NAME));
-        Asserts.assertValidUri(null, URI_NAME);
+        exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
+        Asserts.assertValidUrl(null, URI_NAME);
     }
 
     @Test
-    public void assertValidUri_throwsIllegalArgumentExceptionWhenValueIsInvalid() {
+    public void throwsIllegalArgumentExceptionWhenValueIsInvalid() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(String.format("'%s' must be a valid URI!", URI_NAME));
-        Asserts.assertValidUri("http://test/this is invalid", URI_NAME);
+        exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
+        Asserts.assertValidUrl("http://test/this is invalid", URI_NAME);
     }
 }

--- a/src/test/java/com/auth0/utils/AssertsTest.java
+++ b/src/test/java/com/auth0/utils/AssertsTest.java
@@ -72,4 +72,11 @@ public class AssertsTest {
         exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
         Asserts.assertValidUrl("not.a.domain", URI_NAME);
     }
+
+    @Test
+    public void throwsIllegalArgumentExceptionWhenValueIsCustomSchemeAndInvalid() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
+        Asserts.assertValidUrl("demo://host:%39%39/", URI_NAME);
+    }
 }

--- a/src/test/java/com/auth0/utils/AssertsTest.java
+++ b/src/test/java/com/auth0/utils/AssertsTest.java
@@ -1,0 +1,63 @@
+package com.auth0.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AssertsTest {
+
+    private static final String URI_NAME = "name";
+
+    @SuppressWarnings("deprecation")
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void assertValidUri_succeedsForHttps() {
+        Asserts.assertValidUri("https://me.auth0.com", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_succeedsForHttp() {
+        Asserts.assertValidUri("http://me.auth0.com", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_succeedsWithPath() {
+        Asserts.assertValidUri("https://me.auth0.com/path", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_succeedsWithQueryParams() {
+        Asserts.assertValidUri("https://me.auth0.com?query=params&moreQuery=params", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_succeedsWithCustomDomain() {
+        Asserts.assertValidUri("https://a.custom.domain", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_succeedsWithCustomAppScheme() {
+        Asserts.assertValidUri("custom.app.scheme://custom.domain.com/path/callback", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_succeedsWithCustomAppSchemeWithQueryParams() {
+        Asserts.assertValidUri("custom.app.scheme://custom.domain.com/path/callback?query=params&moreQuery=params", URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_throwsIllegalArgumentExceptionWhenValueIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("'%s' cannot be null!", URI_NAME));
+        Asserts.assertValidUri(null, URI_NAME);
+    }
+
+    @Test
+    public void assertValidUri_throwsIllegalArgumentExceptionWhenValueIsInvalid() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("'%s' must be a valid URI!", URI_NAME));
+        Asserts.assertValidUri("http://test/this is invalid", URI_NAME);
+    }
+}

--- a/src/test/java/com/auth0/utils/AssertsTest.java
+++ b/src/test/java/com/auth0/utils/AssertsTest.java
@@ -1,9 +1,13 @@
 package com.auth0.utils;
 
 import okhttp3.HttpUrl;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AssertsTest {
 
@@ -29,6 +33,11 @@ public class AssertsTest {
     }
 
     @Test
+    public void succeedWithUnEncodedUrl(){
+        Asserts.assertValidUrl("https://me.auth0.com/path should fail", URI_NAME);
+    }
+
+    @Test
     public void succeedsWithQueryParams() {
         Asserts.assertValidUrl("https://me.auth0.com?query=params&moreQuery=params", URI_NAME);
     }
@@ -41,6 +50,8 @@ public class AssertsTest {
     @Test
     public void succeedsWithCustomAppScheme() {
         Asserts.assertValidUrl("custom.app.scheme://custom.domain.com/path/callback", URI_NAME);
+        Asserts.assertValidUrl("demo://custom.domain.com/path/callback", URI_NAME);
+        Asserts.assertValidUrl("com.custom_app.scheme://custom.domain.com/path/callback", URI_NAME);
     }
 
     @Test
@@ -59,6 +70,6 @@ public class AssertsTest {
     public void throwsIllegalArgumentExceptionWhenValueIsInvalid() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
-        Asserts.assertValidUrl("http://test/this is invalid", URI_NAME);
+        Asserts.assertValidUrl("not.a.domain", URI_NAME);
     }
 }


### PR DESCRIPTION
…logoutUrl to accept all valid URIs using java.net.URI

### Changes

Please see https://github.com/auth0/auth0-java/issues/424 for context. 

### References

https://github.com/auth0/auth0-java/issues/424

It is probably also worth noting the decision behind the use of the java.net.URI constructor instead of the static URI.create() method which can be found in their documentation [here](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#create-java.lang.String-) where it states The constructors, which throw URISyntaxException directly, should be used situations where a URI is being constructed from user input or from some other source that may be prone to errors.

### Testing

Testing can be done by running the modified unit tests in `AuthApiTest.java` and the new unit tests in `AssertsTest.java`.

I wrote a handful of test cases to give examples of what would and would not pass validation. I'm not very familiar with [rfc2396](https://www.ietf.org/rfc/rfc2396.txt) which is referenced by [java.net.URI](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#URI-java.lang.String-) as the syntax that defines a URI, but it seems quite broad. Obviously since URIs expand well past valid http or https URLs this would introduce a lot of values that would be considered valid. I don't necessarily have any concern here because these still must be configured as valid callback urls within Auth0 itself.

- [x] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
