### PR TITLE
Fix ship build.gradle version replacement expression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ship: auth0/ship@0.7.2
+  ship: auth0/ship@0.7.3
   codecov: codecov/codecov@3
   
 commands:

--- a/.shiprc
+++ b/.shiprc
@@ -1,7 +1,7 @@
 {
   "files": {
     "README.md": [],
-    "build.gradle": ["version[[:blank:]]*=[[:blank:]]*{MAJOR}.{MINOR}.{PATCH}"]
+    "build.gradle": ['version = "{MAJOR}.{MINOR}.{PATCH}"']
   },
   "prefixVersion": false
 }


### PR DESCRIPTION
Fixes the `.shiprc` build.gradle version replacement expression and update ship-orb (see https://github.com/auth0/ship-orb/pull/17)