### PR TITLE
[SDK-3741] Return response info

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -270,7 +270,7 @@ public class AuthAPI {
      * {@code
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
-     *      UserInfo result = auth.userInfo("A9CvPwFojaBIA9CvI").execute();
+     *      UserInfo result = auth.userInfo("A9CvPwFojaBIA9CvI").execute().getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -302,7 +302,7 @@ public class AuthAPI {
      * {@code
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
-     *      auth.resetPassword("me@auth0.com", "db-connection").execute();
+     *      auth.resetPassword("me@auth0.com", "db-connection").execute().getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -504,7 +504,8 @@ public class AuthAPI {
      * try {
      *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t})
      *          .setScope("openid email nickname")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -543,7 +544,8 @@ public class AuthAPI {
      * try {
      *      TokenHolder result = auth.login("me@auth0.com", "topsecret", "my-realm")
      *          .setAudience("https://myapi.me.auth0.com/users")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -570,7 +572,8 @@ public class AuthAPI {
      * try {
      *      TokenHolder result = auth.login("me@auth0.com", new char[]{'s','e','c','r','e','t'}, "my-realm")
      *          .setAudience("https://myapi.me.auth0.com/users")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -611,7 +614,8 @@ public class AuthAPI {
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
      *      TokenHolder result = auth.exchangePasswordlessOtp("user@domain.com", "email", new char[]{'c','o','d','e'})
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      // Something happened
      * }
@@ -658,7 +662,8 @@ public class AuthAPI {
      * try {
      *      TokenHolder result = auth.requestToken("https://myapi.me.auth0.com/users")
      *          .setRealm("my-realm")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -726,7 +731,8 @@ public class AuthAPI {
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
      *      TokenHolder result = auth.renewAuth("ej2E8zNEzjrcSD2edjaE")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -761,7 +767,8 @@ public class AuthAPI {
      * try {
      *      TokenHolder result = auth.exchangeCode("SnWoFLMzApDskr", "https://me.auth0.com/callback")
      *          .setScope("openid name nickname")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }
@@ -849,7 +856,8 @@ public class AuthAPI {
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
      *      PasswordlessEmailResponse result = auth.startPasswordlessEmailFlow("user@domain.com", PasswordlessEmailType.CODE)
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      // Something happened
      * }
@@ -893,7 +901,8 @@ public class AuthAPI {
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
      *      PasswordlessSmsResponse result = auth.startPasswordlessSmsFlow("+16511234567")
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      // Something happened
      * }
@@ -934,7 +943,8 @@ public class AuthAPI {
      * AuthAPI auth = new AuthAPI("me.auth0.com", "B3c6RYhk1v9SbIJcRIOwu62gIUGsnze", "2679NfkaBn62e6w5E8zNEzjr-yWfkaBne");
      * try {
      *      TokenHolder result = auth.exchangeMfaOtp("the-mfa-token", new char[]{'a','n','o','t','p'})
-     *          .execute();
+     *          .execute()
+     *          .getBody();
      * } catch (Auth0Exception e) {
      *      //Something happened
      * }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -118,7 +118,7 @@ public class AuthAPI {
                     private static final String PROXY_AUTHORIZATION_HEADER = "Proxy-Authorization";
 
                     @Override
-                    public okhttp3.Request authenticate(Route route, Response response) throws IOException {
+                    public okhttp3.Request authenticate(Route route, okhttp3.Response response) throws IOException {
                         if (response.request().header(PROXY_AUTHORIZATION_HEADER) != null) {
                             return null;
                         }

--- a/src/main/java/com/auth0/net/ExtendedBaseRequest.java
+++ b/src/main/java/com/auth0/net/ExtendedBaseRequest.java
@@ -61,7 +61,7 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
     }
 
     @Override
-    protected T parseResponse(Response response) throws Auth0Exception {
+    protected T parseResponseBody(okhttp3.Response response) throws Auth0Exception {
         if (!response.isSuccessful()) {
             throw createResponseException(response);
         }
@@ -118,7 +118,7 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
      * @param response the unsuccessful response, as received. If its body is accessed, the buffer must be closed.
      * @return the exception with the error details.
      */
-    protected Auth0Exception createResponseException(Response response) {
+    protected Auth0Exception createResponseException(okhttp3.Response response) {
         if (response.code() == STATUS_CODE_TOO_MANY_REQUEST) {
             return createRateLimitException(response);
         }
@@ -134,7 +134,7 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
         }
     }
 
-    private RateLimitException createRateLimitException(Response response) {
+    private RateLimitException createRateLimitException(okhttp3.Response response) {
         // -1 as default value if the header could not be found.
         long limit = Long.parseLong(response.header("X-RateLimit-Limit", "-1"));
         long remaining = Long.parseLong(response.header("X-RateLimit-Remaining", "-1"));

--- a/src/main/java/com/auth0/net/Request.java
+++ b/src/main/java/com/auth0/net/Request.java
@@ -15,7 +15,7 @@ public interface Request<T> {
     /**
      * Executes this request synchronously.
      *
-     * @return the response body JSON decoded as T
+     * @return a {@link Response} containing information about the response.
      * @throws APIException   if the request was executed but the response wasn't successful.
      * @throws Auth0Exception if the request couldn't be created or executed successfully.
      */

--- a/src/main/java/com/auth0/net/Request.java
+++ b/src/main/java/com/auth0/net/Request.java
@@ -19,7 +19,7 @@ public interface Request<T> {
      * @throws APIException   if the request was executed but the response wasn't successful.
      * @throws Auth0Exception if the request couldn't be created or executed successfully.
      */
-    T execute() throws Auth0Exception;
+    Response<T> execute() throws Auth0Exception;
 
     /**
      * Executes this request asynchronously.
@@ -33,7 +33,7 @@ public interface Request<T> {
      *
      * @return a {@linkplain CompletableFuture} representing the specified request.
      */
-    default CompletableFuture<T> executeAsync() {
+    default CompletableFuture<Response<T>> executeAsync() {
         throw new UnsupportedOperationException("executeAsync");
     }
 }

--- a/src/main/java/com/auth0/net/Response.java
+++ b/src/main/java/com/auth0/net/Response.java
@@ -1,0 +1,26 @@
+package com.auth0.net;
+
+import java.util.Map;
+
+/**
+ * Represents the response of an HTTP request executed by {@link Request}.
+ *
+ * @param <T> the type of the parsed response body.
+ */
+public interface Response<T> {
+
+    /**
+     * @return the HTTP response headers.
+     */
+    Map<String, String> getHeaders();
+
+    /**
+     * @return the response body.
+     */
+    T getBody();
+
+    /**
+     * @return the HTTP status code.
+     */
+    int getStatusCode();
+}

--- a/src/main/java/com/auth0/net/ResponseImpl.java
+++ b/src/main/java/com/auth0/net/ResponseImpl.java
@@ -1,0 +1,32 @@
+package com.auth0.net;
+
+import java.util.Collections;
+import java.util.Map;
+
+class ResponseImpl<T> implements Response<T> {
+
+    private final Map<String, String> headers;
+    private final T body;
+    private final int statusCode;
+
+    ResponseImpl(Map<String, String> headers, T body, int statusCode) {
+        this.headers = Collections.unmodifiableMap(headers);
+        this.body = body;
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public T getBody() {
+        return body;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/com/auth0/net/VoidRequest.java
+++ b/src/main/java/com/auth0/net/VoidRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 
+import java.util.Collections;
 import java.util.HashMap;
 
 /**
@@ -24,7 +25,7 @@ public class VoidRequest extends CustomRequest<Void> {
     }
 
     @Override
-    protected Void parseResponse(Response response) throws Auth0Exception {
+    protected Void parseResponseBody(Response response) throws Auth0Exception {
         if (!response.isSuccessful()) {
             throw super.createResponseException(response);
         }

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1423,7 +1423,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -565,7 +565,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_USER_INFO, 200);
-        UserInfo response = request.execute();
+        UserInfo response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/userinfo"));
@@ -616,7 +616,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_RESET_PASSWORD, 200);
-        Void response = request.execute();
+        Void response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/change_password"));
@@ -735,7 +735,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_SIGN_UP_USERNAME, 200);
-        CreatedUser response = request.execute();
+        CreatedUser response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -763,7 +763,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        CreatedUser response = request.execute();
+        CreatedUser response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -794,7 +794,7 @@ public class AuthAPITest {
         request.setCustomFields(customFields);
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        CreatedUser response = request.execute();
+        CreatedUser response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/dbconnections/signup"));
@@ -841,7 +841,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -871,7 +871,7 @@ public class AuthAPITest {
         request.setScope("profile photos contacts");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -928,7 +928,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -959,7 +959,7 @@ public class AuthAPITest {
         request.setAudience("https://myapi.auth0.com/users");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -989,7 +989,7 @@ public class AuthAPITest {
         request.addHeader("some-header", "some-value");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -1051,7 +1051,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -1083,7 +1083,7 @@ public class AuthAPITest {
         request.setScope("profile photos contacts");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -1123,7 +1123,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -1152,7 +1152,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(PASSWORDLESS_EMAIL_RESPONSE, 200);
-        PasswordlessEmailResponse response = request.execute();
+        PasswordlessEmailResponse response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/passwordless/start"));
@@ -1199,7 +1199,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(PASSWORDLESS_EMAIL_RESPONSE, 200);
-        PasswordlessEmailResponse response = request.execute();
+        PasswordlessEmailResponse response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/passwordless/start"));
@@ -1227,7 +1227,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(PASSWORDLESS_SMS_RESPONSE, 200);
-        PasswordlessSmsResponse response = request.execute();
+        PasswordlessSmsResponse response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/passwordless/start"));
@@ -1256,7 +1256,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(PASSWORDLESS_SMS_RESPONSE, 200);
-        PasswordlessSmsResponse response = request.execute();
+        PasswordlessSmsResponse response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/passwordless/start"));
@@ -1288,7 +1288,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -1324,7 +1324,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        Void response = request.execute();
+        Void response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/revoke"));
@@ -1354,7 +1354,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));
@@ -1396,7 +1396,7 @@ public class AuthAPITest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/token"));

--- a/src/test/java/com/auth0/client/mgmt/ActionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ActionsEntityTest.java
@@ -5,6 +5,7 @@ import com.auth0.client.mgmt.filter.ActionsFilter;
 import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.json.mgmt.actions.*;
 import com.auth0.net.Request;
+import com.auth0.net.Response;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION, 200);
-        Action response = request.execute();
+        Action response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/actions/action-id"));
@@ -71,7 +72,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION, 200);
-        Action response = request.execute();
+        Response<Action> response = request.execute();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/actions/actions"));
@@ -107,6 +108,8 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(secretsOnRequest.get(0), hasEntry("value", secret.getValue()));
 
         assertThat(response, is(notNullValue()));
+        assertThat(response.getBody(), is(instanceOf(Action.class)));
+        assertThat(response.getStatusCode(), is(200));
     }
 
     @Test
@@ -122,7 +125,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/actions/actions/action-id"));
@@ -137,7 +140,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/actions/actions/action-id"));
@@ -152,7 +155,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_TRIGGERS, 200);
-        Triggers triggers = request.execute();
+        Triggers triggers = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/triggers"));
@@ -193,7 +196,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION, 200);
-        Action response = request.execute();
+        Action response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/actions/actions/action-id"));
@@ -236,7 +239,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_VERSION, 200);
-        Version response = request.execute();
+        Version response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/actions/actions/action-id/deploy"));
@@ -268,7 +271,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_VERSION, 200);
-        Version response = request.execute();
+        Version response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/actions/action-id/versions/version-id"));
@@ -298,7 +301,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_VERSION, 200);
-        Version response = request.execute();
+        Version response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/actions/actions/action-id/versions/version-id/deploy"));
@@ -323,7 +326,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_EXECUTION, 200);
-        Execution response = request.execute();
+        Execution response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/executions/execution-id"));
@@ -339,7 +342,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTIONS_LIST, 200);
-        ActionsPage response = request.execute();
+        ActionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/actions"));
@@ -362,7 +365,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTIONS_LIST, 200);
-        ActionsPage response = request.execute();
+        ActionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/actions"));
@@ -391,7 +394,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_VERSIONS_LIST, 200);
-        VersionsPage response = request.execute();
+        VersionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/actions/action-id/versions"));
@@ -410,7 +413,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_VERSIONS_LIST, 200);
-        VersionsPage response = request.execute();
+        VersionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/actions/action-id/versions"));
@@ -435,7 +438,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_TRIGGER_BINDINGS, 200);
-        BindingsPage response = request.execute();
+        BindingsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/triggers/trigger-id/bindings"));
@@ -454,7 +457,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_TRIGGER_BINDINGS, 200);
-        BindingsPage response = request.execute();
+        BindingsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/actions/triggers/trigger-id/bindings"));
@@ -495,7 +498,7 @@ public class ActionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ACTION_TRIGGER_BINDINGS, 200);
-        BindingsPage response = request.execute();
+        BindingsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/actions/triggers/trigger-id/bindings"));

--- a/src/test/java/com/auth0/client/mgmt/AttackProtectionEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/AttackProtectionEntityTest.java
@@ -23,7 +23,7 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(BREACHED_PASSWORD_SETTINGS, 200);
-        BreachedPassword response = request.execute();
+        BreachedPassword response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/attack-protection/breached-password-detection"));
@@ -60,7 +60,7 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(BREACHED_PASSWORD_SETTINGS, 200);
-        BreachedPassword response = request.execute();
+        BreachedPassword response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/attack-protection/breached-password-detection"));
@@ -86,7 +86,7 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(BRUTE_FORCE_CONFIGURATION, 200);
-        BruteForceConfiguration response = request.execute();
+        BruteForceConfiguration response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/attack-protection/brute-force-protection"));
@@ -123,7 +123,7 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(BRUTE_FORCE_CONFIGURATION, 200);
-        BruteForceConfiguration response = request.execute();
+        BruteForceConfiguration response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/attack-protection/brute-force-protection"));
@@ -148,7 +148,7 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(SUSPICIOUS_IP_THROTTLING_CONFIGURATION, 200);
-        SuspiciousIPThrottlingConfiguration response = request.execute();
+        SuspiciousIPThrottlingConfiguration response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/attack-protection/suspicious-ip-throttling"));
@@ -198,7 +198,7 @@ public class AttackProtectionEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(BRUTE_FORCE_CONFIGURATION, 200);
-        SuspiciousIPThrottlingConfiguration response = request.execute();
+        SuspiciousIPThrottlingConfiguration response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/attack-protection/suspicious-ip-throttling"));

--- a/src/test/java/com/auth0/client/mgmt/BlacklistsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/BlacklistsEntityTest.java
@@ -28,7 +28,7 @@ public class BlacklistsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_BLACKLISTED_TOKENS_LIST, 200);
-        List<Token> response = request.execute();
+        List<Token> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/blacklists/tokens"));
@@ -46,7 +46,7 @@ public class BlacklistsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Token> response = request.execute();
+        List<Token> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Token.class)));
@@ -65,7 +65,7 @@ public class BlacklistsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_BLACKLISTED_TOKENS_LIST, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/blacklists/tokens"));

--- a/src/test/java/com/auth0/client/mgmt/BrandingEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/BrandingEntityTest.java
@@ -20,7 +20,7 @@ public class BrandingEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_BRANDING_SETTINGS, 200);
-        BrandingSettings response = request.execute();
+        BrandingSettings response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/branding"));
@@ -43,7 +43,7 @@ public class BrandingEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_BRANDING_SETTINGS, 200);
-        BrandingSettings response = request.execute();
+        BrandingSettings response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/branding"));
@@ -59,7 +59,7 @@ public class BrandingEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_BRANDING_LOGIN_TEMPLATE, 200);
-        UniversalLoginTemplate response = request.execute();
+        UniversalLoginTemplate response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/branding/templates/universal-login"));
@@ -75,7 +75,7 @@ public class BrandingEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/branding/templates/universal-login"));
@@ -96,7 +96,7 @@ public class BrandingEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/branding/templates/universal-login"));

--- a/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
@@ -24,7 +24,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
-        ClientGrantsPage response = request.execute();
+        ClientGrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
@@ -42,7 +42,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
-        ClientGrantsPage response = request.execute();
+        ClientGrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
@@ -62,7 +62,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANTS_PAGED_LIST, 200);
-        ClientGrantsPage response = request.execute();
+        ClientGrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
@@ -87,7 +87,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
-        ClientGrantsPage response = request.execute();
+        ClientGrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
@@ -108,7 +108,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
-        List<ClientGrant> response = request.execute();
+        List<ClientGrant> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/client-grants"));
@@ -126,7 +126,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<ClientGrant> response = request.execute();
+        List<ClientGrant> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(ClientGrant.class)));
@@ -159,7 +159,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANT, 200);
-        ClientGrant response = request.execute();
+        ClientGrant response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/client-grants"));
@@ -189,7 +189,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANT, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/client-grants/1"));
@@ -217,7 +217,7 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT_GRANT, 200);
-        ClientGrant response = request.execute();
+        ClientGrant response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/client-grants/1"));

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -24,7 +24,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENTS_LIST, 200);
-        ClientsPage response = request.execute();
+        ClientsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
@@ -42,7 +42,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENTS_LIST, 200);
-        ClientsPage response = request.execute();
+        ClientsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
@@ -62,7 +62,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENTS_PAGED_LIST, 200);
-        ClientsPage response = request.execute();
+        ClientsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
@@ -85,7 +85,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENTS_PAGED_LIST, 200);
-        ClientsPage response = request.execute();
+        ClientsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
@@ -108,7 +108,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENTS_LIST, 200);
-        ClientsPage response = request.execute();
+        ClientsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
@@ -129,7 +129,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENTS_LIST, 200);
-        List<Client> response = request.execute();
+        List<Client> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients"));
@@ -147,7 +147,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Client> response = request.execute();
+        List<Client> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Client.class)));
@@ -166,7 +166,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        Client response = request.execute();
+        Client response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients/1"));
@@ -185,7 +185,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        Client response = request.execute();
+        Client response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients/1"));
@@ -203,7 +203,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        Client response = request.execute();
+        Client response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/clients/1"));
@@ -226,7 +226,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        Client response = request.execute();
+        Client response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/clients"));
@@ -253,7 +253,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/clients/1"));
@@ -281,7 +281,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        Client response = request.execute();
+        Client response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/clients/1"));
@@ -308,7 +308,7 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CLIENT, 200);
-        Client response = request.execute();
+        Client response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/clients/1/rotate-secret"));

--- a/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
@@ -24,7 +24,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute();
+        List<Connection> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -44,7 +44,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute();
+        List<Connection> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -65,7 +65,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute();
+        List<Connection> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -86,7 +86,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute();
+        List<Connection> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -105,7 +105,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        ConnectionsPage response = request.execute();
+        ConnectionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -125,7 +125,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute();
+        List<Connection> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -144,7 +144,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        ConnectionsPage response = request.execute();
+        ConnectionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -164,7 +164,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTIONS_PAGED_LIST, 200);
-        ConnectionsPage response = request.execute();
+        ConnectionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections"));
@@ -188,7 +188,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Connection> response = request.execute();
+        List<Connection> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Connection.class)));
@@ -207,7 +207,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        Connection response = request.execute();
+        Connection response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections/1"));
@@ -224,7 +224,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        Connection response = request.execute();
+        Connection response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/connections/1"));
@@ -249,7 +249,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        Connection response = request.execute();
+        Connection response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/connections"));
@@ -277,7 +277,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/connections/1"));
@@ -305,7 +305,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        Connection response = request.execute();
+        Connection response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/connections/1"));
@@ -340,7 +340,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/connections/1/users"));

--- a/src/test/java/com/auth0/client/mgmt/DeviceCredentialsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/DeviceCredentialsEntityTest.java
@@ -21,7 +21,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS_LIST, 200);
-        List<DeviceCredentials> response = request.execute();
+        List<DeviceCredentials> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/device-credentials"));
@@ -39,7 +39,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS_LIST, 200);
-        List<DeviceCredentials> response = request.execute();
+        List<DeviceCredentials> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/device-credentials"));
@@ -58,7 +58,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS_LIST, 200);
-        List<DeviceCredentials> response = request.execute();
+        List<DeviceCredentials> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/device-credentials"));
@@ -78,7 +78,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS_LIST, 200);
-        List<DeviceCredentials> response = request.execute();
+        List<DeviceCredentials> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/device-credentials"));
@@ -98,7 +98,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS_LIST, 200);
-        List<DeviceCredentials> response = request.execute();
+        List<DeviceCredentials> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/device-credentials"));
@@ -117,7 +117,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<DeviceCredentials> response = request.execute();
+        List<DeviceCredentials> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(DeviceCredentials.class)));
@@ -136,7 +136,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS, 200);
-        DeviceCredentials response = request.execute();
+        DeviceCredentials response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/device-credentials"));
@@ -167,7 +167,7 @@ public class DeviceCredentialsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DEVICE_CREDENTIALS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/device-credentials/1"));

--- a/src/test/java/com/auth0/client/mgmt/EmailProviderEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailProviderEntityTest.java
@@ -21,7 +21,7 @@ public class EmailProviderEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        EmailProvider response = request.execute();
+        EmailProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/emails/provider"));
@@ -38,7 +38,7 @@ public class EmailProviderEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        EmailProvider response = request.execute();
+        EmailProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/emails/provider"));
@@ -63,7 +63,7 @@ public class EmailProviderEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        EmailProvider response = request.execute();
+        EmailProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/emails/provider"));
@@ -83,7 +83,7 @@ public class EmailProviderEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/emails/provider"));
@@ -104,7 +104,7 @@ public class EmailProviderEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        EmailProvider response = request.execute();
+        EmailProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/emails/provider"));

--- a/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EmailTemplatesEntityTest.java
@@ -21,7 +21,7 @@ public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_TEMPLATE, 200);
-        EmailTemplate response = request.execute();
+        EmailTemplate response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/email-templates/welcome_email"));
@@ -52,7 +52,7 @@ public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        EmailTemplate response = request.execute();
+        EmailTemplate response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/email-templates"));
@@ -91,7 +91,7 @@ public class EmailTemplatesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        EmailTemplate response = request.execute();
+        EmailTemplate response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/email-templates/welcome_email"));

--- a/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
@@ -22,7 +22,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GRANTS_LIST, 200);
-        GrantsPage response = request.execute();
+        GrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
@@ -48,7 +48,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GRANTS_LIST, 200);
-        GrantsPage response = request.execute();
+        GrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
@@ -69,7 +69,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GRANTS_PAGED_LIST, 200);
-        GrantsPage response = request.execute();
+        GrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
@@ -95,7 +95,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GRANTS_LIST, 200);
-        GrantsPage response = request.execute();
+        GrantsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
@@ -117,7 +117,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GRANTS_LIST, 200);
-        List<Grant> response = request.execute();
+        List<Grant> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/grants"));
@@ -152,7 +152,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Grant> response = request.execute();
+        List<Grant> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Grant.class)));
@@ -171,7 +171,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/grants/1"));
@@ -192,7 +192,7 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/grants"));

--- a/src/test/java/com/auth0/client/mgmt/GuardianEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GuardianEntityTest.java
@@ -31,7 +31,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_ENROLLMENT, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/guardian/enrollments/1"));
@@ -52,7 +52,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_ENROLLMENT_TICKET, 200);
-        EnrollmentTicket response = request.execute();
+        EnrollmentTicket response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/guardian/enrollments/ticket"));
@@ -72,7 +72,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TEMPLATES, 200);
-        GuardianTemplates response = request.execute();
+        GuardianTemplates response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/guardian/factors/sms/templates"));
@@ -95,7 +95,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TEMPLATES, 200);
-        GuardianTemplates response = request.execute();
+        GuardianTemplates response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/sms/templates"));
@@ -111,7 +111,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_FACTORS_LIST, 200);
-        List<Factor> response = request.execute();
+        List<Factor> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/guardian/factors"));
@@ -128,7 +128,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Factor> response = request.execute();
+        List<Factor> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Factor.class)));
@@ -154,7 +154,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_FACTOR, 200);
-        Factor response = request.execute();
+        Factor response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/my-factor"));
@@ -174,7 +174,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TWILIO_FACTOR_PROVIDER_WITH_MSSID, 200);
-        TwilioFactorProvider response = request.execute();
+        TwilioFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/guardian/factors/sms/providers/twilio"));
@@ -190,7 +190,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TWILIO_FACTOR_PROVIDER_WITH_FROM, 200);
-        TwilioFactorProvider response = request.execute();
+        TwilioFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/guardian/factors/sms/providers/twilio"));
@@ -214,7 +214,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TWILIO_FACTOR_PROVIDER_WITH_FROM, 200);
-        TwilioFactorProvider response = request.execute();
+        TwilioFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/sms/providers/twilio"));
@@ -241,7 +241,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TWILIO_FACTOR_PROVIDER_WITH_MSSID, 200);
-        TwilioFactorProvider response = request.execute();
+        TwilioFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/sms/providers/twilio"));
@@ -267,7 +267,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_TWILIO_FACTOR_PROVIDER_EMPTY, 200);
-        TwilioFactorProvider response = request.execute();
+        TwilioFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/sms/providers/twilio"));
@@ -290,7 +290,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_SNS_FACTOR_PROVIDER, 200);
-        SNSFactorProvider response = request.execute();
+        SNSFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/guardian/factors/push-notification/providers/sns"));
@@ -314,7 +314,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_SNS_FACTOR_PROVIDER, 200);
-        SNSFactorProvider response = request.execute();
+        SNSFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/push-notification/providers/sns"));
@@ -338,7 +338,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_SNS_FACTOR_PROVIDER_EMPTY, 200);
-        SNSFactorProvider response = request.execute();
+        SNSFactorProvider response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/factors/push-notification/providers/sns"));
@@ -362,7 +362,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_AUTHENTICATION_POLICIES_LIST, 200);
-        List<String> response = request.execute();
+        List<String> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/guardian/policies"));
@@ -386,7 +386,7 @@ public class GuardianEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_AUTHENTICATION_POLICIES_LIST, 200);
-        List<String> response = request.execute();
+        List<String> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/guardian/policies"));

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -46,7 +46,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/jobs/1"));
@@ -69,7 +69,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_ERROR_DETAILS, 200);
-        List<JobErrorDetails> response = request.execute();
+        List<JobErrorDetails> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/jobs/1/errors"));
@@ -87,7 +87,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.noContentResponse();
-        List<JobErrorDetails> response = request.execute();
+        List<JobErrorDetails> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/jobs/1/errors"));
@@ -116,7 +116,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
@@ -138,7 +138,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
@@ -161,7 +161,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
@@ -187,7 +187,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-exports"));
@@ -214,7 +214,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_VERIFICATION_EMAIL, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/verification-email"));
@@ -234,7 +234,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_VERIFICATION_EMAIL, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/verification-email"));
@@ -256,7 +256,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_VERIFICATION_EMAIL, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/verification-email"));
@@ -282,7 +282,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_VERIFICATION_EMAIL, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/verification-email"));
@@ -351,7 +351,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_USERS_IMPORTS, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-imports"));
@@ -392,7 +392,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_JOB_POST_USERS_IMPORTS, 200);
-        Job response = request.execute();
+        Job response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/jobs/users-imports"));

--- a/src/test/java/com/auth0/client/mgmt/KeysEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/KeysEntityTest.java
@@ -34,7 +34,7 @@ public class KeysEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(KEY_LIST, 200);
-        List<Key> response = request.execute();
+        List<Key> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/keys/signing"));
@@ -51,7 +51,7 @@ public class KeysEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(KEY, 200);
-        Key response = request.execute();
+        Key response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/keys/signing/123"));
@@ -67,7 +67,7 @@ public class KeysEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(KEY_ROTATE, 200);
-        Key response = request.execute();
+        Key response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/keys/signing/rotate"));
@@ -83,7 +83,7 @@ public class KeysEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(KEY_REVOKE, 200);
-        Key response = request.execute();
+        Key response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/keys/signing/123/revoke"));

--- a/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogEventsEntityTest.java
@@ -20,7 +20,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -38,7 +38,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -58,7 +58,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_PAGED_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -81,7 +81,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -100,7 +100,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -119,7 +119,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -139,7 +139,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs"));
@@ -158,7 +158,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), is(emptyCollectionOf(LogEvent.class)));
@@ -177,7 +177,7 @@ public class LogEventsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENT, 200);
-        LogEvent response = request.execute();
+        LogEvent response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/logs/1"));

--- a/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/LogStreamsEntityTest.java
@@ -24,7 +24,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.MGMT_LOG_STREAMS_LIST, 200);
-        List<LogStream> response = request.execute();
+        List<LogStream> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/log-streams"));
@@ -46,7 +46,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<LogStream> response = request.execute();
+        List<LogStream> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, empty());
@@ -58,7 +58,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.MGMT_LOG_STREAM, 200);
-        LogStream response = request.execute();
+        LogStream response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/log-streams/123"));
@@ -81,7 +81,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_STREAM, 200);
-        LogStream response = request.execute();
+        LogStream response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/log-streams"));
@@ -112,7 +112,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_STREAM, 200);
-        LogStream response = request.execute();
+        LogStream response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/log-streams/123"));
@@ -139,7 +139,7 @@ public class LogStreamsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/log-streams/1"));

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -27,7 +27,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATIONS_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
@@ -45,7 +45,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATIONS_PAGED_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
@@ -65,7 +65,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATIONS_CHECKPOINT_PAGED_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
@@ -85,7 +85,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATIONS_PAGED_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations"));
@@ -110,7 +110,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION, 200);
-        Organization response = request.execute();
+        Organization response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123"));
@@ -133,7 +133,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION, 200);
-        Organization response = request.execute();
+        Organization response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/name/org-1"));
@@ -178,7 +178,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION, 200);
-        Organization response = request.execute();
+        Organization response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations"));
@@ -231,7 +231,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION, 200);
-        Organization response = request.execute();
+        Organization response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/organizations/org_abc"));
@@ -261,7 +261,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc"));
@@ -284,7 +284,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_LIST, 200);
-        MembersPage response = request.execute();
+        MembersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
@@ -302,7 +302,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_LIST, 200);
-        MembersPage response = request.execute();
+        MembersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
@@ -322,7 +322,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_PAGED_LIST, 200);
-        MembersPage response = request.execute();
+        MembersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
@@ -341,7 +341,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_MEMBERS_CHECKPOINT_PAGED_LIST, 200);
-        MembersPage response = request.execute();
+        MembersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members"));
@@ -376,7 +376,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_abc/members"));
@@ -410,7 +410,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/members"));
@@ -437,7 +437,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION_CONNECTIONS_LIST, 200);
-        EnabledConnectionsPage response = request.execute();
+        EnabledConnectionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/enabled_connections"));
@@ -455,7 +455,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION_CONNECTIONS_LIST, 200);
-        EnabledConnectionsPage response = request.execute();
+        EnabledConnectionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/enabled_connections"));
@@ -475,7 +475,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MockServer.ORGANIZATION_CONNECTIONS_PAGED_LIST, 200);
-        EnabledConnectionsPage response = request.execute();
+        EnabledConnectionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/enabled_connections"));
@@ -507,7 +507,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_CONNECTION, 200);
-        EnabledConnection response = request.execute();
+        EnabledConnection response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/enabled_connections/con_abc"));
@@ -541,7 +541,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_CONNECTION, 201);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_abc/enabled_connections"));
@@ -574,7 +574,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/enabled_connections/con_123"));
@@ -612,7 +612,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_CONNECTION, 201);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/organizations/org_abc/enabled_connections/con_123"));
@@ -646,7 +646,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_MEMBER_ROLES_LIST, 200);
-        RolesPage response = request.execute();
+        RolesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members/user_123/roles"));
@@ -663,7 +663,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_MEMBER_ROLES_LIST, 200);
-        RolesPage response = request.execute();
+        RolesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members/user_123/roles"));
@@ -682,7 +682,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATION_MEMBER_ROLES_PAGED_LIST, 200);
-        RolesPage response = request.execute();
+        RolesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_abc/members/user_123/roles"));
@@ -722,7 +722,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_abc/members/user_123/roles"));
@@ -762,7 +762,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/members/user_123/roles"));
@@ -796,7 +796,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATION, 200);
-        Invitation response = request.execute();
+        Invitation response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations/invitation_id"));
@@ -813,7 +813,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATION, 200);
-        Invitation response = request.execute();
+        Invitation response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations/invitation_id"));
@@ -838,7 +838,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATIONS_LIST, 200);
-        InvitationsPage response = request.execute();
+        InvitationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
@@ -858,7 +858,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATIONS_LIST, 200);
-        InvitationsPage response = request.execute();
+        InvitationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
@@ -879,7 +879,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATIONS_LIST, 200);
-        InvitationsPage response = request.execute();
+        InvitationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
@@ -899,7 +899,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATIONS_PAGED_LIST, 200);
-        InvitationsPage response = request.execute();
+        InvitationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/organizations/org_123/invitations"));
@@ -936,7 +936,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(INVITATION, 201);
-        Invitation response = request.execute();
+        Invitation response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/organizations/org_123/invitations"));
@@ -974,7 +974,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/organizations/org_abc/invitations/inv_123"));

--- a/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
@@ -26,7 +26,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVERS_LIST, 200);
-        ResourceServersPage response = request.execute();
+        ResourceServersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
@@ -44,7 +44,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVERS_LIST, 200);
-        ResourceServersPage response = request.execute();
+        ResourceServersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
@@ -64,7 +64,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVERS_PAGED_LIST, 200);
-        ResourceServersPage response = request.execute();
+        ResourceServersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
@@ -88,7 +88,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
         server.jsonResponse(MGMT_RESOURCE_SERVERS_LIST, 200);
 
-        List<ResourceServer> response = request.execute();
+        List<ResourceServer> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers"));
@@ -118,7 +118,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVER, 200);
-        ResourceServer response = request.execute();
+        ResourceServer response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/resource-servers/23445566abab"));
@@ -139,7 +139,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVER, 200);
-        ResourceServer response = request.execute();
+        ResourceServer response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/resource-servers/23445566abab"));
@@ -156,7 +156,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RESOURCE_SERVER, 200);
-        ResourceServer response = request.execute();
+        ResourceServer response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/resource-servers"));
@@ -177,7 +177,7 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/resource-servers/23445566abab"));

--- a/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RolesEntityTest.java
@@ -29,7 +29,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLES_LIST, 200);
-    RolesPage response = request.execute();
+    RolesPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles"));
@@ -47,7 +47,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLES_LIST, 200);
-    RolesPage response = request.execute();
+    RolesPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles"));
@@ -67,7 +67,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLES_PAGED_LIST, 200);
-    RolesPage response = request.execute();
+    RolesPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles"));
@@ -89,7 +89,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE, 200);
-    Role response = request.execute();
+    Role response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1"));
@@ -121,7 +121,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE, 200);
-    Role response = request.execute();
+    Role response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/roles"));
@@ -157,7 +157,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE, 200);
-    Role response = request.execute();
+    Role response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/roles/1"));
@@ -184,7 +184,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
-    request.execute();
+    request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/roles/1"));
@@ -205,7 +205,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE_USERS_PAGED_LIST, 200);
-    UsersPage response = request.execute();
+    UsersPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/users"));
@@ -223,7 +223,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE_USERS_PAGED_LIST, 200);
-    UsersPage response = request.execute();
+    UsersPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/users"));
@@ -243,7 +243,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE_USERS_PAGED_LIST, 200);
-    UsersPage response = request.execute();
+    UsersPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/users"));
@@ -266,7 +266,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_ROLE_USERS_CHECKPOINT_PAGED_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/users"));
@@ -313,7 +313,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
-    Object response = request.execute();
+    Object response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/roles/1/users"));
@@ -333,7 +333,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE_PERMISSIONS_PAGED_LIST, 200);
-    PermissionsPage response = request.execute();
+    PermissionsPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/permissions"));
@@ -351,7 +351,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE_PERMISSIONS_PAGED_LIST, 200);
-    PermissionsPage response = request.execute();
+    PermissionsPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/permissions"));
@@ -371,7 +371,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.jsonResponse(MGMT_ROLE_PERMISSIONS_PAGED_LIST, 200);
-    PermissionsPage response = request.execute();
+    PermissionsPage response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/roles/1/permissions"));
@@ -418,7 +418,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
-    Object response = request.execute();
+    Object response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/roles/1/permissions"));
@@ -463,7 +463,7 @@ public class RolesEntityTest extends BaseMgmtEntityTest {
     assertThat(request, is(notNullValue()));
 
     server.emptyResponse(200);
-    Object response = request.execute();
+    Object response = request.execute().getBody();
     RecordedRequest recordedRequest = server.takeRequest();
 
     assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/roles/1/permissions"));

--- a/src/test/java/com/auth0/client/mgmt/RulesConfigsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesConfigsEntityTest.java
@@ -22,7 +22,7 @@ public class RulesConfigsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_CONFIGS_LIST, 200);
-        List<RulesConfig> response = request.execute();
+        List<RulesConfig> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules-configs"));
@@ -39,7 +39,7 @@ public class RulesConfigsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<RulesConfig> response = request.execute();
+        List<RulesConfig> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(RulesConfig.class)));
@@ -58,7 +58,7 @@ public class RulesConfigsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/rules-configs/1"));
@@ -86,7 +86,7 @@ public class RulesConfigsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        RulesConfig response = request.execute();
+        RulesConfig response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PUT", "/api/v2/rules-configs/1"));

--- a/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
@@ -24,7 +24,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute();
+        List<Rule> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -41,7 +41,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_LIST, 200);
-        RulesPage response = request.execute();
+        RulesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -61,7 +61,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute();
+        List<Rule> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -82,7 +82,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute();
+        List<Rule> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -104,7 +104,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute();
+        List<Rule> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -123,7 +123,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_LIST, 200);
-        RulesPage response = request.execute();
+        RulesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -143,7 +143,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULES_PAGED_LIST, 200);
-        RulesPage response = request.execute();
+        RulesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules"));
@@ -166,7 +166,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Rule> response = request.execute();
+        List<Rule> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Rule.class)));
@@ -185,7 +185,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);
-        Rule response = request.execute();
+        Rule response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules/1"));
@@ -202,7 +202,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);
-        Rule response = request.execute();
+        Rule response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/rules/1"));
@@ -227,7 +227,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);
-        Rule response = request.execute();
+        Rule response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/rules"));
@@ -255,7 +255,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RULE, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/rules/1"));
@@ -283,7 +283,7 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
-        Rule response = request.execute();
+        Rule response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/rules/1"));

--- a/src/test/java/com/auth0/client/mgmt/StatsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/StatsEntityTest.java
@@ -22,7 +22,7 @@ public class StatsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_ACTIVE_USERS_COUNT, 200);
-        Integer response = request.execute();
+        Integer response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/stats/active-users"));
@@ -60,7 +60,7 @@ public class StatsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_DAILY_STATS_LIST, 200);
-        List<DailyStats> response = request.execute();
+        List<DailyStats> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/stats/daily"));
@@ -78,7 +78,7 @@ public class StatsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<DailyStats> response = request.execute();
+        List<DailyStats> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(DailyStats.class)));

--- a/src/test/java/com/auth0/client/mgmt/TenantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/TenantsEntityTest.java
@@ -20,7 +20,7 @@ public class TenantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_TENANT, 200);
-        Tenant response = request.execute();
+        Tenant response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/tenants/settings"));
@@ -37,7 +37,7 @@ public class TenantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_TENANT, 200);
-        Tenant response = request.execute();
+        Tenant response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/tenants/settings"));
@@ -62,7 +62,7 @@ public class TenantsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_TENANT, 200);
-        Tenant response = request.execute();
+        Tenant response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/tenants/settings"));

--- a/src/test/java/com/auth0/client/mgmt/TicketsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/TicketsEntityTest.java
@@ -33,7 +33,7 @@ public class TicketsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_VERIFICATION_TICKET, 200);
-        EmailVerificationTicket response = request.execute();
+        EmailVerificationTicket response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/tickets/email-verification"));
@@ -62,7 +62,7 @@ public class TicketsEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_PASSWORD_CHANGE_TICKET, 200);
-        PasswordChangeTicket response = request.execute();
+        PasswordChangeTicket response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/tickets/password-change"));

--- a/src/test/java/com/auth0/client/mgmt/UserBlocksEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UserBlocksEntityTest.java
@@ -26,7 +26,7 @@ public class UserBlocksEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_BLOCKS, 200);
-        UserBlocks response = request.execute();
+        UserBlocks response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/user-blocks"));
@@ -50,7 +50,7 @@ public class UserBlocksEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_BLOCKS, 200);
-        UserBlocks response = request.execute();
+        UserBlocks response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/user-blocks/1"));
@@ -73,7 +73,7 @@ public class UserBlocksEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_BLOCKS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/user-blocks"));
@@ -95,7 +95,7 @@ public class UserBlocksEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_BLOCKS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/user-blocks/1"));

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -37,7 +37,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        List<User> response = request.execute();
+        List<User> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users-by-email"));
@@ -56,7 +56,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        List<User> response = request.execute();
+        List<User> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users-by-email"));
@@ -76,7 +76,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<User> response = request.execute();
+        List<User> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(User.class)));
@@ -88,7 +88,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
@@ -106,7 +106,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
@@ -126,7 +126,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_PAGED_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
@@ -149,7 +149,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
@@ -168,7 +168,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
@@ -188,7 +188,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USERS_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users"));
@@ -207,7 +207,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        UsersPage response = request.execute();
+        UsersPage response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), is(emptyCollectionOf(User.class)));
@@ -226,7 +226,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER, 200);
-        User response = request.execute();
+        User response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1"));
@@ -243,7 +243,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER, 200);
-        User response = request.execute();
+        User response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1"));
@@ -268,7 +268,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER, 200);
-        User response = request.execute();
+        User response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users"));
@@ -295,7 +295,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/1"));
@@ -323,7 +323,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER, 200);
-        User response = request.execute();
+        User response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("PATCH", "/api/v2/users/1"));
@@ -351,7 +351,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_GUARDIAN_ENROLLMENTS_LIST, 200);
-        List<Enrollment> response = request.execute();
+        List<Enrollment> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/enrollments"));
@@ -367,7 +367,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Enrollment> response = request.execute();
+        List<Enrollment> response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response, is(emptyCollectionOf(Enrollment.class)));
@@ -386,7 +386,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/logs"));
@@ -403,7 +403,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/logs"));
@@ -422,7 +422,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/logs"));
@@ -442,7 +442,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_PAGED_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/logs"));
@@ -465,7 +465,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/logs"));
@@ -484,7 +484,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_LOG_EVENTS_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/logs"));
@@ -503,7 +503,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        LogEventsPage response = request.execute();
+        LogEventsPage response = request.execute().getBody();
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), is(emptyCollectionOf(LogEvent.class)));
@@ -522,7 +522,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/auth0%7C23/authenticators"));
@@ -550,7 +550,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_EMAIL_PROVIDER, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/1/multifactor/duo"));
@@ -571,7 +571,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_RECOVERY_CODE, 200);
-        RecoveryCode response = request.execute();
+        RecoveryCode response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/recovery-code-regeneration"));
@@ -622,7 +622,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_IDENTITIES_LIST, 200);
-        List<Identity> response = request.execute();
+        List<Identity> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/identities"));
@@ -643,7 +643,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_IDENTITIES_LIST, 200);
-        List<Identity> response = request.execute();
+        List<Identity> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/identities"));
@@ -663,7 +663,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_IDENTITIES_LIST, 200);
-        List<Identity> response = request.execute();
+        List<Identity> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/identities"));
@@ -706,7 +706,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_IDENTITIES_LIST, 200);
-        List<Identity> response = request.execute();
+        List<Identity> response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/1/identities/auth0/2"));
@@ -729,7 +729,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_ROLES_PAGED_LIST, 200);
-        RolesPage response = request.execute();
+        RolesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/roles"));
@@ -747,7 +747,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_ROLES_PAGED_LIST, 200);
-        RolesPage response = request.execute();
+        RolesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/roles"));
@@ -767,7 +767,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_ROLES_PAGED_LIST, 200);
-        RolesPage response = request.execute();
+        RolesPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/roles"));
@@ -810,7 +810,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        Object response = request.execute();
+        Object response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/roles"));
@@ -851,7 +851,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse( 200);
-        Object response = request.execute();
+        Object response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/1/roles"));
@@ -871,7 +871,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_PERMISSIONS_PAGED_LIST, 200);
-        PermissionsPage response = request.execute();
+        PermissionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/permissions"));
@@ -889,7 +889,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_PERMISSIONS_PAGED_LIST, 200);
-        PermissionsPage response = request.execute();
+        PermissionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/permissions"));
@@ -909,7 +909,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_USER_PERMISSIONS_PAGED_LIST, 200);
-        PermissionsPage response = request.execute();
+        PermissionsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/permissions"));
@@ -956,7 +956,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        Object response = request.execute();
+        Object response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("POST", "/api/v2/users/1/permissions"));
@@ -1001,7 +1001,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(200);
-        Object response = request.execute();
+        Object response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("DELETE", "/api/v2/users/1/permissions"));
@@ -1028,7 +1028,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATIONS_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/organizations"));
@@ -1045,7 +1045,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATIONS_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/organizations"));
@@ -1064,7 +1064,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(ORGANIZATIONS_PAGED_LIST, 200);
-        OrganizationsPage response = request.execute();
+        OrganizationsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath("GET", "/api/v2/users/1/organizations"));

--- a/src/test/java/com/auth0/net/CreateUserRequestTest.java
+++ b/src/test/java/com/auth0/net/CreateUserRequestTest.java
@@ -32,7 +32,7 @@ public class CreateUserRequestTest {
         request.addParameter("non_empty", "body");
 
         server.jsonResponse(AUTH_SIGN_UP, 200);
-        CreatedUser execute = request.execute();
+        CreatedUser execute = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(execute, is(notNullValue()));
@@ -48,7 +48,7 @@ public class CreateUserRequestTest {
         request.setCustomFields(customFields);
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         Map<String, Object> values = bodyFromRequest(recordedRequest);

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -62,7 +62,7 @@ public class CustomRequestTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder execute = request.execute();
+        TokenHolder execute = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("GET"));
         assertThat(execute, is(notNullValue()));
@@ -75,7 +75,7 @@ public class CustomRequestTest {
         request.addParameter("non_empty", "body");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder execute = request.execute();
+        TokenHolder execute = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(execute, is(notNullValue()));
@@ -89,7 +89,7 @@ public class CustomRequestTest {
         request.addParameter("map", mapValue);
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         Map<String, Object> values = bodyFromRequest(recordedRequest);
         assertThat(values, hasEntry("key", "value"));
@@ -104,7 +104,7 @@ public class CustomRequestTest {
         request.addHeader("Authorization", "Bearer my_access_token");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest.getHeader("Extra-Info"), is("this is a test"));
@@ -118,7 +118,7 @@ public class CustomRequestTest {
         request.addHeader("Content-Type", "plaintext");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest.getHeader("Content-Type"), is("application/json"));
@@ -135,7 +135,7 @@ public class CustomRequestTest {
         when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
         when(call.execute()).thenThrow(IOException.class);
         CustomRequest<Void> request = new CustomRequest<>(client, server.getBaseUrl(), "GET", voidType);
-        request.execute();
+        request.execute().getBody();
     }
 
     @Test
@@ -148,14 +148,14 @@ public class CustomRequestTest {
         exception.expect(Auth0Exception.class);
         exception.expectCause(Matchers.<Throwable>instanceOf(JsonProcessingException.class));
         exception.expectMessage("Couldn't create the request body.");
-        request.execute();
+        request.execute().getBody();
     }
 
     @Test
     public void shouldParseSuccessfulResponse() throws Exception {
         CustomRequest<TokenHolder> request = new CustomRequest<>(client, server.getBaseUrl(), "GET", tokenHolderType);
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         server.takeRequest();
 
         assertThat(response, is(notNullValue()));
@@ -172,7 +172,7 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -193,7 +193,7 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_ERROR_DESCRIPTION, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -214,7 +214,7 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_ERROR, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -236,7 +236,7 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_DESCRIPTION_AND_EXTRA_PROPERTIES, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -259,7 +259,7 @@ public class CustomRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_DESCRIPTION, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -280,7 +280,7 @@ public class CustomRequestTest {
         server.jsonResponse(MGMT_ERROR_WITH_MESSAGE, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -301,7 +301,7 @@ public class CustomRequestTest {
         server.textResponse(AUTH_ERROR_PLAINTEXT, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -323,7 +323,7 @@ public class CustomRequestTest {
         server.rateLimitReachedResponse(100, 10, 5);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -348,7 +348,7 @@ public class CustomRequestTest {
         server.rateLimitReachedResponse(-1, -1, -1);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;

--- a/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
@@ -44,7 +44,7 @@ public class EmptyBodyRequestTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(recordedRequest.getBodySize(), is(0L));
@@ -58,7 +58,7 @@ public class EmptyBodyRequestTest {
         request.addParameter("map", mapValue);
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(recordedRequest.getBodySize(), is(0L));

--- a/src/test/java/com/auth0/net/MultipartRequestTest.java
+++ b/src/test/java/com/auth0/net/MultipartRequestTest.java
@@ -75,7 +75,7 @@ public class MultipartRequestTest {
         request.addPart("non_empty", "body");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder execute = request.execute();
+        TokenHolder execute = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(execute, is(notNullValue()));
@@ -92,7 +92,7 @@ public class MultipartRequestTest {
         request.addPart("jsonFile", fileValue, "text/json");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         RecordedMultipartRequest recordedMultipartRequest = new RecordedMultipartRequest(recordedRequest);
         assertThat(recordedMultipartRequest.getPartsCount(), is(2));
@@ -118,7 +118,7 @@ public class MultipartRequestTest {
         request.addHeader("Content-Type", "plaintext");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest.getHeader("Content-Type"), is("multipart/form-data; boundary=5c49fdf2"));
@@ -132,7 +132,7 @@ public class MultipartRequestTest {
         request.addHeader("Authorization", "Bearer my_access_token");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest.getHeader("Extra-Info"), is("this is a test"));
@@ -151,7 +151,7 @@ public class MultipartRequestTest {
         when(call.execute()).thenThrow(IOException.class);
         MultipartRequest<Void> request = new MultipartRequest<>(client, server.getBaseUrl(), "POST", voidType);
         request.addPart("non_empty", "body");
-        request.execute();
+        request.execute().getBody();
     }
 
     @Test
@@ -159,7 +159,7 @@ public class MultipartRequestTest {
         Exception exception = null;
         try {
             MultipartRequest<Void> request = new MultipartRequest<>(client, server.getBaseUrl(), "POST", voidType);
-            request.execute();
+            request.execute().getBody();
         } catch (Exception e) {
             exception = e;
         }
@@ -175,7 +175,7 @@ public class MultipartRequestTest {
         MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), "POST", tokenHolderType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         server.takeRequest();
 
         assertThat(response, is(notNullValue()));
@@ -193,7 +193,7 @@ public class MultipartRequestTest {
         server.jsonResponse(AUTH_TOKENS, 200);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -215,7 +215,7 @@ public class MultipartRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_ERROR_DESCRIPTION, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -237,7 +237,7 @@ public class MultipartRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_ERROR, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -259,7 +259,7 @@ public class MultipartRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_DESCRIPTION_AND_EXTRA_PROPERTIES, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -283,7 +283,7 @@ public class MultipartRequestTest {
         server.jsonResponse(AUTH_ERROR_WITH_DESCRIPTION, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -305,7 +305,7 @@ public class MultipartRequestTest {
         server.jsonResponse(MGMT_ERROR_WITH_MESSAGE, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -327,7 +327,7 @@ public class MultipartRequestTest {
         server.textResponse(AUTH_ERROR_PLAINTEXT, 400);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -350,7 +350,7 @@ public class MultipartRequestTest {
         server.rateLimitReachedResponse(100, 10, 5);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;
@@ -376,7 +376,7 @@ public class MultipartRequestTest {
         server.rateLimitReachedResponse(-1, -1, -1);
         Exception exception = null;
         try {
-            request.execute();
+            request.execute().getBody();
             server.takeRequest();
         } catch (Exception e) {
             exception = e;

--- a/src/test/java/com/auth0/net/RequestTest.java
+++ b/src/test/java/com/auth0/net/RequestTest.java
@@ -12,7 +12,7 @@ public class RequestTest {
             UnsupportedOperationException.class,
             new Request<String>() {
                 @Override
-                public String execute() throws Auth0Exception {
+                public Response<String> execute() throws Auth0Exception {
                     return null;
                 }
             }::executeAsync);

--- a/src/test/java/com/auth0/net/TokenRequestTest.java
+++ b/src/test/java/com/auth0/net/TokenRequestTest.java
@@ -38,7 +38,7 @@ public class TokenRequestTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        TokenHolder response = request.execute();
+        TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(response, is(notNullValue()));
@@ -51,7 +51,7 @@ public class TokenRequestTest {
         request.setAudience("https://myapi.auth0.com/users");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         Map<String, Object> values = bodyFromRequest(recordedRequest);
         assertThat(values, hasEntry("audience", "https://myapi.auth0.com/users"));
@@ -64,7 +64,7 @@ public class TokenRequestTest {
         request.setScope("email profile photos");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         Map<String, Object> values = bodyFromRequest(recordedRequest);
         assertThat(values, hasEntry("scope", "email profile photos"));
@@ -77,7 +77,7 @@ public class TokenRequestTest {
         request.setRealm("dbconnection");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        request.execute();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         Map<String, Object> values = bodyFromRequest(recordedRequest);
         assertThat(values, hasEntry("realm", "dbconnection"));

--- a/src/test/java/com/auth0/net/VoidRequestTest.java
+++ b/src/test/java/com/auth0/net/VoidRequestTest.java
@@ -26,7 +26,7 @@ public class VoidRequestTest {
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        Void execute = request.execute();
+        Void execute = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("GET"));
         assertThat(execute, is(nullValue()));
@@ -39,7 +39,7 @@ public class VoidRequestTest {
         request.addParameter("non_empty", "body");
 
         server.jsonResponse(AUTH_TOKENS, 200);
-        Void execute = request.execute();
+        Void execute = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod(), is("POST"));
         assertThat(execute, is(nullValue()));


### PR DESCRIPTION
This change enables callers to inspect HTTP response info such as headers and status code, in addition to the parsed response body.

Prior to this change:
```java
// only parsed response body returned
User user = api.users().getUser("auth0|123").execute();
```

With this change:

```java
// new Response type returned
Response<User> response = api.users().getUser("auth0|123").execute();
Map<String, String> headers = response.getHeaders();
int statusCode = response.getStatusCode();
User user = response.getBody();
```

**Breaking Changes**

Methods that returned a parsed response body `T` from `Request#execute()` or `Request#executeAsync` now return a `Response`. If only the response body is required, clients should replace calls to `request.execute()` with `request.execute().getBody()`. See test changes in this PR for examples.
