### PR TITLE
[SDK-3753] Use single ObjectMapper

### DIFF
--- a/src/main/java/com/auth0/json/ObjectMapperProvider.java
+++ b/src/main/java/com/auth0/json/ObjectMapperProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Provides access to a single {@link ObjectMapper} instance for the serialization and deserialization of JSON data.
+ * This class is for internal use only and is subject to change without notice.
  */
 public class ObjectMapperProvider {
 

--- a/src/main/java/com/auth0/json/ObjectMapperProvider.java
+++ b/src/main/java/com/auth0/json/ObjectMapperProvider.java
@@ -1,0 +1,21 @@
+package com.auth0.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Provides access to a single {@link ObjectMapper} instance for the serialization and deserialization of JSON data.
+ */
+public class ObjectMapperProvider {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // prevent instantiation
+    private ObjectMapperProvider() {}
+
+    /**
+     * @return the {@code ObjectMapper} instance to process JSON data
+     */
+    public static ObjectMapper getMapper() {
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/PageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/PageDeserializer.java
@@ -1,9 +1,9 @@
 package com.auth0.json.mgmt;
 
+import com.auth0.json.ObjectMapperProvider;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.type.CollectionType;
@@ -23,7 +23,6 @@ public abstract class PageDeserializer<T, U> extends StdDeserializer<T> {
 
     private final String itemsPropertyName;
     private final Class<U> uClazz;
-    private static final ObjectMapper mapper = new ObjectMapper();
 
     protected PageDeserializer(Class<U> clazz, String arrayName) {
         super(Object.class);
@@ -82,7 +81,7 @@ public abstract class PageDeserializer<T, U> extends StdDeserializer<T> {
     }
 
     private List<U> getArrayElements(ArrayNode array) throws IOException {
-        CollectionType type = mapper.getTypeFactory().constructCollectionType(List.class, uClazz);
-        return mapper.readerFor(type).readValue(array);
+        CollectionType type = ObjectMapperProvider.getMapper().getTypeFactory().constructCollectionType(List.class, uClazz);
+        return ObjectMapperProvider.getMapper().readerFor(type).readValue(array);
     }
 }

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.json.ObjectMapperProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.MediaType;
@@ -38,7 +39,7 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
     }
 
     public CustomRequest(OkHttpClient client, String url, String method, TypeReference<T> tType) {
-        this(client, url, method, new ObjectMapper(), tType);
+        this(client, url, method, ObjectMapperProvider.getMapper(), tType);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.json.ObjectMapperProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.*;
@@ -42,7 +43,7 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
     }
 
     public MultipartRequest(OkHttpClient client, String url, String method, TypeReference<T> tType) {
-        this(client, url, method, new ObjectMapper(), tType, new MultipartBody.Builder());
+        this(client, url, method, ObjectMapperProvider.getMapper(), tType, new MultipartBody.Builder());
     }
 
     @Override

--- a/src/main/java/com/auth0/net/Telemetry.java
+++ b/src/main/java/com/auth0/net/Telemetry.java
@@ -1,7 +1,7 @@
 package com.auth0.net;
 
+import com.auth0.json.ObjectMapperProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Base64;
 import java.util.Collections;
@@ -63,7 +63,7 @@ public class Telemetry {
 
         String tmpValue;
         try {
-            String json = new ObjectMapper().writeValueAsString(values);
+            String json = ObjectMapperProvider.getMapper().writeValueAsString(values);
             tmpValue = Base64.getUrlEncoder().encodeToString(json.getBytes());
         } catch (JsonProcessingException e) {
             tmpValue = null;

--- a/src/test/java/com/auth0/json/ObjectMapperProviderTest.java
+++ b/src/test/java/com/auth0/json/ObjectMapperProviderTest.java
@@ -1,0 +1,16 @@
+package com.auth0.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ObjectMapperProviderTest {
+
+    @Test
+    public void providesSameInstance() {
+        ObjectMapper mapper = ObjectMapperProvider.getMapper();
+        assertThat(mapper, equalTo(ObjectMapperProvider.getMapper()));
+    }
+}


### PR DESCRIPTION
`ObjectMapper` is thread-safe and should be reused. This PR adds a new class `ObjectMapperProvider`, which returns a singleton instance for internal usages to process JSON data. 