### PR TITLE
Add support for deleting all user's authenticators

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -244,6 +244,23 @@ public class UsersEntity extends BaseManagementEntity {
     }
 
     /**
+     * Delete all an user's authenticators.
+     * A token with scope delete:guardian_enrollments is needed.
+     *
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators">API docs</a>
+     *
+     * @param userId   the user id
+     * @return a Request to execute.
+     */
+    public Request<Void> deleteAllAuthenticators(String userId) {
+        Asserts.assertNotNull(userId, "user id");
+
+        return voidRequest("DELETE", builder -> {
+            builder.withPathSegments(String.format("api/v2/users/%s/authenticators", userId));
+        });
+    }
+    
+    /**
      * Delete an existing User's Multifactor Provider.
      * A token with scope update:users is needed.
      * See https://auth0.com/docs/api/management/v2#!/Users/delete_multifactor_by_provider

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -510,6 +510,27 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldThrowOnDeleteUserAuthenticatorsWithNullId() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'user id' cannot be null!");
+        api.users().deleteAllAuthenticators(null);
+    }
+
+    @Test
+    public void shouldDeleteUserAuthenticators() throws Exception {
+        Request<Void> request = api.users().deleteAllAuthenticators("auth0|23");
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/auth0%7C23/authenticators"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    @Test
     public void shouldThrowOnDeleteUserMultifactorProviderWithNullId() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'user id' cannot be null!");


### PR DESCRIPTION
Adds support for deleting all an user's authenticators.

See the [API docs](https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators) for definition of this API.