### PR TITLE
Bump oss-library and auth0/ship

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.6.0
+  ship: auth0/ship@0.6.1
 commands:
   checkout-and-build:
     steps:

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.16.0'
+        id 'com.auth0.gradle.oss-library.java' version '0.17.0'
     }
 }
 


### PR DESCRIPTION
### Changes

Bump OSS-library to use the latest version to ensure we are set for releasing using the latest version of Auth0/Ship

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
