### PR TITLE
Ensure version is defined before plugins are applied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+buildscript {
+    version = "1.42.0"
+}
+
 plugins {
     id 'java'
     id 'jacoco'
@@ -15,7 +19,6 @@ signing {
     useInMemoryPgpKeys(signingKey, signingKeyPwd)
 }
 
-version = '1.42.0'
 group = 'com.auth0'
 logger.lifecycle("Using version ${version} for ${name} group $group")
 


### PR DESCRIPTION
### Changes

This PR ensures the version property is defined before the plugins are applied, to ensure we can use it in the LibraryPlugin's apply method.

### References

https://github.com/auth0/oss-library-gradle-plugin/pull/32

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
