### PR TITLE
Support stage property on Breached Password Detection

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPassword.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPassword.java
@@ -23,6 +23,8 @@ public class BreachedPassword {
     private List<String> shields;
     @JsonProperty("admin_notification_frequency")
     private List<String> adminNotificationFrequency;
+    @JsonProperty("stage")
+    private BreachedPasswordStage stage;
 
     /**
      * @return whether or not breached password detection is active.
@@ -84,5 +86,19 @@ public class BreachedPassword {
         this.adminNotificationFrequency = adminNotificationFrequency;
     }
 
+    /**
+     * @return the per-stage configuration options
+     */
+    public BreachedPasswordStage getStage() {
+        return stage;
+    }
+
+   /**
+     * Sets the per-stage configuration options.
+     * @param stage the per-stage configuration options.
+     */
+    public void setStage(BreachedPasswordStage stage) {
+        this.stage = stage;
+    }
 
 }

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPasswordStage.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPasswordStage.java
@@ -1,0 +1,34 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the BreachedPassword stage configuration options
+ *
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BreachedPasswordStage {
+
+    @JsonProperty("pre-user-registration")
+    BreachedPasswordStageEntry preUserRegistrationStage;
+
+    /**
+     * Get the pre-user-registration stage entry.
+     * @return the pre-user-registration stage entry.
+     */
+    public BreachedPasswordStageEntry getPreUserRegistrationStage() {
+        return preUserRegistrationStage;
+    }
+
+    /**
+     * Set the pre-user-registration stage entry.
+     * @param preUserRegistrationStage the pre-user-registration stage entry.
+     */
+    public void setPreUserRegistrationStage(BreachedPasswordStageEntry preUserRegistrationStage) {
+        this.preUserRegistrationStage = preUserRegistrationStage;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPasswordStageEntry.java
+++ b/src/main/java/com/auth0/json/mgmt/attackprotection/BreachedPasswordStageEntry.java
@@ -1,0 +1,36 @@
+package com.auth0.json.mgmt.attackprotection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the per-stage configuration options for BreachedPasswordStage
+ *
+ * @see Stage
+ * @see com.auth0.client.mgmt.AttackProtectionEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BreachedPasswordStageEntry {
+    @JsonProperty("shields")
+    private List<String> shields;
+
+    /**
+     * Get the shields for this Stage entry
+     * @return the shields for this Stage entry
+     */
+    public List<String> getShields() {
+        return shields;
+    }
+
+    /**
+     * Sets the shields for this Stage entry
+     * @param shields the shields for this Stage entry
+     */
+    public void setShields(List<String> shields) {
+        this.shields = shields;
+    }
+}

--- a/src/test/java/com/auth0/client/mgmt/AttackProtectionEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/AttackProtectionEntityTest.java
@@ -39,15 +39,22 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(response.getAdminNotificationFrequency(), is(notNullValue()));
         assertThat(response.getAdminNotificationFrequency().size(), is(2));
         assertThat(response.getAdminNotificationFrequency(), contains("immediately", "weekly"));
+        assertThat(response.getStage().getPreUserRegistrationStage().getShields(), contains("admin_notification"));
     }
 
     @Test
     public void shouldUpdateBreachedPasswordSettings() throws Exception {
+        BreachedPasswordStage stage = new BreachedPasswordStage();
+        BreachedPasswordStageEntry preReg = new BreachedPasswordStageEntry();
+        preReg.setShields(Arrays.asList("admin_notification"));
+        stage.setPreUserRegistrationStage(preReg);
+
         BreachedPassword breachedPassword = new BreachedPassword();
         breachedPassword.setEnabled(true);
         breachedPassword.setMethod("standard");
         breachedPassword.setAdminNotificationFrequency(Arrays.asList("immediately", "daily"));
         breachedPassword.setShields(Arrays.asList("admin_notification", "block"));
+        breachedPassword.setStage(stage);
 
         Request<BreachedPassword> request = api.attackProtection().updateBreachedPasswordSettings(breachedPassword);
         assertThat(request, is(notNullValue()));
@@ -63,11 +70,12 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         Map<String, Object> body = bodyFromRequest(recordedRequest);
         System.out.println(body);
 
-        assertThat(body.size(), is(4));
+        assertThat(body.size(), is(5));
         assertThat(body.get("method"), is("standard"));
         assertThat(body.get("enabled"), is(true));
         assertThat(((List<?>)body.get("shields")).size(), is(2));
         assertThat((List<?>) body.get("shields"), contains("admin_notification", "block"));
+        assertThat(body.get("stage"), is(notNullValue()));
 
         assertThat(response, is(notNullValue()));
     }

--- a/src/test/resources/mgmt/breached_password_settings.json
+++ b/src/test/resources/mgmt/breached_password_settings.json
@@ -8,5 +8,12 @@
     "immediately",
     "weekly"
   ],
-  "method": "standard"
+  "method": "standard",
+  "stage": {
+    "pre-user-registration": {
+      "shields": [
+        "admin_notification"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
### Changes
Adds support for the stages property on Breached Password Detection configuration. Similar to Suspicious IP Throttling this is used to configured the shields applied at different stages. Currently only pre-user-registration is supported

### References

See linked tickets on SDK-3640

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
