### PR TITLE
[SDK-3742] support Authorization Code + PKCE

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -792,6 +792,56 @@ public class AuthAPI {
     }
 
     /**
+     * Creates a request to exchange the code obtained from the {@code /authorize} call using the Authorization Code
+     * with PKCE grant.
+     * <pre>
+     * {@code
+     * AuthAPI auth = new AuthAPI("DOMAIN", "CLIENT-ID", "CLIENT-SECRET");
+     *
+     * SecureRandom sr = new SecureRandom();
+     * byte[] code = new byte[32];
+     * sr.nextBytes(code);
+     * String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(code);
+     *
+     * byte[] bytes = verifier.getBytes("US-ASCII");
+     * MessageDigest md = MessageDigest.getInstance("SHA-256");
+     * md.update(bytes, 0, bytes.length);
+     * byte[] digest = md.digest();
+     * String challenge = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+     *
+     * // generate authorize URL with code challenge derived from verifier
+     * String url = auth.authorizeUrl("https://me.auth0.com/callback")
+     *      .withCodeChallenge(challenge)
+     *      .build();
+     *
+     * // on redirect, exchange code and verify challenge
+     * try {
+     *      TokenHolder result = auth.exchangeCodeWithVerifier("CODE", verifier, "https://me.auth0.com/callback")
+     *          .setScope("openid name nickname")
+     *          .execute();
+     * } catch (Auth0Exception e) {
+     *      // Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param code the authorization code received from the {@code /authorize} call.
+     * @param verifier the cryptographically random key that was used to generate the {@code code_challenge} passed to
+     *                 {@code /authorize}
+     * @param redirectUri the redirect uri sent on the /authorize call.
+     * @return a Request to configure and execute.
+     */
+    public TokenRequest exchangeCodeWithVerifier(String code, String verifier, String redirectUri) {
+        Asserts.assertNotNull(code, "code");
+        Asserts.assertNotNull(redirectUri, "redirect uri");
+        Asserts.assertNotNull(verifier, "verifier");
+
+        TokenRequest request = exchangeCode(code, redirectUri);
+        request.addParameter("code_verifier", verifier);
+        return request;
+    }
+
+    /**
      * Create a request to send an email containing a link or a code to begin authentication with Passwordless connections.
      *
      * <pre>

--- a/src/main/java/com/auth0/client/auth/AuthorizeUrlBuilder.java
+++ b/src/main/java/com/auth0/client/auth/AuthorizeUrlBuilder.java
@@ -146,6 +146,22 @@ public class AuthorizeUrlBuilder {
     }
 
     /**
+     * Sets the {@code code_challenge} parameter used when using the Authorization Code Flow with Proof of Code Exchange (PKCE).
+     *
+     * @param challenge the generated challenge from a {@code code_verifier}
+     * @return the builder instance.
+     *
+     * @see <a href="https://auth0.com/docs/api/authentication#authorization-code-flow-with-pkce">Authentication API docuementation</a>
+     * @see <a href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/add-login-using-the-authorization-code-flow-with-pkce">Authorization Code Flow with Proof of Code Exchange (PKCE)</a>
+     */
+    public AuthorizeUrlBuilder withCodeChallenge(String challenge) {
+        assertNotNull(challenge, "challenge");
+        parameters.put("code_challenge", challenge);
+        parameters.put("code_challenge_method", "S256");
+        return this;
+    }
+
+    /**
      * Creates a string representation of the URL with the configured parameters.
      *
      * @return the string URL

--- a/src/test/java/com/auth0/client/auth/AuthorizeUrlBuilderTest.java
+++ b/src/test/java/com/auth0/client/auth/AuthorizeUrlBuilderTest.java
@@ -226,4 +226,22 @@ public class AuthorizeUrlBuilderTest {
             .withInvitation(null)
             .build();
     }
+
+    @Test
+    public void shouldAddCodeChallengeParameter() {
+        String authUrl = AuthorizeUrlBuilder.newInstance(DOMAIN, CLIENT_ID, REDIRECT_URI)
+            .withCodeChallenge("insecure_challenge")
+            .build();
+        assertThat(authUrl, hasQueryParameter("code_challenge", "insecure_challenge"));
+        assertThat(authUrl, hasQueryParameter("code_challenge_method", "S256"));
+    }
+
+    @Test
+    public void shouldThrowWhenChallengeIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'challenge' cannot be null!");
+        AuthorizeUrlBuilder.newInstance(DOMAIN, CLIENT_ID, REDIRECT_URI)
+            .withCodeChallenge(null)
+            .build();
+    }
 }


### PR DESCRIPTION
Adds support for Authorization Code Flow with PKCE.

* Adds a new method to the `AuthorizeUrlBuilder` to add a `code_challenge` parameter when making the `/authorize` request
* Adds a new method to `AuthAPI` to include the `code_verifier` on the request to `/oauth/token` to exchange the code for the tokens

The implementation of the `code_verifier` and `code_challenge` is left to the user - when we make use of this in `mvc-commons` that library will generate the verifier and its challenge.