### PR TITLE
Use latest ship orb and provide publish-java context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@dev:a8a89be
+  ship: auth0/ship@dev:c90b57e
 commands:
   checkout-and-build:
     steps:
@@ -63,6 +63,7 @@ workflows:
           prefix-tag: false
           context:
             - publish-gh
+            - publish-java
           filters:
             branches:
               only:


### PR DESCRIPTION
Updates the Circle CI config to use the latest version of the unpublished java-configured orb.
It also gives access to the `publish-java` context to the `java-publish` job.