### PR TITLE
Support for custom scheme URL

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -229,7 +229,7 @@ public class AuthAPI {
      * </pre>
      *
      * @param redirectUri the URL to redirect to after authorization has been granted by the user. Your Auth0 application
-     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded HTTP or HTTPS URL.
+     *                    must have this URL as one of its Allowed Callback URLs. Must be a valid non-encoded URL.
      * @return a new instance of the {@link AuthorizeUrlBuilder} to configure.
      */
     public AuthorizeUrlBuilder authorizeUrl(String redirectUri) {
@@ -250,7 +250,7 @@ public class AuthAPI {
      * }
      * </pre>
      *
-     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded HTTP or HTTPS URL.
+     * @param returnToUrl the URL the user should be navigated to upon logout. Must be a valid non-encoded URL.
      * @param setClientId whether the client_id value must be set or not. If {@code true}, the {@code returnToUrl} must
      *                    be included in your Auth0 Application's Allowed Logout URLs list. If {@code false}, the
      *                    {@code returnToUrl} must be included in your Auth0's Allowed Logout URLs at the Tenant level.

--- a/src/main/java/com/auth0/utils/Asserts.java
+++ b/src/main/java/com/auth0/utils/Asserts.java
@@ -26,7 +26,13 @@ public abstract class Asserts {
      * @throws IllegalArgumentException if the value is null or is not a valid URL.
      */
     public static void assertValidUrl(String value, String name) {
-        if (value == null || HttpUrl.parse(value) == null) {
+        if (value == null) {
+            throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
+        }
+        boolean isValidUrl = HttpUrl.parse(value) != null;
+        boolean isValidCustomSchemeUrl = value.contains(":") &&
+            HttpUrl.parse(value.replaceFirst(value.substring(0, value.indexOf(":")), "https")) != null;
+        if (!isValidUrl && !isValidCustomSchemeUrl) {
             throw new IllegalArgumentException(String.format("'%s' must be a valid URL!", name));
         }
     }

--- a/src/test/java/com/auth0/utils/AssertsTest.java
+++ b/src/test/java/com/auth0/utils/AssertsTest.java
@@ -1,0 +1,77 @@
+package com.auth0.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AssertsTest {
+
+    private static final String URI_NAME = "name";
+
+    @SuppressWarnings("deprecation")
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void succeedsForHttps() {
+        Asserts.assertValidUrl("https://me.auth0.com", URI_NAME);
+    }
+
+    @Test
+    public void succeedsForHttp() {
+        Asserts.assertValidUrl("http://me.auth0.com", URI_NAME);
+    }
+
+    @Test
+    public void succeedsWithPath() {
+        Asserts.assertValidUrl("https://me.auth0.com/path", URI_NAME);
+    }
+
+    @Test
+    public void succeedWithUnEncodedUrl(){
+        Asserts.assertValidUrl("https://me.auth0.com/path should fail", URI_NAME);
+    }
+
+    @Test
+    public void succeedsWithQueryParams() {
+        Asserts.assertValidUrl("https://me.auth0.com?query=params&moreQuery=params", URI_NAME);
+    }
+
+    @Test
+    public void succeedsWithCustomDomain() {
+        Asserts.assertValidUrl("https://a.custom.domain", URI_NAME);
+    }
+
+    @Test
+    public void succeedsWithCustomAppScheme() {
+        Asserts.assertValidUrl("custom.app.scheme://custom.domain.com/path/callback", URI_NAME);
+        Asserts.assertValidUrl("demo://custom.domain.com/path/callback", URI_NAME);
+        Asserts.assertValidUrl("com.custom_app.scheme://custom.domain.com/path/callback", URI_NAME);
+    }
+
+    @Test
+    public void succeedsWithCustomAppSchemeWithQueryParams() {
+        Asserts.assertValidUrl("custom.app.scheme://custom.domain.com/path/callback?query=params&moreQuery=params", URI_NAME);
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionWhenValueIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
+        Asserts.assertValidUrl(null, URI_NAME);
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionWhenValueIsInvalid() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
+        Asserts.assertValidUrl("not.a.domain", URI_NAME);
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionWhenValueIsCustomSchemeAndInvalid() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("'%s' must be a valid URL!", URI_NAME));
+        Asserts.assertValidUrl("demo://host:%39%39/", URI_NAME);
+    }
+}


### PR DESCRIPTION
### Changes
We are adding support for Custom schemes. This is done using existing HttpUrl method but just changing the value before `:` if it is a custom domain. We are not using Java's URI class since it doesn't validate unencoded URLs and we do not want to break the existing behaviour of the SDK

### References
Issue - https://github.com/auth0/auth0-java/issues/424
Previous PR - https://github.com/auth0/auth0-java/pull/428

### Testing
We have added tests to check the URL and all the existing tests pass without change

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not