### PR TITLE
Bump `com.fasterxml.jackson.core:jackson-databind` to 2.13.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     implementation "com.auth0:java-jwt:3.19.1"
     implementation "net.jodah:failsafe:2.4.1"
 


### PR DESCRIPTION
Resolves https://www.cve.org/CVERecord?id=CVE-2022-42003