### PR TITLE
Add findAndRegisterModules() to ObjectMapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,11 +83,12 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
     implementation "com.auth0:java-jwt:3.19.1"
     implementation "net.jodah:failsafe:2.4.1"
-
+    
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"
     testImplementation "org.mockito:mockito-core:3.7.7"
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testImplementation "org.hamcrest:hamcrest-core:${hamcrestVersion}"
     testImplementation "org.hamcrest:hamcrest-library:${hamcrestVersion}"
     testImplementation "junit:junit:4.13.1"
+    testImplementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.3'
 }

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -33,7 +33,6 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
     CustomRequest(OkHttpClient client, String url, String method, ObjectMapper mapper, TypeReference<T> tType) {
         super(client, url, method, mapper);
         this.mapper = mapper;
-        this.mapper.findAndRegisterModules();
         this.tType = tType;
         this.parameters = new HashMap<>();
     }
@@ -77,5 +76,10 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
     public CustomRequest<T> setBody(Object value) {
         body = value;
         return this;
+    }
+
+    @Override
+    public void registerModules() {
+        this.mapper.findAndRegisterModules();
     }
 }

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -33,6 +33,7 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
     CustomRequest(OkHttpClient client, String url, String method, ObjectMapper mapper, TypeReference<T> tType) {
         super(client, url, method, mapper);
         this.mapper = mapper;
+        this.mapper.findAndRegisterModules();
         this.tType = tType;
         this.parameters = new HashMap<>();
     }

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -95,4 +95,9 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
         partsCount++;
         return this;
     }
+
+    @Override
+    public void registerModules() {
+        this.mapper.findAndRegisterModules();
+    }
 }

--- a/src/main/java/com/auth0/net/Request.java
+++ b/src/main/java/com/auth0/net/Request.java
@@ -36,4 +36,11 @@ public interface Request<T> {
     default CompletableFuture<T> executeAsync() {
         throw new UnsupportedOperationException("executeAsync");
     }
+
+    /**
+     * Calls the findAndRegisterModules() method of the internal ObjectMapper
+     * 
+     * This is for example needed, if Java 8 date types are sent within a request body. 
+     */
+    void registerModules();
 }

--- a/src/test/java/com/auth0/net/BaseRequestTest.java
+++ b/src/test/java/com/auth0/net/BaseRequestTest.java
@@ -247,6 +247,11 @@ public class BaseRequestTest {
         protected Request createRequest() throws Auth0Exception {
             return null;
         }
+
+        @Override
+        public void registerModules() {
+            
+        }
     }
 
 }

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -18,6 +18,7 @@ import org.junit.*;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -365,6 +366,21 @@ public class CustomRequestTest {
         assertThat(rateLimitException.getLimit(), is(-1L));
         assertThat(rateLimitException.getRemaining(), is(-1L));
         assertThat(rateLimitException.getReset(), is(-1L));
+    }
+
+    @Test
+    public void shouldRegisterModulesAndConvert() throws Exception {
+        CustomRequest<TokenHolder> request = new CustomRequest<>(client, server.getBaseUrl(), "POST", tokenHolderType);
+        assertThat(request, is(notNullValue()));
+        request.registerModules();
+
+        Instant body = Instant.now();
+        request.setBody(body);
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder execute = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(execute, is(notNullValue()));
     }
 
 }

--- a/src/test/java/com/auth0/net/RequestTest.java
+++ b/src/test/java/com/auth0/net/RequestTest.java
@@ -15,6 +15,9 @@ public class RequestTest {
                 public String execute() throws Auth0Exception {
                     return null;
                 }
+
+                @Override
+                public void registerModules() {}
             }::executeAsync);
     }
 }


### PR DESCRIPTION
### Changes

After initialization of CustomRequest, I added the call `this.mapper.findAndRegisterModules();` which will let the ObjectMapper register all the modules that are configured (i.e. JavaTimeModule for Java 8 Date classes)
This fixes #440 

### References

#440 

### Testing

As this is only one line of code that has quite 0 logic, I didn't add tests. If required, a possible test could be to verify that the modules are getting loaded

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
