### PR TITLE
[SDK-3740] Enable LTS testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ oss {
     description 'Java client library for the Auth0 platform.'
     baselineCompareVersion '1.27.0'
     skipAssertSigningConfiguration true
+    enableJava8Testing true
+    enableJava17Testing true
 
     developers {
         auth0 {
@@ -86,7 +88,7 @@ dependencies {
     implementation "net.jodah:failsafe:2.4.1"
 
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.68"
-    testImplementation "org.mockito:mockito-core:3.7.7"
+    testImplementation "org.mockito:mockito-core:4.8.1"
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testImplementation "org.hamcrest:hamcrest-core:${hamcrestVersion}"
     testImplementation "org.hamcrest:hamcrest-library:${hamcrestVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,7 @@ oss {
     description 'Java client library for the Auth0 platform.'
     baselineCompareVersion '1.27.0'
     skipAssertSigningConfiguration true
-    enableJava8Testing true
-    enableJava17Testing true
+    testInJavaVersions = [8, 11, 17]
 
     developers {
         auth0 {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.17.2'
+        id 'com.auth0.gradle.oss-library.java' version '0.18.0'
     }
 }
 

--- a/src/test/java/com/auth0/net/TelemetryTest.java
+++ b/src/test/java/com/auth0/net/TelemetryTest.java
@@ -2,6 +2,7 @@ package com.auth0.net;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -12,6 +13,12 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TelemetryTest {
+
+    @BeforeClass
+    public static void setup() {
+        //Set so that Telemetry object doesn't use different Java versions while testing which will create different Base64 encoded value
+        System.setProperty("java.specification.version", "1.8");
+    }
 
     @Test
     public void shouldReturnBasicTelemetryBase64Value() throws Exception {


### PR DESCRIPTION
### Changes

- Migrated to OSS plugin with LTS testing support
- Enabled testing for Java 17 and Java 8 (Java 11 is ignored since tests run in this version by default)
- Updated Mockito so that it doesn't fail

⚠️ Looks like Java 17 has changed the Base 64 encoding method, so the tests fail. Need to explore further

### Testing

Tested plugin working locally
