### PR TITLE
Remove Ship Orb integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  ship: auth0/ship@0.6.1
   codecov: codecov/codecov@3
   
 commands:
@@ -62,17 +61,6 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - ship/java-publish:
-          prefix-tag: false
-          context:
-            - publish-gh
-            - publish-sonatype
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - build
             
   api-diff:
     jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-buildscript {
-    version = "1.42.0"
-}
-
 plugins {
     id 'java'
     id 'jacoco'
@@ -10,13 +6,6 @@ plugins {
 
 repositories {
     mavenCentral()
-}
-
-def signingKey = findProperty('SIGNING_KEY')
-def signingKeyPwd = findProperty('SIGNING_PASSWORD')
-
-signing {
-    useInMemoryPgpKeys(signingKey, signingKeyPwd)
 }
 
 group = 'com.auth0'


### PR DESCRIPTION
### Changes

Reverts changes made that rely on using the Ship Orb, making it impossible to release manually.
Reverting this until we have fixed the Ship Orb for Java.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
