### PR TITLE
disable API diff checks for v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,6 @@ workflows:
           requires:
             - build
             
-  api-diff:
-    jobs:
-      - api-diff
+#  api-diff:
+#    jobs:
+#      - api-diff


### PR DESCRIPTION
Disables the API diff checking in v2, as there will be breaking changes in v2.