### PR TITLE
Bump `java-jwt` to 3.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
-    implementation "com.auth0:java-jwt:3.19.1"
+    implementation "com.auth0:java-jwt:3.19.3"
     implementation "net.jodah:failsafe:2.4.1"
 
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"


### PR DESCRIPTION
Updates to v3.19.3 of `java-jwt` which includes fix for Resolves https://www.cve.org/CVERecord?id=CVE-2022-42003.