### PR TITLE
[SDK-3836] deprecate API client constructors

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -58,13 +58,15 @@ public class AuthAPI {
      * These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
      * In addition, accepts an {@link HttpOptions} that will be used to configure the networking client.
      *
+     * @deprecated Use the {@link Builder} to configure and create instances.
+     *
      * @param domain       tenant's domain.
      * @param clientId     the application's client id.
      * @param clientSecret the application's client secret.
      * @param options      configuration options for this client instance.
      * @see #AuthAPI(String, String, String)
      */
-    // TODO deprecate and provide Builder
+    @Deprecated
     public AuthAPI(String domain, String clientId, String clientSecret, HttpOptions options) {
         this(domain, clientId, clientSecret, buildNetworkingClient(options));
     }
@@ -73,11 +75,13 @@ public class AuthAPI {
      * Create a new instance with the given tenant's domain, application's client id and client secret.
      * These values can be obtained at https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings.
      *
+     * @deprecated Use the {@link Builder} to configure and create instances.
+     *
      * @param domain       tenant's domain.
      * @param clientId     the application's client id.
      * @param clientSecret the application's client secret.
      */
-    // TODO deprecate and provide Builder
+    @Deprecated
     public AuthAPI(String domain, String clientId, String clientSecret) {
         this(domain, clientId, clientSecret, new HttpOptions());
     }

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -34,12 +34,14 @@ public class ManagementAPI {
      * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens
      * to learn how to obtain a token.
      *
+     * @deprecated Use the {@link Builder} to configure and create instances.
+     *
      * @param domain   the tenant's domain.
      * @param apiToken the token to authenticate the calls with.
      * @param options  configuration options for this client instance.
      * @see #ManagementAPI(String, String)
      */
-    // TODO deprecate and provide Builder
+    @Deprecated
     public ManagementAPI(String domain, String apiToken, HttpOptions options) {
         this(domain, apiToken, buildNetworkingClient(options));
     }
@@ -49,10 +51,12 @@ public class ManagementAPI {
      * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens
      * to learn how to obtain a token.
      *
+     * @deprecated Use the {@link Builder} to configure and create instances.
+     *
      * @param domain   the tenant's domain.
      * @param apiToken the token to authenticate the calls with.
      */
-    // TODO deprecate and provide Builder
+    @Deprecated
     public ManagementAPI(String domain, String apiToken) {
         this(domain, apiToken, DefaultHttpClient.newBuilder().build());
     }

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -64,6 +64,7 @@ public class AuthAPITest {
     // Configuration
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldAcceptHttpOptions() {
         AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, new HttpOptions());
         assertThat(api, is(notNullValue()));

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -53,6 +53,7 @@ public class ManagementAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldCreateWithDomainAndToken() {
         ManagementAPI api = new ManagementAPI(DOMAIN, API_TOKEN);
         assertThat(api, is(notNullValue()));
@@ -164,6 +165,7 @@ public class ManagementAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void acceptsHttpOptions() {
         HttpOptions httpOptions = new HttpOptions();
         httpOptions.setConnectTimeout(15);
@@ -172,6 +174,7 @@ public class ManagementAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void httpOptionsShouldThrowWhenNull() {
         assertThrows(IllegalArgumentException.class, () -> new ManagementAPI(DOMAIN, API_TOKEN, null));
     }


### PR DESCRIPTION
Deprecates the API client constructors in favor of the builders introduced in #475 