### PR TITLE
Replace Codecov uploader w/ CircleCI Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
+
 orbs:
   ship: auth0/ship@0.6.1
+  codecov: codecov/codecov@3
+  
 commands:
   checkout-and-build:
     steps:
@@ -17,13 +20,12 @@ commands:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "build.gradle" }}
+          
   run-tests:
     steps:
       - run: ./gradlew check jacocoTestReport --continue --console=plain
-      - run:
-          name: Upload Coverage
-          when: on_success
-          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
+      - codecov/upload
+      
   run-api-diff:
     steps:
       # run apiDiff task
@@ -44,6 +46,7 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
       _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
       TERM: dumb
+      
   api-diff:
     docker:
       - image: openjdk:8-jdk
@@ -70,6 +73,7 @@ workflows:
                 - master
           requires:
             - build
+            
   api-diff:
     jobs:
       - api-diff


### PR DESCRIPTION
### Changes

This PR replaces the deprecated Codecov “bash uploader” for the recommended CircleCI Orb equivalent.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
