### PR TITLE
Update ship orb configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
           filters:
             branches:
               only:
-                - chore/ship-orb-version
+                - master
           requires:
             - build
   api-diff:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@dev:2e189a9
+  ship: auth0/ship@dev:a8a89be
 commands:
   checkout-and-build:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - chore/ship-orb-version
           requires:
             - build
   api-diff:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@dev:b224b98
+  ship: auth0/ship@dev:2e189a9
 commands:
   checkout-and-build:
     steps:
@@ -60,6 +60,7 @@ workflows:
     jobs:
       - build
       - ship/java-publish:
+          prefix-tag: false
           context:
             - publish-gh
           filters:

--- a/.shiprc
+++ b/.shiprc
@@ -1,5 +1,6 @@
 {
   "files": {
+    "build.gradle": [],
     "README.md": []
   },
   "prefixVersion": false

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ repositories {
     mavenCentral()
 }
 
+version = '1.42.0'
 group = 'com.auth0'
 logger.lifecycle("Using version ${version} for ${name} group $group")
 


### PR DESCRIPTION
This PR better prepares the project for integration with our automated releasing tooling

- It tracks the version inside build.gradle
- It configures Ship CLI to replace the version in `build.gradle`
- It configures our ship orb to not prefix the version with `v`.
- It bumps the version of our shipping orb, to use the latest changes.