### PR TITLE
escape strings in version sub pattern

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,7 +1,7 @@
 {
   "files": {
     "README.md": [],
-    "build.gradle": ['version = "{MAJOR}.{MINOR}.{PATCH}"']
+    "build.gradle": ["version = \"{MAJOR}.{MINOR}.{PATCH}\""]
   },
   "prefixVersion": false
 }


### PR DESCRIPTION
When trying to perform a release with `@a0/ship`, was getting an error regarding invalid JSON. I suspect this is coming from the `files` definition in `.shiprc`. The change in this PR escapes the double quote char. When attempting to run ship with this change, I did not receive a JSON parsing error, just a dirty repo error. That should mean that the JSON is valid now. Once this is merged we can try and perform the release again.