### PR TITLE
[SDK-2558] Add support for tenant session cookie

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/tenants/SessionCookie.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/SessionCookie.java
@@ -23,8 +23,4 @@ public class SessionCookie {
     public String getMode() {
         return mode;
     }
-
-    public void setMode(String mode) {
-        this.mode = mode;
-    }
 }

--- a/src/main/java/com/auth0/json/mgmt/tenants/SessionCookie.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/SessionCookie.java
@@ -1,0 +1,30 @@
+package com.auth0.json.mgmt.tenants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the value of the {@code session_cookie} field of the {@link Tenant}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SessionCookie {
+
+    @JsonProperty("mode")
+    private String mode;
+
+    @JsonCreator
+    public SessionCookie(@JsonProperty("mode") String mode) {
+        this.mode = mode;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
@@ -40,6 +40,9 @@ public class Tenant {
     @JsonProperty("session_lifetime")
     private Integer sessionLifetime;
 
+    @JsonProperty("session_cookie")
+    private SessionCookie sessionCookie;
+
     @JsonProperty("idle_session_lifetime")
     private Integer idleSessionLifetime;
 
@@ -271,6 +274,21 @@ public class Tenant {
     @JsonProperty("session_lifetime")
     public Integer getSessionLifetime() {
         return sessionLifetime;
+    }
+
+    /**
+     * @return the value of the session cookie.
+     */
+    public SessionCookie getSessionCookie() {
+        return sessionCookie;
+    }
+
+    /**
+     * Sets the value of the session cookie.
+     * @param sessionCookie the value of the session cookie to set.
+     */
+    public void setSessionCookie(SessionCookie sessionCookie) {
+        this.sessionCookie = sessionCookie;
     }
 
     /**

--- a/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
@@ -12,7 +12,8 @@ import static org.hamcrest.Matchers.*;
 
 public class TenantTest extends JsonTest<Tenant> {
 
-    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5}";
+    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}}";
+
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -30,6 +31,7 @@ public class TenantTest extends JsonTest<Tenant> {
         tenant.setAllowedLogoutUrls(Collections.singletonList("https://domain.auth0.com/logout"));
         tenant.setSessionLifetime(48);
         tenant.setIdleSessionLifetime(0);
+        tenant.setSessionCookie(new SessionCookie("persistent"));
 
         String serialized = toJSON(tenant);
         assertThat(serialized, is(notNullValue()));
@@ -47,6 +49,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(serialized, JsonMatcher.hasEntry("allowed_logout_urls", Arrays.asList("https://domain.auth0.com/logout")));
         assertThat(serialized, JsonMatcher.hasEntry("session_lifetime", 48));
         assertThat(serialized, JsonMatcher.hasEntry("idle_session_lifetime", 0));
+        assertThat(serialized, JsonMatcher.hasEntry("session_cookie", notNullValue()));
     }
 
     @Test
@@ -67,6 +70,8 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(tenant.getAllowedLogoutUrls(), contains("https://domain.auth0.com/logout"));
         assertThat(tenant.getSessionLifetime(), is(24));
         assertThat(tenant.getIdleSessionLifetime(), is(0));
+        assertThat(tenant.getSessionCookie(), is(notNullValue()));
+        assertThat(tenant.getSessionCookie().getMode(), is("persistent"));
     }
 
 }

--- a/src/test/resources/mgmt/tenant.json
+++ b/src/test/resources/mgmt/tenant.json
@@ -29,5 +29,8 @@
   "support_url": "https://mycompany.org/support",
   "allowed_logout_urls": [
     "https://mycompany.org/logoutCallback"
-  ]
+  ],
+  "session_cookie": {
+    "mode": "persistent"
+  }
 }


### PR DESCRIPTION
Adds support for the `session_cookie` field on a `Tenant`.

See https://auth0.com/docs/api/management/v2#!/Tenants/tenant_settings_route and https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings