### PR TITLE
Security: Update OkHttp to 4.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ test {
 }
 
 ext {
-    okhttpVersion = '4.9.10'
+    okhttpVersion = '4.10.0'
     hamcrestVersion = '2.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ test {
 }
 
 ext {
-    okhttpVersion = '4.9.3'
+    okhttpVersion = '4.9.10'
     hamcrestVersion = '2.2'
 }
 


### PR DESCRIPTION
This PR updates OkHttp to 4.10.0 to resolve [CVE-2022-24329](https://www.cve.org/CVERecord?id=CVE-2022-24329)