### PR TITLE
[SDK-3777] Use builders to construct API client instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Authentication API client is based on the [Auth0 Authentication API](https:/
 Create an `AuthAPI` instance by providing the Application details from the [dashboard](https://manage.auth0.com/#/applications).
 
 ```java
-AuthAPI auth = new AuthAPI("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CLIENT_SECRET}");
+AuthAPI auth = AuthAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CLIENT_SECRET}").build();
 ```
 
 #### Management API Client
@@ -57,24 +57,24 @@ The Management API client is based on the [Management API Docs](https://auth0.co
 Create a `ManagementAPI` instance by providing the domain from the [Application dashboard](https://manage.auth0.com/#/applications) and a valid API Token.
 
 ```java
-ManagementAPI mgmt = new ManagementAPI("{YOUR_DOMAIN}", "{YOUR_API_TOKEN}");
+ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_API_TOKEN}").build();
 ```
 
 The Management API is organized by entities represented by the Auth0 Management API objects.
 
 ```java
-User user = mgmt.users().get("auth0|user-id", new UserFilter()).execute();
-Role role = mgmt.roles().get("role-id").execute();
+User user = mgmt.users().get("auth0|user-id", new UserFilter()).execute().getBody();
+Role role = mgmt.roles().get("role-id").execute().getBody();
 ```
 
 You can use the Authentication API to obtain a token for a previously authorized Application:
 
 ```java
-AuthAPI authAPI = new AuthAPI("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CLIENT_SECRET}");
+AuthAPI authAPI = AuthAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CLIENT_SECRET}").build();
 AuthRequest authRequest = authAPI.requestToken("https://{YOUR_DOMAIN}/api/v2/");
-TokenHolder holder = authRequest.execute();
+TokenHolder holder = authRequest.execute().getBody();
 String accessToken = holder.getAccessToken();
-ManagementAPI mgmt = new ManagementAPI("{YOUR_DOMAIN}", accessToken);
+ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", accessToken).build();
 ```
 
 An expired token for an existing `ManagementAPI` instance can be replaced by calling the `setApiToken` method with the new token.

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -2,6 +2,7 @@ package com.auth0.client.auth;
 
 import com.auth0.client.HttpOptions;
 import com.auth0.client.LoggingOptions;
+import com.auth0.client.mgmt.ManagementAPI;
 import com.auth0.json.auth.PasswordlessEmailResponse;
 import com.auth0.json.auth.PasswordlessSmsResponse;
 import com.auth0.json.auth.UserInfo;

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -15,10 +15,12 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
+import org.jetbrains.annotations.TestOnly;
 
 /**
- * Class that provides an implementation of some of the Authentication and Authorization API methods defined in https://auth0.com/docs/api/authentication.
- * To begin create a new instance of {@link #AuthAPI(String, String, String)} using the tenant domain, and the Application's client id and client secret.
+ * Class that provides an implementation of of the Authentication and Authorization API methods defined by the <a href="https://auth0.com/docs/api/authentication">Auth0 Authentication API</a>.
+ * Instances are created using the {@link Builder}. If you are also using the {@link ManagementAPI}, it is recommended
+ * to configure each with the same {@link DefaultHttpClient} to enable both API clients to share the same Http client.
  * <p>
  * This class is not entirely thread-safe:
  * A new immutable {@link OkHttpClient} instance is being created with each instantiation, not sharing the thread pool
@@ -68,21 +70,7 @@ public class AuthAPI {
      */
     // TODO deprecate and provide Builder
     public AuthAPI(String domain, String clientId, String clientSecret, HttpOptions options) {
-        Asserts.assertNotNull(domain, "domain");
-        Asserts.assertNotNull(clientId, "client id");
-        Asserts.assertNotNull(clientSecret, "client secret");
-        Asserts.assertNotNull(options, "client options");
-
-        this.baseUrl = createBaseUrl(domain);
-        if (baseUrl == null) {
-            throw new IllegalArgumentException("The domain had an invalid format and couldn't be parsed as an URL.");
-        }
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
-
-        telemetry = new TelemetryInterceptor();
-        logging = new HttpLoggingInterceptor();
-        client = buildNetworkingClient(options);
+        this(domain, clientId, clientSecret, buildNetworkingClient(options));
     }
 
     /**
@@ -99,13 +87,43 @@ public class AuthAPI {
     }
 
     /**
+     * Initialize a new {@link Builder} to configure and create an instance.
+     * @param domain the tenant's domain. Must be a non-null valid HTTPS URL.
+     * @param clientId the application's client ID.
+     * @param clientSecret the applications client secret.
+     * @return a Builder for further configuration.
+     */
+    public static AuthAPI.Builder newBuilder(String domain, String clientId, String clientSecret) {
+        return new AuthAPI.Builder(domain, clientId, clientSecret);
+    }
+
+    private AuthAPI(String domain, String clientId, String clientSecret, Auth0HttpClient httpClient) {
+        Asserts.assertNotNull(domain, "domain");
+        Asserts.assertNotNull(clientId, "client id");
+        Asserts.assertNotNull(clientSecret, "client secret");
+        Asserts.assertNotNull(httpClient, "Http client");
+
+        this.baseUrl = createBaseUrl(domain);
+        if (baseUrl == null) {
+            throw new IllegalArgumentException("The domain had an invalid format and couldn't be parsed as an URL.");
+        }
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+
+        telemetry = new TelemetryInterceptor();
+        logging = new HttpLoggingInterceptor();
+        this.client = httpClient;
+
+    }
+    /**
      * Given a set of options, it creates a new instance of the {@link OkHttpClient}
      * configuring them according to their availability.
      *
      * @param options the options to set to the client.
      * @return a new networking client instance configured as requested.
      */
-    private Auth0HttpClient buildNetworkingClient(HttpOptions options) {
+    private static Auth0HttpClient buildNetworkingClient(HttpOptions options) {
+        Asserts.assertNotNull(options, "Http options");
         return DefaultHttpClient.newBuilder()
             .withLogging(options.getLoggingOptions())
             .withMaxRetries(options.getManagementAPIMaxRetries())
@@ -115,6 +133,11 @@ public class AuthAPI {
             .withConnectTimeout(options.getConnectTimeout())
             .withReadTimeout(options.getReadTimeout())
             .build();
+    }
+
+    @TestOnly
+    Auth0HttpClient getHttpClient() {
+        return this.client;
     }
 
     /**
@@ -924,5 +947,46 @@ public class AuthAPI {
         request.addParameter(KEY_MFA_TOKEN, mfaToken);
         request.addParameter(KEY_OTP, otp);
         return request;
+    }
+
+    /**
+     * Builder for {@link AuthAPI} API client instances.
+     */
+    public static class Builder {
+        private final String domain;
+        private final String clientId;
+        private final String clientSecret;
+        private Auth0HttpClient httpClient = DefaultHttpClient.newBuilder().build();
+
+        /**
+         * Create a new Builder
+         * @param domain the domain of the tenant.
+         * @param clientId the client ID of the Auth0 application.
+         * @param clientSecret the client secret of the Auth0 application.
+         */
+        public Builder(String domain, String clientId, String clientSecret) {
+            this.domain = domain;
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+        }
+
+        /**
+         * Configure the client with an {@link Auth0HttpClient}.
+         * @param httpClient the HTTP client to use when making requests.
+         * @return the builder instance.
+         * @see DefaultHttpClient
+         */
+        public Builder withHttpClient(Auth0HttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        /**
+         * Builds an {@link AuthAPI} instance using this builder's configuration.
+         * @return the configured {@code AuthAPI} instance.
+         */
+        public AuthAPI build() {
+            return new AuthAPI(domain, clientId, clientSecret, httpClient);
+        }
     }
 }

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -259,6 +259,9 @@ public class DefaultHttpClient implements Auth0HttpClient {
         return dispatcher;
     }
 
+    /**
+     * Builder for {@link DefaultHttpClient} instances.
+     */
     // TODO accept default headers
     public static class Builder {
         private int readTimeout = 10;

--- a/src/test/java/com/auth0/client/mgmt/BaseMgmtEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/BaseMgmtEntityTest.java
@@ -20,7 +20,7 @@ public class BaseMgmtEntityTest {
     @Before
     public void setUp() throws Exception {
         server = new MockServer();
-        api = new ManagementAPI(server.getBaseUrl(), API_TOKEN);
+        api = ManagementAPI.newBuilder(server.getBaseUrl(), API_TOKEN).build();
     }
 
     @After


### PR DESCRIPTION
Adds builders for constructing API clients. This affords greater flexibility if/when additional configuration options are added, without having to continually overload constructors.

A follow-up PR will deprecate the existing constructors in favor of the builders.