### PR TITLE
#448 Adding field filter option to get client by ID API

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -1,6 +1,7 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.filter.ClientFilter;
+import com.auth0.client.mgmt.filter.FieldsFilter;
 import com.auth0.json.mgmt.client.Client;
 import com.auth0.json.mgmt.client.ClientsPage;
 import com.auth0.net.CustomRequest;
@@ -89,6 +90,33 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
+        CustomRequest<Client> request = new CustomRequest<>(client, url, "GET", new TypeReference<Client>() {
+        });
+        request.addHeader("Authorization", "Bearer " + apiToken);
+        return request;
+    }
+
+    /**
+     * Request an Application. A token with scope read:clients is needed. If you also need the client_secret and encryption_key attributes the token must have read:client_keys scope.
+     * See https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
+     *
+     * @param clientId the application's client id.
+     * @param filter optional filter to restrict fields (to be included/excluded in response)
+     * @return a Request to execute.
+     */
+    public Request<Client> get(String clientId, FieldsFilter filter) {
+        Asserts.assertNotNull(clientId, "client id");
+
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/clients")
+            .addPathSegment(clientId);
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+        String url = builder.build().toString();
         CustomRequest<Client> request = new CustomRequest<>(client, url, "GET", new TypeReference<Client>() {
         });
         request.addHeader("Authorization", "Bearer " + apiToken);

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -1,6 +1,7 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.filter.ClientFilter;
+import com.auth0.client.mgmt.filter.FieldsFilter;
 import com.auth0.json.mgmt.client.Client;
 import com.auth0.json.mgmt.client.ClientsPage;
 import com.auth0.net.Request;
@@ -171,6 +172,27 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients/1"));
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldGetClientWithFilter() throws Exception {
+        FieldsFilter fieldsFilter = new FieldsFilter()
+            .withFields("name,client_id,app_type,tenant", true);
+
+        Request<Client> request = api.clients().get("1", fieldsFilter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT, 200);
+        Client response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients/1"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("fields", "name,client_id,app_type,tenant"));
+        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
 
         assertThat(response, is(notNullValue()));
     }

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -198,6 +198,22 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldGetClientWithNullFilter() throws Exception {
+        Request<Client> request = api.clients().get("1", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_CLIENT, 200);
+        Client response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients/1"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
     public void shouldThrowOnCreateClientWithNullData() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'client' cannot be null!");


### PR DESCRIPTION
### Changes
Current auth0-java SDK does not provide filter option to "get Client By Id" API, which is available in auth0-management API
This feature is useful if we intend to read only limited client fields.

Solution here is - Adding new method to ClientsEntity.java, which accepts "FieldsFilter" parameter

### References

Please include relevant links supporting this change such as a:

- Feature Requested
https://github.com/auth0/auth0-java/issues/448
### Testing

Locally tested by connecting to real auth0

- [x] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
