### PR TITLE
[SDK-3844] Support fetching and renewing Managment API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,10 @@ AuthAPI auth = AuthAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CL
 
 The Management API client is based on the [Management API Docs](https://auth0.com/docs/api/management/v2).
 
-Create a `ManagementAPI` instance by providing the domain from the [Application dashboard](https://manage.auth0.com/#/applications) and a valid API Token.
+For simple, short-lived usages, the `ManagementAPI` client can be created with a domain and API token:
 
 ```java
 ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_API_TOKEN}").build();
-```
-
-The Management API is organized by entities represented by the Auth0 Management API objects.
-
-```java
-User user = mgmt.users().get("auth0|user-id", new UserFilter()).execute().getBody();
-Role role = mgmt.roles().get("role-id").execute().getBody();
 ```
 
 You can use the Authentication API to obtain a token for a previously authorized Application:
@@ -77,7 +70,22 @@ String accessToken = holder.getAccessToken();
 ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", accessToken).build();
 ```
 
-An expired token for an existing `ManagementAPI` instance can be replaced by calling the `setApiToken` method with the new token.
+If your use-case requires the `ManagementAPI` client to be used beyond the length of the API token expiry, you can 
+create it with an `AuthAPI` client configured with a client ID and client secret for an [application authorized for
+the Management API audience](https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-access-tokens-for-production). 
+In this case, the `ManagementAPI` client will fetch, store, and renew the API token:
+
+```java
+AuthAPI auth = AuthAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CLIENT_SECRET}").build();
+ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN"}, auth).build();
+```
+
+The Management API is organized by entities represented by the Auth0 Management API objects.
+
+```java
+User user = mgmt.users().get("auth0|user-id", new UserFilter()).execute().getBody();
+Role role = mgmt.roles().get("role-id").execute().getBody();
+```
 
 See the [Auth0 Management API documentation](https://auth0.com/docs/api/management/v2/tokens) for more information on how to obtain API Tokens.
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", accessToken).buil
 ```
 
 If your use-case requires the `ManagementAPI` client to be used beyond the length of the API token expiry, you can 
-create it with a `TokenProvider` configured with a client ID and client secret for an [application authorized for
-the Management API audience](https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-access-tokens-for-production). 
+create it with a `TokenProvider` configured with a client ID and client secret for a non-interactive client authorized 
+for the Management API audience (see the [Auth0 documentation](https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-access-tokens-for-production) 
+for more information).
 In this case, the `ManagementAPI` client will fetch, store, and renew the API token:
 
 ```java

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", accessToken).buil
 ```
 
 If your use-case requires the `ManagementAPI` client to be used beyond the length of the API token expiry, you can 
-create it with an `AuthAPI` client configured with a client ID and client secret for an [application authorized for
+create it with a `TokenProvider` configured with a client ID and client secret for an [application authorized for
 the Management API audience](https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-access-tokens-for-production). 
 In this case, the `ManagementAPI` client will fetch, store, and renew the API token:
 
 ```java
-AuthAPI auth = AuthAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_CLIENT_ID}", "{YOUR_CLIENT_SECRET}").build();
-ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN"}, auth).build();
+TokenProvider provider = ManagedTokenProvider.newBuilder("{DOMAIN}", "{CLIENT-ID}", "{CLIENT-SECRET}")
+ManagementAPI mgmt = ManagementAPI.newBuilder("{DOMAIN"}, provider).build();
 ```
 
 The Management API is organized by entities represented by the Auth0 Management API objects.

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -176,6 +176,10 @@ public class AuthAPI {
         return HttpUrl.parse(url);
     }
 
+    public String getManagementAPIAudience() {
+        return baseUrl.newBuilder().addPathSegments("api/v2/").toString();
+    }
+
     /**
      * Creates an instance of the {@link AuthorizeUrlBuilder} with the given redirect url.
      * i.e.:
@@ -249,7 +253,7 @@ public class AuthAPI {
                 .addPathSegment("userinfo")
                 .build()
                 .toString();
-        CustomRequest<UserInfo> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<UserInfo>() {
+        CustomRequest<UserInfo> request = new CustomRequest<>(client, null, url, HttpMethod.GET, new TypeReference<UserInfo>() {
         });
         request.addHeader("Authorization", "Bearer " + accessToken);
         return request;
@@ -284,7 +288,7 @@ public class AuthAPI {
                 .addPathSegment("change_password")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(client, null, url, HttpMethod.POST);
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_EMAIL, email);
         request.addParameter(KEY_CONNECTION, connection);
@@ -659,7 +663,7 @@ public class AuthAPI {
                 .addPathSegment(PATH_REVOKE)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(client, null, url, HttpMethod.POST);
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_TOKEN, refreshToken);
         addSecret(request, false);
@@ -809,7 +813,7 @@ public class AuthAPI {
                 .build()
                 .toString();
 
-        CustomRequest<PasswordlessEmailResponse> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<PasswordlessEmailResponse>() {
+        CustomRequest<PasswordlessEmailResponse> request = new CustomRequest<>(client, null, url, HttpMethod.POST, new TypeReference<PasswordlessEmailResponse>() {
         });
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_CONNECTION, "email");
@@ -851,7 +855,7 @@ public class AuthAPI {
                 .build()
                 .toString();
 
-        CustomRequest<PasswordlessSmsResponse> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<PasswordlessSmsResponse>() {
+        CustomRequest<PasswordlessSmsResponse> request = new CustomRequest<>(client, null, url, HttpMethod.POST, new TypeReference<PasswordlessSmsResponse>() {
         });
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_CONNECTION, "sms");

--- a/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
@@ -35,8 +35,8 @@ public class ActionsEntity extends BaseManagementEntity {
 
     private final static String AUTHORIZATION_HEADER = "Authorization";
 
-    ActionsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ActionsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -57,10 +57,9 @@ public class ActionsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        CustomRequest<Action> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<Action>() {
+        CustomRequest<Action> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Action>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(action);
         return request;
     }
@@ -84,11 +83,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Action> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Action>() {
-        });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Action>() {});
     }
 
     /**
@@ -125,9 +120,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest = new VoidRequest(client, url, HttpMethod.DELETE);
-        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return voidRequest;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -144,11 +137,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Triggers> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Triggers>() {
-        });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Triggers>() {});
     }
 
     /**
@@ -173,11 +162,10 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Action> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<Action>() {
+        CustomRequest<Action> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Action>() {
         });
 
         request.setBody(action);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -204,11 +192,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        EmptyBodyRequest<Version> request = new EmptyBodyRequest<>(client, url, HttpMethod.POST, new TypeReference<Version>() {
+        return new EmptyBodyRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Version>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -235,11 +220,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Version> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Version>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Version>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -269,11 +251,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .toString();
 
         // Needed to successfully call the roll-back endpoint until DXEX-1738 is resolved.
-        EmptyObjectRequest<Version> request = new EmptyObjectRequest<>(client, url, HttpMethod.POST, new TypeReference<Version>() {
+        return new EmptyObjectRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Version>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -297,11 +276,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Execution> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Execution>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Execution>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -321,11 +297,8 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<ActionsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<ActionsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ActionsPage>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -353,11 +326,8 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<VersionsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<VersionsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<VersionsPage>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -386,11 +356,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<BindingsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<BindingsPage>() {
-        });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<BindingsPage>() {
+        });
     }
 
     /**
@@ -418,11 +386,10 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<BindingsPage> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<BindingsPage>() {
+        CustomRequest<BindingsPage> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<BindingsPage>() {
         });
 
         request.setBody(bindingsUpdateRequest);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -434,8 +401,8 @@ public class ActionsEntity extends BaseManagementEntity {
 
     // Temporary request implementation to send an empty json object on the request body.
     private static class EmptyObjectRequest<T> extends EmptyBodyRequest<T> {
-        EmptyObjectRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-            super(client, url, method, tType);
+        EmptyObjectRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+            super(client, tokenProvider, url, method, tType);
         }
 
         @Override

--- a/src/main/java/com/auth0/client/mgmt/AttackProtectionEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/AttackProtectionEntity.java
@@ -15,8 +15,8 @@ import okhttp3.HttpUrl;
  * @see ManagementAPI
  */
 public class AttackProtectionEntity extends BaseManagementEntity {
-    AttackProtectionEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    AttackProtectionEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
@@ -10,19 +10,18 @@ import java.util.function.Consumer;
 
 abstract class BaseManagementEntity {
     protected final Auth0HttpClient client;
-    // TODO decouple from OkHttp!!
     protected final HttpUrl baseUrl;
-    protected final String apiToken;
+    protected final TokenProvider tokenProvider;
 
-    BaseManagementEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
+    BaseManagementEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
         this.client = client;
         this.baseUrl = baseUrl;
-        this.apiToken = apiToken;
+        this.tokenProvider = tokenProvider;
     }
 
     protected Request<Void> voidRequest(HttpMethod method, Consumer<RequestBuilder<Void>> customizer) {
         return customizeRequest(
-            new RequestBuilder<>(client, method, baseUrl, new TypeReference<Void>() {
+            new RequestBuilder<>(client, tokenProvider, method, baseUrl, new TypeReference<Void>() {
             }),
             customizer
         );
@@ -30,13 +29,12 @@ abstract class BaseManagementEntity {
 
     protected <T> Request<T> request(HttpMethod method, TypeReference<T> target, Consumer<RequestBuilder<T>> customizer) {
         return customizeRequest(
-            new RequestBuilder<>(client, method, baseUrl, target),
+            new RequestBuilder<>(client, tokenProvider, method, baseUrl, target),
             customizer
         );
     }
 
     private <T> Request<T> customizeRequest(RequestBuilder<T> builder, Consumer<RequestBuilder<T>> customizer) {
-        builder.withHeader("Authorization", "Bearer " + apiToken);
         customizer.accept(builder);
         return builder.build();
     }

--- a/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
@@ -22,8 +22,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class BlacklistsEntity extends BaseManagementEntity {
 
-    BlacklistsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    BlacklistsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -42,10 +42,8 @@ public class BlacklistsEntity extends BaseManagementEntity {
                 .addQueryParameter("aud", audience)
                 .build()
                 .toString();
-        CustomRequest<List<Token>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Token>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Token>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -63,8 +61,7 @@ public class BlacklistsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/blacklists/tokens")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request = new VoidRequest(client, tokenProvider, url, HttpMethod.POST);
         request.setBody(token);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/BrandingEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BrandingEntity.java
@@ -20,8 +20,8 @@ import okhttp3.HttpUrl;
 @SuppressWarnings("WeakerAccess")
 public class BrandingEntity extends BaseManagementEntity {
 
-    BrandingEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    BrandingEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class ClientGrantsEntity extends BaseManagementEntity {
 
-    ClientGrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ClientGrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -47,10 +47,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        CustomRequest<ClientGrantsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -68,10 +66,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        CustomRequest<List<ClientGrant>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -93,9 +89,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        CustomRequest<ClientGrant> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<ClientGrant>() {
+        CustomRequest<ClientGrant> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<ClientGrant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("client_id", clientId);
         request.addParameter("audience", audience);
         request.addParameter("scope", scope);
@@ -119,9 +114,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegment(clientGrantId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -142,9 +135,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegment(clientGrantId)
                 .build()
                 .toString();
-        CustomRequest<ClientGrant> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<ClientGrant>() {
+        CustomRequest<ClientGrant> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<ClientGrant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("scope", scope);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -27,8 +27,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class ClientsEntity extends BaseManagementEntity {
 
-    ClientsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ClientsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -46,10 +46,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        CustomRequest<List<Client>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Client>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Client>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -69,10 +67,8 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<ClientsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<ClientsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ClientsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -91,10 +87,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        CustomRequest<Client> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Client>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -118,10 +112,8 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<Client> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Client>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -139,9 +131,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        CustomRequest<Client> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Client>() {
+        CustomRequest<Client> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(client);
         return request;
     }
@@ -162,9 +153,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -185,9 +174,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        CustomRequest<Client> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Client>() {
+        CustomRequest<Client> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(client);
         return request;
     }
@@ -210,9 +198,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment("rotate-secret")
                 .build()
                 .toString();
-        CustomRequest<Client> request = new EmptyBodyRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Client>() {
+        return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class ConnectionsEntity extends BaseManagementEntity {
 
-    ConnectionsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ConnectionsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
 
@@ -47,10 +47,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<ConnectionsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<ConnectionsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ConnectionsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
 
@@ -77,10 +75,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<List<Connection>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Connection>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Connection>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -104,10 +100,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<Connection> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Connection>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Connection>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -125,9 +119,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/connections")
                 .build()
                 .toString();
-        CustomRequest<Connection> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Connection>() {
+        CustomRequest<Connection> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Connection>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -148,9 +141,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegment(connectionId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -171,9 +162,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegment(connectionId)
                 .build()
                 .toString();
-        CustomRequest<Connection> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Connection>() {
+        CustomRequest<Connection> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Connection>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -198,8 +188,6 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addQueryParameter("email", email)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
@@ -24,8 +24,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class DeviceCredentialsEntity extends BaseManagementEntity {
 
-    DeviceCredentialsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    DeviceCredentialsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -45,10 +45,8 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<List<DeviceCredentials>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -66,9 +64,8 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/device-credentials")
                 .build()
                 .toString();
-        CustomRequest<DeviceCredentials> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<DeviceCredentials>() {
+        CustomRequest<DeviceCredentials> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<DeviceCredentials>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(deviceCredentials);
         return request;
     }
@@ -89,8 +86,6 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
                 .addPathSegment(deviceCredentialsId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
@@ -22,8 +22,8 @@ import java.util.Map;
  */
 @SuppressWarnings("WeakerAccess")
 public class EmailProviderEntity extends BaseManagementEntity {
-    EmailProviderEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    EmailProviderEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -43,10 +43,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<EmailProvider> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<EmailProvider>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EmailProvider>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -64,9 +62,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        CustomRequest<EmailProvider> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<EmailProvider>() {
+        CustomRequest<EmailProvider> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<EmailProvider>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(emailProvider);
         return request;
     }
@@ -83,9 +80,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -103,9 +98,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        CustomRequest<EmailProvider> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<EmailProvider>() {
+        CustomRequest<EmailProvider> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<EmailProvider>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(emailProvider);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -29,8 +29,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
     public static final String TEMPLATE_PASSWORD_RESET = "password_reset";
     public static final String TEMPLATE_MFA_OOB_CODE = "mfa_oob_code";
 
-    EmailTemplatesEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    EmailTemplatesEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -47,10 +47,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .addPathSegment(templateName);
         String url = builder.build().toString();
-        CustomRequest<EmailTemplate> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<EmailTemplate>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EmailTemplate>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -68,9 +66,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .build()
                 .toString();
-        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<EmailTemplate>() {
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<EmailTemplate>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(template);
         return request;
     }
@@ -93,9 +90,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegment(templateName)
                 .build()
                 .toString();
-        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<EmailTemplate>() {
+        CustomRequest<EmailTemplate> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<EmailTemplate>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(template);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class GrantsEntity extends BaseManagementEntity {
 
-    GrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    GrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -51,10 +51,8 @@ public class GrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        CustomRequest<GrantsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<GrantsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<GrantsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -76,10 +74,8 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        CustomRequest<List<Grant>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Grant>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Grant>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -98,9 +94,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addPathSegment(grantId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -119,9 +113,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
 }

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -20,8 +20,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class GuardianEntity extends BaseManagementEntity {
 
-    GuardianEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    GuardianEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -32,8 +32,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class JobsEntity extends BaseManagementEntity {
 
-    JobsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    JobsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -53,10 +53,8 @@ public class JobsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<Job> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Job>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Job>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -79,7 +77,7 @@ public class JobsEntity extends BaseManagementEntity {
 
         TypeReference<List<JobErrorDetails>> jobErrorDetailsListType = new TypeReference<List<JobErrorDetails>>() {
         };
-        CustomRequest<List<JobErrorDetails>> request = new CustomRequest<List<JobErrorDetails>>(client, url, HttpMethod.GET, jobErrorDetailsListType) {
+        return new CustomRequest<List<JobErrorDetails>>(client, tokenProvider, url, HttpMethod.GET, jobErrorDetailsListType) {
             @Override
             protected List<JobErrorDetails> readResponseBody(Auth0HttpResponse response) throws IOException {
                 if (response.getBody() == null || response.getBody().length() == 0) {
@@ -88,8 +86,6 @@ public class JobsEntity extends BaseManagementEntity {
                 return super.readResponseBody(response);
             }
         };
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -158,9 +154,8 @@ public class JobsEntity extends BaseManagementEntity {
             Asserts.assertNotNull(emailVerificationIdentity.getUserId(), "identity user id");
             requestBody.put("identity", emailVerificationIdentity);
         }
-        CustomRequest<Job> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<Job>() {
+        CustomRequest<Job> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(requestBody);
         return request;
     }
@@ -189,9 +184,8 @@ public class JobsEntity extends BaseManagementEntity {
             requestBody.putAll(filter.getAsMap());
         }
 
-        CustomRequest<Job> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<Job>() {
+        CustomRequest<Job> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(requestBody);
         return request;
     }
@@ -217,7 +211,7 @@ public class JobsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        MultipartRequest<Job> request = new MultipartRequest<>(client, url, HttpMethod.POST, new TypeReference<Job>() {
+        MultipartRequest<Job> request = new MultipartRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
         });
         if (options != null) {
             for (Map.Entry<String, Object> e : options.getAsMap().entrySet()) {
@@ -226,7 +220,6 @@ public class JobsEntity extends BaseManagementEntity {
         }
         request.addPart("connection_id", connectionId);
         request.addPart("users", users, "text/json");
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/KeysEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/KeysEntity.java
@@ -21,9 +21,8 @@ import java.util.List;
  */
 public class KeysEntity extends BaseManagementEntity {
 
-    KeysEntity(Auth0HttpClient client, HttpUrl baseUrl,
-               String apiToken) {
-        super(client, baseUrl, apiToken);
+    KeysEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -38,10 +37,8 @@ public class KeysEntity extends BaseManagementEntity {
             .newBuilder()
             .addEncodedPathSegments("api/v2/keys/signing");
         String url = builder.build().toString();
-        CustomRequest<List<Key>> request = new CustomRequest<>(this.client, url, HttpMethod.GET, new TypeReference<List<Key>>() {
+        return new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Key>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
 
@@ -60,10 +57,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing")
             .addPathSegment(kid);
         String url = builder.build().toString();
-        CustomRequest<Key> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Key>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Key>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -79,10 +74,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing/rotate")
             .build()
             .toString();
-        CustomRequest<Key> request = new EmptyBodyRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Key>() {
+        return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Key>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -103,9 +96,7 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegment("revoke")
             .build()
             .toString();
-        CustomRequest<Key> request = new EmptyBodyRequest<>(this.client, url, HttpMethod.PUT, new TypeReference<Key>() {
+        return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<Key>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
@@ -25,8 +25,8 @@ import static com.auth0.client.mgmt.filter.QueryFilter.KEY_QUERY;
 @SuppressWarnings("WeakerAccess")
 public class LogEventsEntity extends BaseManagementEntity {
 
-    LogEventsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    LogEventsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -50,10 +50,8 @@ public class LogEventsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<LogEventsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -72,9 +70,7 @@ public class LogEventsEntity extends BaseManagementEntity {
                 .addPathSegment(logEventId)
                 .build()
                 .toString();
-        CustomRequest<LogEvent> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<LogEvent>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogEvent>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -24,8 +24,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
     private final static String LOG_STREAMS_PATH = "api/v2/log-streams";
     private final static String AUTHORIZATION_HEADER = "Authorization";
 
-    LogStreamsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    LogStreamsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -41,10 +41,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<List<LogStream>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<LogStream>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<LogStream>>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -64,10 +62,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<LogStream> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<LogStream>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogStream>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -86,8 +82,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<LogStream> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<LogStream>(){});
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        CustomRequest<LogStream> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<LogStream>(){});
         request.setBody(logStream);
         return request;
     }
@@ -111,9 +106,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<LogStream> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<LogStream>(){
+        CustomRequest<LogStream> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<LogStream>(){
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(logStream);
         return request;
     }
@@ -135,8 +129,6 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
@@ -1,0 +1,58 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.client.auth.AuthAPI;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.json.auth.TokenHolder;
+import com.auth0.utils.Asserts;
+import org.jetbrains.annotations.TestOnly;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * An implementation of {@link TokenProvider} that fetches, stores (in-memory), and renews Auth0 Management API tokens.
+ */
+public class ManagedTokenProvider implements TokenProvider {
+
+    private final AuthAPI authAPI;
+    private TokenHolder tokenHolder;
+    final static int LEEWAY = 10;
+
+    public static ManagedTokenProvider create(AuthAPI authAPI) {
+        return new ManagedTokenProvider(authAPI);
+    }
+
+    @Override
+    public synchronized String getToken() throws Auth0Exception {
+        // get tokens on first request if not set yet
+        if (Objects.isNull(tokenHolder)) {
+            tokenHolder = getTokenHolder();
+            return tokenHolder.getAccessToken();
+        }
+
+        // if expired (or about to expire), renew the token, store it, and return it
+        if (isExpired()) {
+            this.tokenHolder = getTokenHolder();
+            return tokenHolder.getAccessToken();
+        }
+
+        // token still valid
+        return tokenHolder.getAccessToken();
+    }
+
+    ManagedTokenProvider(AuthAPI authAPI) {
+        Asserts.assertNotNull(authAPI, "Auth API");
+        this.authAPI = authAPI;
+    }
+
+    @TestOnly
+    boolean isExpired() {
+        return Instant.now().plusSeconds(LEEWAY).isAfter(tokenHolder.getExpiresAt().toInstant());
+    }
+
+    private TokenHolder getTokenHolder() throws Auth0Exception {
+        return this.authAPI.requestToken(this.authAPI.getManagementAPIAudience())
+            .execute()
+            .getBody();
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.util.Objects;
 
 /**
- * An implementation of {@link TokenProvider} that fetches, stores (in-memory), and renews Auth0 Management API tokens.
+ * An implementation of {@link TokenProvider} that fetches, maintains, and renews Auth0 Management API tokens.
  */
 public class ManagedTokenProvider implements TokenProvider {
 

--- a/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
@@ -52,6 +52,10 @@ public class ManagedTokenProvider implements TokenProvider {
         return tokenHolder.getAccessToken();
     }
 
+    private boolean isExpired() {
+        return Instant.now().plusSeconds(this.leeway).isAfter(tokenHolder.getExpiresAt().toInstant());
+    }
+    
     private ManagedTokenProvider(Builder builder) {
         if (builder.leeway < 0) {
             throw new IllegalArgumentException("leeway must be a positive number of seconds");
@@ -73,11 +77,6 @@ public class ManagedTokenProvider implements TokenProvider {
     @TestOnly
     Auth0HttpClient getHttpClient() {
         return this.httpClient;
-    }
-
-    @TestOnly
-    boolean isExpired() {
-        return Instant.now().plusSeconds(this.leeway).isAfter(tokenHolder.getExpiresAt().toInstant());
     }
 
     private TokenHolder getTokenHolder() throws Auth0Exception {

--- a/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
@@ -3,7 +3,8 @@ package com.auth0.client.mgmt;
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
-import com.auth0.utils.Asserts;
+import com.auth0.net.client.Auth0HttpClient;
+import com.auth0.net.client.DefaultHttpClient;
 import org.jetbrains.annotations.TestOnly;
 
 import java.time.Instant;
@@ -16,10 +17,21 @@ public class ManagedTokenProvider implements TokenProvider {
 
     private final AuthAPI authAPI;
     private TokenHolder tokenHolder;
-    final static int LEEWAY = 10;
+    private final int leeway;
+    private final Auth0HttpClient httpClient;
 
-    public static ManagedTokenProvider create(AuthAPI authAPI) {
-        return new ManagedTokenProvider(authAPI);
+    /**
+     * Initializes a new {@link Builder} with details about an
+     * <a href="https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-access-tokens-for-production">
+     *     Auth0 application authorized for the Management API.
+     * </a>
+     * @param domain the tenant's domain. Must be a non-null valid HTTPS URL.
+     * @param clientId the client ID of the application.
+     * @param clientSecret the client secret of the application.
+     * @return a Builder for further configuration.
+     */
+    public static ManagedTokenProvider.Builder newBuilder(String domain, String clientId, String clientSecret) {
+        return new ManagedTokenProvider.Builder(domain, clientId, clientSecret);
     }
 
     @Override
@@ -40,19 +52,100 @@ public class ManagedTokenProvider implements TokenProvider {
         return tokenHolder.getAccessToken();
     }
 
-    ManagedTokenProvider(AuthAPI authAPI) {
-        Asserts.assertNotNull(authAPI, "Auth API");
-        this.authAPI = authAPI;
+    private ManagedTokenProvider(Builder builder) {
+        if (builder.leeway < 0) {
+            throw new IllegalArgumentException("leeway must be a positive number of seconds");
+        }
+
+        this.leeway = builder.leeway;
+        this.httpClient = Objects.nonNull(builder.httpClient) ? builder.httpClient : DefaultHttpClient.newBuilder().build();
+
+        // allow injection of AuthAPI client for testing purposes
+        if (Objects.nonNull(builder.authAPI)) {
+            this.authAPI = builder.authAPI;
+        } else {
+            this.authAPI = AuthAPI.newBuilder(builder.domain, builder.clientId, builder.clientSecret)
+                .withHttpClient(this.httpClient)
+                .build();
+        }
+    }
+
+    @TestOnly
+    Auth0HttpClient getHttpClient() {
+        return this.httpClient;
     }
 
     @TestOnly
     boolean isExpired() {
-        return Instant.now().plusSeconds(LEEWAY).isAfter(tokenHolder.getExpiresAt().toInstant());
+        return Instant.now().plusSeconds(this.leeway).isAfter(tokenHolder.getExpiresAt().toInstant());
     }
 
     private TokenHolder getTokenHolder() throws Auth0Exception {
         return this.authAPI.requestToken(this.authAPI.getManagementAPIAudience())
             .execute()
             .getBody();
+    }
+
+    /**
+     * A Builder to configure and construct a {@link ManagedTokenProvider}.
+     */
+    public static class Builder {
+        private final String domain;
+        private final String clientId;
+        private final String clientSecret;
+        private Auth0HttpClient httpClient;
+        private int leeway = 10;
+        private AuthAPI authAPI;
+
+        /**
+         * Create a new Builder instance.
+         * @param domain the tenant's domain. Must be a non-null valid HTTPS URL.
+         * @param clientId the client ID of the application.
+         * @param clientSecret the client secret of the application.
+         */
+        public Builder(String domain, String clientId, String clientSecret) {
+            this.domain = domain;
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+        }
+
+        /**
+         * Specify a leeway, in seconds, used to determine of the token is expired. By default, a value of 10 seconds
+         * is used.
+         * <p>
+         * The calculation used to determine if the token is expired is {@code isExpired = timeNow + leeway > tokenExpiry}
+         * </p>
+         * @param leewaySeconds the number of seconds to add
+         * @return the builder instance.
+         */
+        public Builder withLeeway(int leewaySeconds) {
+            this.leeway = leewaySeconds;
+            return this;
+        }
+
+        /**
+         * Specify an {@link Auth0HttpClient} to use when fetching the API token.
+         * @param httpClient the Http client to use.
+         * @return the builder instance.
+         */
+        public Builder withHttpClient(Auth0HttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        // allow tests to inject an AuthAPI
+        @TestOnly
+        Builder withAuthAPI(AuthAPI authAPI) {
+            this.authAPI = authAPI;
+            return this;
+        }
+
+        /**
+         * Constructs a {@link ManagedTokenProvider} from this builder.
+         * @return the constructed instance.
+         */
+        public ManagedTokenProvider build() {
+            return new ManagedTokenProvider(this);
+        }
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagedTokenProvider.java
@@ -3,12 +3,14 @@ package com.auth0.client.mgmt;
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.auth.TokenHolder;
+import com.auth0.net.Response;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.DefaultHttpClient;
 import org.jetbrains.annotations.TestOnly;
 
 import java.time.Instant;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * An implementation of {@link TokenProvider} that fetches, maintains, and renews Auth0 Management API tokens.
@@ -17,6 +19,7 @@ public class ManagedTokenProvider implements TokenProvider {
 
     private final AuthAPI authAPI;
     private TokenHolder tokenHolder;
+    private CompletableFuture<Response<TokenHolder>> tokenHolderAsync;
     private final int leeway;
     private final Auth0HttpClient httpClient;
 
@@ -43,7 +46,7 @@ public class ManagedTokenProvider implements TokenProvider {
         }
 
         // if expired (or about to expire), renew the token, store it, and return it
-        if (isExpired()) {
+        if (isExpired(tokenHolder.getExpiresAt().toInstant())) {
             this.tokenHolder = getTokenHolder();
             return tokenHolder.getAccessToken();
         }
@@ -52,8 +55,30 @@ public class ManagedTokenProvider implements TokenProvider {
         return tokenHolder.getAccessToken();
     }
 
-    private boolean isExpired() {
-        return Instant.now().plusSeconds(this.leeway).isAfter(tokenHolder.getExpiresAt().toInstant());
+    @Override
+    public CompletableFuture<String> getTokenAsync() {
+        // get tokens on first request if not set yet
+        if (Objects.isNull(tokenHolderAsync)) {
+            this.tokenHolderAsync = getTokenHolderAsync();
+            return this.tokenHolderAsync.thenCompose(this::tokenFuture);
+        }
+
+        return tokenHolderAsync.thenCompose(tokenHolderResponse -> {
+            if (isExpired(tokenHolderResponse.getBody().getExpiresAt().toInstant())) {
+                this.tokenHolderAsync = getTokenHolderAsync();
+                return this.tokenHolderAsync.thenCompose(this::tokenFuture);
+            } else {
+                return tokenFuture(tokenHolderResponse);
+            }
+        });
+    }
+
+    private CompletableFuture<String> tokenFuture(Response<TokenHolder> tokenHolderResponse) {
+        return CompletableFuture.supplyAsync(() -> tokenHolderResponse.getBody().getAccessToken());
+    }
+
+    private boolean isExpired(Instant expiry) {
+        return Instant.now().plusSeconds(this.leeway).isAfter(expiry);
     }
     
     private ManagedTokenProvider(Builder builder) {
@@ -83,6 +108,11 @@ public class ManagedTokenProvider implements TokenProvider {
         return this.authAPI.requestToken(this.authAPI.getManagementAPIAudience())
             .execute()
             .getBody();
+    }
+
+    private CompletableFuture<Response<TokenHolder>> getTokenHolderAsync() {
+        return this.authAPI.requestToken(this.authAPI.getManagementAPIAudience())
+            .executeAsync();
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -435,9 +435,10 @@ public class ManagementAPI {
         }
 
         /**
-         * Specify a {@link TokenProvider} to use when making requests to the Auth0 Management APIs. This is useful
-         * for long-running applications that would prefer the library to manage the token, including renewing it when
-         * required.
+         * Specify a {@link TokenProvider} to use when making requests to the Auth0 Management APIs. Providing a
+         * {@link ManagedTokenProvider} may be useful for long-running applications that would prefer the library
+         * to manage the token, including renewing it when required.
+         * 
          * @param tokenProvider
          * @return
          */

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -29,8 +29,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
     private final static String ORGS_PATH = "api/v2/organizations";
     private final static String AUTHORIZATION_HEADER = "Authorization";
 
-    OrganizationsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    OrganizationsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     // Organizations Entity
@@ -51,11 +51,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<OrganizationsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
-        });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        });
     }
 
     /**
@@ -76,11 +74,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Organization> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Organization>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Organization>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -102,11 +97,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Organization> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Organization>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Organization>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -126,10 +118,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Organization> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<Organization>() {
+        CustomRequest<Organization> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Organization>() {
         });
-
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(organization);
         return request;
     }
@@ -154,10 +144,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Organization> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<Organization>() {
+        CustomRequest<Organization> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Organization>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(organization);
         return request;
     }
@@ -180,9 +169,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest = new VoidRequest(client, url, HttpMethod.DELETE);
-        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return voidRequest;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     // Organization members
@@ -208,10 +195,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<MembersPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<MembersPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<MembersPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -235,8 +220,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request = new VoidRequest(client, tokenProvider, url, HttpMethod.POST);
         request.setBody(members);
         return request;
     }
@@ -262,8 +246,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request = new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
         request.setBody(members);
         return request;
     }
@@ -291,10 +274,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<EnabledConnectionsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -319,10 +300,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<EnabledConnection>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EnabledConnection>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -346,9 +325,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<EnabledConnection>() {
+        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<EnabledConnection>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -375,9 +353,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest = new VoidRequest(client, url, HttpMethod.DELETE);
-        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return voidRequest;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -404,9 +380,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<EnabledConnection>() {
+        CustomRequest<EnabledConnection> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<EnabledConnection>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -438,10 +413,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<RolesPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<RolesPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RolesPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -469,8 +442,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request = new VoidRequest(client, tokenProvider, url, HttpMethod.POST);
         request.setBody(roles);
         return request;
     }
@@ -500,8 +472,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request = new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
         request.setBody(roles);
         return request;
     }
@@ -529,9 +500,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        CustomRequest<Invitation> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<Invitation>() {
+        CustomRequest<Invitation> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Invitation>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(invitation);
         return request;
 
@@ -561,10 +531,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<Invitation> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Invitation>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Invitation>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -588,10 +556,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        CustomRequest<InvitationsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<InvitationsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<InvitationsPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -616,9 +582,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     private void applyFilter(BaseFilter filter, HttpUrl.Builder builder) {

--- a/src/main/java/com/auth0/client/mgmt/RequestBuilder.java
+++ b/src/main/java/com/auth0/client/mgmt/RequestBuilder.java
@@ -25,8 +25,11 @@ class RequestBuilder<T> {
     private final Map<String, String> headers = new HashMap<>();
     private final Map<String, Object> parameters = new HashMap<>();
 
-    public RequestBuilder(Auth0HttpClient client, HttpMethod method, HttpUrl baseUrl, TypeReference<T> target) {
+    private final TokenProvider tokenProvider;
+
+    public RequestBuilder(Auth0HttpClient client, TokenProvider tokenProvider, HttpMethod method, HttpUrl baseUrl, TypeReference<T> target) {
         this.client = client;
+        this.tokenProvider = tokenProvider;
         this.method = method;
         this.url = baseUrl.newBuilder();
         this.target = target;
@@ -58,9 +61,9 @@ class RequestBuilder<T> {
 
         final String url = this.url.build().toString();
         if ("java.lang.Void".equals(target.getType().getTypeName())) {
-            request = (CustomRequest<T>) new VoidRequest(client, url, method);
+            request = (CustomRequest<T>) new VoidRequest(client, tokenProvider, url, method);
         } else {
-            request = new CustomRequest<>(client, url, method, target);
+            request = new CustomRequest<>(client, tokenProvider, url, method, target);
         }
 
         if (body != null) {

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -24,8 +24,8 @@ import java.util.Map;
  */
 public class ResourceServerEntity extends BaseManagementEntity {
 
-    ResourceServerEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ResourceServerEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -46,11 +46,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        CustomRequest<ResourceServersPage> request = new CustomRequest<>(client, url, HttpMethod.GET,
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET,
                 new TypeReference<ResourceServersPage>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -68,11 +66,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        CustomRequest<List<ResourceServer>> request = new CustomRequest<>(client, url, HttpMethod.GET,
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET,
                 new TypeReference<List<ResourceServer>>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -91,11 +87,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerIdOrIdentifier);
 
         String url = builder.build().toString();
-        CustomRequest<ResourceServer> request = new CustomRequest<>(client, url, HttpMethod.GET,
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET,
                 new TypeReference<ResourceServer>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -113,10 +107,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        CustomRequest<ResourceServer> request = new CustomRequest<>(client, url, HttpMethod.POST,
+        CustomRequest<ResourceServer> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST,
                 new TypeReference<ResourceServer>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(resourceServer);
         return request;
     }
@@ -137,9 +130,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerId);
 
         String url = builder.build().toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -160,10 +151,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerId);
 
         String url = builder.build().toString();
-        CustomRequest<ResourceServer> request = new CustomRequest<ResourceServer>(client, url, HttpMethod.PATCH,
+        CustomRequest<ResourceServer> request = new CustomRequest<ResourceServer>(client, tokenProvider, url, HttpMethod.PATCH,
                 new TypeReference<ResourceServer>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(resourceServer);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/RolesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RolesEntity.java
@@ -29,9 +29,8 @@ import java.util.Map;
  */
 public class RolesEntity extends BaseManagementEntity {
 
-  RolesEntity(Auth0HttpClient client, HttpUrl baseUrl,
-              String apiToken) {
-    super(client, baseUrl, apiToken);
+  RolesEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+    super(client, baseUrl, tokenProvider);
   }
 
   /**
@@ -52,9 +51,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    CustomRequest<RolesPage> request = new CustomRequest<>(this.client, url, HttpMethod.GET, new TypeReference<RolesPage>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
-    return request;
+    return new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<RolesPage>() {});
   }
 
   /**
@@ -74,9 +71,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId);
 
     String url = builder.build().toString();
-    CustomRequest<Role> request = new CustomRequest<>(this.client, url, HttpMethod.GET, new TypeReference<Role>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
-    return request;
+    return new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<Role>() {});
   }
 
 
@@ -96,8 +91,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("api/v2/roles")
         .build()
         .toString();
-    CustomRequest<Role> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Role>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    CustomRequest<Role> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Role>() {});
     request.setBody(role);
     return request;
   }
@@ -119,9 +113,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
-    request.addHeader("Authorization", "Bearer " + apiToken);
-    return request;
+    return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
   }
 
   /**
@@ -143,8 +135,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-    CustomRequest<Role> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Role>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    CustomRequest<Role> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Role>() {});
     request.setBody(role);
     return request;
   }
@@ -172,9 +163,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    CustomRequest<UsersPage> request = new CustomRequest<>(this.client, url, HttpMethod.GET, new TypeReference<UsersPage>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
-    return request;
+    return new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<UsersPage>() {});
   }
 
   /**
@@ -200,8 +189,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("users")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
     request.setBody(body);
     return request;
   }
@@ -229,9 +217,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    CustomRequest<PermissionsPage> request = new CustomRequest<>(this.client, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
-    return request;
+    return new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {});
   }
 
   /**
@@ -257,9 +243,8 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("permissions")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
     request.setBody(body);
-    request.addHeader("Authorization", "Bearer " + apiToken);
     return request;
   }
 
@@ -287,9 +272,8 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("permissions")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
     request.setBody(body);
-    request.addHeader("Authorization", "Bearer " + apiToken);
     return request;
   }
 }

--- a/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
@@ -22,8 +22,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class RulesConfigsEntity extends BaseManagementEntity {
 
-    RulesConfigsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    RulesConfigsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -39,10 +39,8 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .newBuilder()
                 .addPathSegments("api/v2/rules-configs");
         String url = builder.build().toString();
-        CustomRequest<List<RulesConfig>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -61,9 +59,7 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .addPathSegment(rulesConfigKey)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -84,9 +80,8 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .addPathSegment(rulesConfigKey)
                 .build()
                 .toString();
-        CustomRequest<RulesConfig> request = new CustomRequest<>(this.client, url, HttpMethod.PUT, new TypeReference<RulesConfig>() {
+        CustomRequest<RulesConfig> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<RulesConfig>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(rulesConfig);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/RulesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class RulesEntity extends BaseManagementEntity {
 
-    RulesEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    RulesEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -46,10 +46,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<RulesPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<RulesPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RulesPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -75,10 +73,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<List<Rule>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Rule>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Rule>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -102,10 +98,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<Rule> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Rule>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Rule>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -123,9 +117,8 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/rules")
                 .build()
                 .toString();
-        CustomRequest<Rule> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Rule>() {
+        CustomRequest<Rule> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Rule>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(rule);
         return request;
     }
@@ -146,9 +139,7 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegment(ruleId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -169,9 +160,8 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegment(ruleId)
                 .build()
                 .toString();
-        CustomRequest<Rule> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Rule>() {
+        CustomRequest<Rule> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Rule>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(rule);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
@@ -2,6 +2,8 @@ package com.auth0.client.mgmt;
 
 import com.auth0.utils.Asserts;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * An implementation of {@link TokenProvider} that simply returns the token it is configured with. This is used
  * when creating the {@link ManagementAPI} with an API token directly. Tokens will not be renewed; consumers are
@@ -18,6 +20,11 @@ public class SimpleTokenProvider implements TokenProvider {
     @Override
     public String getToken() {
         return apiToken;
+    }
+
+    @Override
+    public CompletableFuture<String> getTokenAsync() {
+        return CompletableFuture.supplyAsync(() -> apiToken);
     }
 
     private SimpleTokenProvider(String apiToken) {

--- a/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
@@ -1,0 +1,22 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.exception.Auth0Exception;
+import com.auth0.utils.Asserts;
+
+public class SimpleTokenProvider implements TokenProvider {
+    private final String apiToken;
+
+    public static SimpleTokenProvider create(String apiToken) {
+        return new SimpleTokenProvider(apiToken);
+    }
+
+    private SimpleTokenProvider(String apiToken) {
+        Asserts.assertNotNull(apiToken, "api token");
+        this.apiToken = apiToken;
+    }
+
+    @Override
+    public String getToken() {
+        return apiToken;
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
@@ -1,8 +1,13 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.exception.Auth0Exception;
 import com.auth0.utils.Asserts;
 
+/**
+ * An implementation of {@link TokenProvider} that simply returns the token it is configured with. This is used
+ * when creating the {@link ManagementAPI} with an API token directly. Tokens will not be renewed; consumers are
+ * responsible for renewing the token when needed and then calling {@link ManagementAPI#setApiToken(String)} with the
+ * new token.
+ */
 public class SimpleTokenProvider implements TokenProvider {
     private final String apiToken;
 
@@ -10,13 +15,13 @@ public class SimpleTokenProvider implements TokenProvider {
         return new SimpleTokenProvider(apiToken);
     }
 
-    private SimpleTokenProvider(String apiToken) {
-        Asserts.assertNotNull(apiToken, "api token");
-        this.apiToken = apiToken;
-    }
-
     @Override
     public String getToken() {
         return apiToken;
+    }
+
+    private SimpleTokenProvider(String apiToken) {
+        Asserts.assertNotNull(apiToken, "api token");
+        this.apiToken = apiToken;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/StatsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/StatsEntity.java
@@ -23,8 +23,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class StatsEntity extends BaseManagementEntity {
 
-    StatsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    StatsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -40,10 +40,8 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<Integer> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Integer>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Integer>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -68,10 +66,8 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<List<DailyStats>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<DailyStats>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<DailyStats>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     protected String formatDate(Date date) {

--- a/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
@@ -22,8 +22,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class TenantsEntity extends BaseManagementEntity {
 
-    TenantsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    TenantsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -43,10 +43,8 @@ public class TenantsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<Tenant> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<Tenant>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Tenant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -65,9 +63,8 @@ public class TenantsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<Tenant> request = new CustomRequest<>(client, url, HttpMethod.PATCH, new TypeReference<Tenant>() {
+        CustomRequest<Tenant> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Tenant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(tenant);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/TicketsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TicketsEntity.java
@@ -20,8 +20,8 @@ import okhttp3.HttpUrl;
 @SuppressWarnings("WeakerAccess")
 public class TicketsEntity extends BaseManagementEntity {
 
-    TicketsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    TicketsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -40,9 +40,8 @@ public class TicketsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<EmailVerificationTicket> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<EmailVerificationTicket>() {
+        CustomRequest<EmailVerificationTicket> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<EmailVerificationTicket>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(emailVerificationTicket);
         return request;
     }
@@ -63,9 +62,8 @@ public class TicketsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<PasswordChangeTicket> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<PasswordChangeTicket>() {
+        CustomRequest<PasswordChangeTicket> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<PasswordChangeTicket>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(passwordChangeTicket);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/TokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/TokenProvider.java
@@ -2,6 +2,15 @@ package com.auth0.client.mgmt;
 
 import com.auth0.exception.Auth0Exception;
 
+/**
+ * A {@code TokenProvider} is responsible for providing the token used when making authorized requests to the Auth0
+ * Management API.
+ */
 public interface TokenProvider {
+
+    /**
+     * @return the token required when making requests to the Auth0 Management API.
+     * @throws Auth0Exception if the token cannot be retrieved.
+     */
     String getToken() throws Auth0Exception;
 }

--- a/src/main/java/com/auth0/client/mgmt/TokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/TokenProvider.java
@@ -2,6 +2,8 @@ package com.auth0.client.mgmt;
 
 import com.auth0.exception.Auth0Exception;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * A {@code TokenProvider} is responsible for providing the token used when making authorized requests to the Auth0
  * Management API.
@@ -13,4 +15,6 @@ public interface TokenProvider {
      * @throws Auth0Exception if the token cannot be retrieved.
      */
     String getToken() throws Auth0Exception;
+
+    CompletableFuture<String> getTokenAsync();
 }

--- a/src/main/java/com/auth0/client/mgmt/TokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/TokenProvider.java
@@ -1,0 +1,7 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.exception.Auth0Exception;
+
+public interface TokenProvider {
+    String getToken() throws Auth0Exception;
+}

--- a/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
@@ -20,8 +20,8 @@ import okhttp3.HttpUrl;
 @SuppressWarnings("WeakerAccess")
 public class UserBlocksEntity extends BaseManagementEntity {
 
-    UserBlocksEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    UserBlocksEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -40,10 +40,8 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        CustomRequest<UserBlocks> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -62,9 +60,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -83,10 +79,8 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        CustomRequest<UserBlocks> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -105,8 +99,6 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -37,8 +37,8 @@ import static com.auth0.client.mgmt.filter.QueryFilter.KEY_QUERY;
 @SuppressWarnings("WeakerAccess")
 public class UsersEntity extends BaseManagementEntity {
 
-    UsersEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    UsersEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -65,10 +65,8 @@ public class UsersEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        CustomRequest<List<User>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<User>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<User>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -86,10 +84,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users");
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        CustomRequest<UsersPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<UsersPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<UsersPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -115,10 +111,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<User> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<User>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<User>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -137,9 +131,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users")
                 .build()
                 .toString();
-        CustomRequest<User> request = new CustomRequest<>(this.client, url, HttpMethod.POST, new TypeReference<User>() {
+        CustomRequest<User> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<User>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(user);
         return request;
     }
@@ -161,9 +154,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -186,9 +177,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        CustomRequest<User> request = new CustomRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<User>() {
+        CustomRequest<User> request = new CustomRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<User>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(user);
         return request;
     }
@@ -212,10 +202,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<List<Enrollment>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Enrollment>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Enrollment>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -238,10 +226,8 @@ public class UsersEntity extends BaseManagementEntity {
 
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        CustomRequest<LogEventsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -282,9 +268,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(provider)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -306,10 +290,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        EmptyBodyRequest<RecoveryCode> request = new EmptyBodyRequest<>(client, url, HttpMethod.POST, new TypeReference<RecoveryCode>() {
+        return new EmptyBodyRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<RecoveryCode>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -336,9 +318,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<List<Identity>> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
+        CustomRequest<List<Identity>> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("provider", provider);
         request.addParameter("user_id", secondaryUserId);
         if (connectionId != null) {
@@ -368,9 +349,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<List<Identity>> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
+        CustomRequest<List<Identity>> request = new CustomRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("link_with", secondaryIdToken);
 
         return request;
@@ -401,10 +381,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        CustomRequest<List<Identity>> request = new CustomRequest<>(client, url, HttpMethod.DELETE, new TypeReference<List<Identity>>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.DELETE, new TypeReference<List<Identity>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     /**
@@ -429,10 +407,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<PermissionsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
 
@@ -459,9 +435,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("permissions")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -488,9 +463,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("permissions")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -516,10 +490,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<RolesPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<RolesPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RolesPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
 
@@ -546,9 +518,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("roles")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -575,9 +546,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("roles")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -606,10 +576,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        CustomRequest<OrganizationsPage> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        return new CustomRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
-        return request;
     }
 
     private static void encodeAndAddQueryParam(HttpUrl.Builder builder, BaseFilter filter) {

--- a/src/main/java/com/auth0/net/BaseRequest.java
+++ b/src/main/java/com/auth0/net/BaseRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpRequest;
@@ -11,9 +12,15 @@ import java.util.concurrent.CompletableFuture;
 public abstract class BaseRequest<T> implements Request<T> {
 
     private final Auth0HttpClient client;
+    private final TokenProvider tokenProvider;
 
-    BaseRequest(Auth0HttpClient client) {
+    BaseRequest(Auth0HttpClient client, TokenProvider tokenProvider) {
         this.client = client;
+        this.tokenProvider = tokenProvider;
+    }
+
+    TokenProvider getTokenProvider() {
+        return this.tokenProvider;
     }
 
     protected abstract Auth0HttpRequest createRequest() throws Auth0Exception;

--- a/src/main/java/com/auth0/net/BaseRequest.java
+++ b/src/main/java/com/auth0/net/BaseRequest.java
@@ -7,6 +7,7 @@ import com.auth0.net.client.Auth0HttpRequest;
 import com.auth0.net.client.Auth0HttpResponse;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class BaseRequest<T> implements Request<T> {
@@ -23,7 +24,7 @@ public abstract class BaseRequest<T> implements Request<T> {
         return this.tokenProvider;
     }
 
-    protected abstract Auth0HttpRequest createRequest() throws Auth0Exception;
+    protected abstract Auth0HttpRequest createRequest(String apiToken) throws Auth0Exception;
 
     protected abstract T parseResponseBody(Auth0HttpResponse response) throws Auth0Exception;
 
@@ -35,7 +36,11 @@ public abstract class BaseRequest<T> implements Request<T> {
      */
     @Override
     public com.auth0.net.Response<T> execute() throws Auth0Exception {
-        Auth0HttpRequest request = createRequest();
+        String apiToken = null;
+        if (Objects.nonNull(tokenProvider)) {
+            apiToken = tokenProvider.getToken();
+        }
+        Auth0HttpRequest request = createRequest(apiToken);
         try {
             Auth0HttpResponse response = client.sendRequest(request);
             T body = parseResponseBody(response);
@@ -50,17 +55,26 @@ public abstract class BaseRequest<T> implements Request<T> {
     @Override
     public CompletableFuture<com.auth0.net.Response<T>> executeAsync() {
         final CompletableFuture<com.auth0.net.Response<T>> future = new CompletableFuture<>();
-        Auth0HttpRequest request;
+
+        if (Objects.nonNull(tokenProvider)) {
+            return tokenProvider.getTokenAsync().thenCompose(token -> {
+                try {
+                    return client.sendRequestAsync(createRequest(token))
+                        .thenCompose(this::getResponseFuture);
+                } catch (Auth0Exception e) {
+                    future.completeExceptionally(e);
+                    return future;
+                }
+            });
+        }
 
         try {
-            request = createRequest();
+            return client.sendRequestAsync(createRequest(null))
+                .thenCompose(this::getResponseFuture);
         } catch (Auth0Exception e) {
             future.completeExceptionally(e);
             return future;
         }
-
-        return client.sendRequestAsync(request)
-            .thenCompose(this::getResponseFuture);
     }
 
     private CompletableFuture<Response<T>> getResponseFuture(Auth0HttpResponse httpResponse) {

--- a/src/main/java/com/auth0/net/CreateUserRequest.java
+++ b/src/main/java/com/auth0/net/CreateUserRequest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public class CreateUserRequest extends CustomRequest<CreatedUser> implements SignUpRequest {
 
     public CreateUserRequest(Auth0HttpClient client, String url) {
-        super(client, url, HttpMethod.POST, new TypeReference<CreatedUser>() {
+        super(client, null, url, HttpMethod.POST, new TypeReference<CreatedUser>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/CustomRequest.java
+++ b/src/main/java/com/auth0/net/CustomRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.json.ObjectMapperProvider;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpResponse;
@@ -31,15 +32,15 @@ public class CustomRequest<T> extends ExtendedBaseRequest<T> implements Customiz
     private final Map<String, Object> parameters;
     private Object body;
 
-    CustomRequest(Auth0HttpClient client, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType) {
-        super(client, url, method, mapper);
+    CustomRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType) {
+        super(client, tokenProvider, url, method, mapper);
         this.mapper = mapper;
         this.tType = tType;
         this.parameters = new HashMap<>();
     }
 
-    public CustomRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-        this(client, url, method, ObjectMapperProvider.getMapper(), tType);
+    public CustomRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        this(client, tokenProvider, url, method, ObjectMapperProvider.getMapper(), tType);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.HttpMethod;
 import com.auth0.net.client.HttpRequestBody;
@@ -13,8 +14,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
  * @see CustomRequest
  */
 public class EmptyBodyRequest<T> extends CustomRequest<T> {
-    public EmptyBodyRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-        super(client, url, method, tType);
+    public EmptyBodyRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        super(client, tokenProvider, url, method, tType);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/ExtendedBaseRequest.java
+++ b/src/main/java/com/auth0/net/ExtendedBaseRequest.java
@@ -45,9 +45,7 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
     }
 
     @Override
-    protected Auth0HttpRequest createRequest() throws Auth0Exception {
-        // createRequest() called by execute(), so fetch token now
-        String token = getToken();
+    protected Auth0HttpRequest createRequest(String apiToken) throws Auth0Exception {
         HttpRequestBody body;
         try {
             body = this.createRequestBody();
@@ -56,25 +54,17 @@ abstract class ExtendedBaseRequest<T> extends BaseRequest<T> {
         }
         headers.put("Content-Type", getContentType());
 
-        // Auth APIs don't take tokens, but are used...
-        if (Objects.nonNull(token)) {
-            headers.put("Authorization", "Bearer " + token);
+        // Auth APIs don't take tokens
+        if (Objects.nonNull(apiToken)) {
+            headers.put("Authorization", "Bearer " + apiToken);
         }
+
         Auth0HttpRequest request = Auth0HttpRequest.newBuilder(url, method)
             .withBody(body)
             .withHeaders(headers)
             .build();
 
         return request;
-    }
-
-    private String getToken() throws Auth0Exception {
-        TokenProvider tokenProvider = this.getTokenProvider();
-        // may be null for Auth requests, e.g., TokenRequest
-        if (Objects.isNull(tokenProvider)) {
-            return null;
-        }
-        return tokenProvider.getToken();
     }
 
     @Override

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.json.ObjectMapperProvider;
 import com.auth0.net.client.*;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -31,8 +32,8 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
     private final ObjectMapper mapper;
     private int partsCount;
 
-    MultipartRequest(Auth0HttpClient client, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType, Auth0MultipartRequestBody.Builder multipartBuilder) {
-        super(client, url, method, mapper);
+    MultipartRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType, Auth0MultipartRequestBody.Builder multipartBuilder) {
+        super(client, tokenProvider, url, method, mapper);
         if (HttpMethod.GET.equals(method)) {
             throw new IllegalArgumentException("Multipart/form-data requests do not support the GET method.");
         }
@@ -41,8 +42,8 @@ public class MultipartRequest<T> extends ExtendedBaseRequest<T> implements FormD
         this.bodyBuilder = Auth0MultipartRequestBody.newBuilder();
     }
 
-    public MultipartRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-        this(client, url, method, ObjectMapperProvider.getMapper(), tType, Auth0MultipartRequestBody.newBuilder());
+    public MultipartRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        this(client, tokenProvider, url, method, ObjectMapperProvider.getMapper(), tType, Auth0MultipartRequestBody.newBuilder());
     }
 
     @Override

--- a/src/main/java/com/auth0/net/TokenRequest.java
+++ b/src/main/java/com/auth0/net/TokenRequest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 public class TokenRequest extends CustomRequest<TokenHolder> implements AuthRequest {
 
     public TokenRequest(Auth0HttpClient client, String url) {
-        super(client, url, HttpMethod.POST, new TypeReference<TokenHolder>() {
+        super(client, null, url, HttpMethod.POST, new TypeReference<TokenHolder>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/VoidRequest.java
+++ b/src/main/java/com/auth0/net/VoidRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpResponse;
@@ -19,8 +20,8 @@ import java.util.HashMap;
  */
 public class VoidRequest extends CustomRequest<Void> {
 
-    public VoidRequest(Auth0HttpClient client, String url, HttpMethod method) {
-        super(client, url, method, new TypeReference<Void>() {
+    public VoidRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method) {
+        super(client, tokenProvider, url, method, new TypeReference<Void>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -259,9 +259,6 @@ public class DefaultHttpClient implements Auth0HttpClient {
         return dispatcher;
     }
 
-    /**
-     * Builder for {@link DefaultHttpClient} instances.
-     */
     // TODO accept default headers
     public static class Builder {
         private int readTimeout = 10;

--- a/src/test/java/com/auth0/client/mgmt/ManagedTokenProviderTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagedTokenProviderTest.java
@@ -1,0 +1,80 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.client.auth.AuthAPI;
+import com.auth0.json.auth.TokenHolder;
+import com.auth0.net.Response;
+import com.auth0.net.TokenRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static org.mockito.Mockito.*;
+
+public class ManagedTokenProviderTest {
+    private ManagedTokenProvider provider;
+    private AuthAPI authAPI;
+
+    @Before
+    public void setup() {
+        authAPI = Mockito.mock(AuthAPI.class);
+        provider = new ManagedTokenProvider(authAPI);
+    }
+
+    @Test
+    public void fetchesTokenInitially() throws Exception {
+        when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
+        TokenRequest tokenRequest = mock(TokenRequest.class);
+        @SuppressWarnings("unchecked")
+        Response<TokenHolder> tokenHolderResponse = mock(Response.class);
+        TokenHolder tokenHolder = mock(TokenHolder.class);
+
+        when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
+        when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
+        when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
+
+        provider.getToken();
+
+        verify(authAPI, times(1)).requestToken(eq("https://domain.auth0.com/api/v2/"));
+    }
+
+    @Test
+    public void returnsTokenWhenNotExpired() throws Exception {
+        when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
+        TokenRequest tokenRequest = mock(TokenRequest.class);
+        @SuppressWarnings("unchecked")
+        Response<TokenHolder> tokenHolderResponse = mock(Response.class);
+        TokenHolder tokenHolder = mock(TokenHolder.class);
+
+        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(ManagedTokenProvider.LEEWAY + 1)));
+        when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
+        when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
+        when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
+
+        provider.getToken();
+        provider.getToken();
+
+        verify(authAPI, times(1)).requestToken(eq("https://domain.auth0.com/api/v2/"));
+    }
+
+    @Test
+    public void fetchesNewTokenWhenExpired() throws Exception {
+        when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
+        TokenRequest tokenRequest = mock(TokenRequest.class);
+        @SuppressWarnings("unchecked")
+        Response<TokenHolder> tokenHolderResponse = mock(Response.class);
+        TokenHolder tokenHolder = mock(TokenHolder.class);
+
+        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(ManagedTokenProvider.LEEWAY - 1)));
+        when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
+        when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
+        when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
+
+        provider.getToken();
+        provider.getToken();
+
+        verify(authAPI, times(2)).requestToken(eq("https://domain.auth0.com/api/v2/"));
+    }
+}

--- a/src/test/java/com/auth0/client/mgmt/ManagedTokenProviderTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagedTokenProviderTest.java
@@ -4,6 +4,8 @@ import com.auth0.client.auth.AuthAPI;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.net.Response;
 import com.auth0.net.TokenRequest;
+import com.auth0.net.client.Auth0HttpClient;
+import com.auth0.net.client.DefaultHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -11,16 +13,44 @@ import org.mockito.Mockito;
 import java.time.Instant;
 import java.util.Date;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class ManagedTokenProviderTest {
-    private ManagedTokenProvider provider;
+    private ManagedTokenProvider.Builder providerBuilder;
     private AuthAPI authAPI;
 
     @Before
     public void setup() {
         authAPI = Mockito.mock(AuthAPI.class);
-        provider = new ManagedTokenProvider(authAPI);
+        providerBuilder = ManagedTokenProvider.newBuilder("https://domain.auth0.com/", "clientId", "clientSecret")
+            .withAuthAPI(authAPI);
+    }
+
+    @Test
+    public void throwsWhenLeewayIsNegative() {
+        IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, () ->
+            ManagedTokenProvider.newBuilder("domain", "clientId", "clientSecret")
+                .withLeeway(-1).build()
+        );
+        assertThat(iae.getMessage(), is("leeway must be a positive number of seconds"));
+    }
+
+    @Test
+    public void sameHttpClientCanBeUsed() {
+        Auth0HttpClient httpClient = DefaultHttpClient.newBuilder().build();
+
+        ManagedTokenProvider tokenProvider = ManagedTokenProvider.newBuilder("domain", "clientId", "clientSecret")
+            .withHttpClient(httpClient)
+            .build();
+        ManagementAPI api = ManagementAPI.newBuilder("domain", tokenProvider)
+            .withTokenProvider(tokenProvider)
+            .withHttpClient(httpClient)
+            .build();
+
+        assertThat(tokenProvider.getHttpClient(), is(api.getHttpClient()));
     }
 
     @Test
@@ -35,24 +65,27 @@ public class ManagedTokenProviderTest {
         when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
         when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
 
-        provider.getToken();
+        providerBuilder.build().getToken();
 
         verify(authAPI, times(1)).requestToken(eq("https://domain.auth0.com/api/v2/"));
     }
 
     @Test
     public void returnsTokenWhenNotExpired() throws Exception {
+        int defaultLeeway = 10;
+
         when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
         TokenRequest tokenRequest = mock(TokenRequest.class);
         @SuppressWarnings("unchecked")
         Response<TokenHolder> tokenHolderResponse = mock(Response.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
 
-        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(ManagedTokenProvider.LEEWAY + 1)));
+        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(defaultLeeway + 1)));
         when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
         when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
         when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
 
+        TokenProvider provider = providerBuilder.build();
         provider.getToken();
         provider.getToken();
 
@@ -61,17 +94,67 @@ public class ManagedTokenProviderTest {
 
     @Test
     public void fetchesNewTokenWhenExpired() throws Exception {
+        int defaultLeeway = 10;
+
         when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
         TokenRequest tokenRequest = mock(TokenRequest.class);
         @SuppressWarnings("unchecked")
         Response<TokenHolder> tokenHolderResponse = mock(Response.class);
         TokenHolder tokenHolder = mock(TokenHolder.class);
 
-        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(ManagedTokenProvider.LEEWAY - 1)));
+        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(defaultLeeway - 1)));
         when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
         when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
         when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
 
+        TokenProvider provider = providerBuilder.build();
+        provider.getToken();
+        provider.getToken();
+
+        verify(authAPI, times(2)).requestToken(eq("https://domain.auth0.com/api/v2/"));
+    }
+
+    @Test
+    public void returnsTokenWhenNotExpiredWithCustomLeeway() throws Exception {
+        int leeway = 15;
+
+        when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
+        TokenRequest tokenRequest = mock(TokenRequest.class);
+        @SuppressWarnings("unchecked")
+        Response<TokenHolder> tokenHolderResponse = mock(Response.class);
+        TokenHolder tokenHolder = mock(TokenHolder.class);
+
+        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(leeway + 1)));
+        when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
+        when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
+        when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
+
+        TokenProvider provider = providerBuilder
+            .withLeeway(leeway)
+            .build();
+        provider.getToken();
+        provider.getToken();
+
+        verify(authAPI, times(1)).requestToken(eq("https://domain.auth0.com/api/v2/"));
+    }
+
+    @Test
+    public void fetchesNewTokenWhenExpiredWithCustomLeeway() throws Exception {
+        int leeway = 15;
+        when(authAPI.getManagementAPIAudience()).thenReturn("https://domain.auth0.com/api/v2/");
+        TokenRequest tokenRequest = mock(TokenRequest.class);
+        @SuppressWarnings("unchecked")
+        Response<TokenHolder> tokenHolderResponse = mock(Response.class);
+        TokenHolder tokenHolder = mock(TokenHolder.class);
+
+        when(tokenHolder.getExpiresAt()).thenReturn(Date.from(Instant.now().plusSeconds(leeway - 1)));
+        when(tokenRequest.execute()).thenReturn(tokenHolderResponse);
+        when(tokenHolderResponse.getBody()).thenReturn(tokenHolder);
+        when(authAPI.requestToken("https://domain.auth0.com/api/v2/")).thenReturn(tokenRequest);
+
+        TokenProvider provider = providerBuilder
+            .withLeeway(leeway)
+            .build();
         provider.getToken();
         provider.getToken();
 

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import static com.auth0.client.UrlMatcher.isUrl;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThrows;
 
 public class ManagementAPITest {
 

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -2,6 +2,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.client.HttpOptions;
 import com.auth0.client.MockServer;
+import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpRequest;
 import com.auth0.net.client.Auth0HttpResponse;
@@ -105,7 +106,7 @@ public class ManagementAPITest {
     public void shouldThrowWhenApiTokenIsNull() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'api token' cannot be null!");
-        ManagementAPI.newBuilder(DOMAIN, null).build();
+        ManagementAPI.newBuilder(DOMAIN, (String) null).build();
     }
 
     @Test
@@ -118,65 +119,50 @@ public class ManagementAPITest {
     }
 
     @Test
-    public void shouldUpdateApiToken() {
+    public void shouldUpdateApiToken() throws Auth0Exception {
         //Initialize with a token
         ManagementAPI api = ManagementAPI.newBuilder(DOMAIN, "first token").build();
 
-        assertThat(api.blacklists().apiToken, is("first token"));
-        assertThat(api.clientGrants().apiToken, is("first token"));
-        assertThat(api.clients().apiToken, is("first token"));
-        assertThat(api.connections().apiToken, is("first token"));
-        assertThat(api.deviceCredentials().apiToken, is("first token"));
-        assertThat(api.emailProvider().apiToken, is("first token"));
-        assertThat(api.emailTemplates().apiToken, is("first token"));
-        assertThat(api.grants().apiToken, is("first token"));
-        assertThat(api.guardian().apiToken, is("first token"));
-        assertThat(api.jobs().apiToken, is("first token"));
-        assertThat(api.logEvents().apiToken, is("first token"));
-        assertThat(api.resourceServers().apiToken, is("first token"));
-        assertThat(api.rules().apiToken, is("first token"));
-        assertThat(api.stats().apiToken, is("first token"));
-        assertThat(api.tenants().apiToken, is("first token"));
-        assertThat(api.tickets().apiToken, is("first token"));
-        assertThat(api.userBlocks().apiToken, is("first token"));
-        assertThat(api.users().apiToken, is("first token"));
+        assertThat(api.blacklists().tokenProvider.getToken(), is("first token"));
+        assertThat(api.clientGrants().tokenProvider.getToken(), is("first token"));
+        assertThat(api.clients().tokenProvider.getToken(), is("first token"));
+        assertThat(api.connections().tokenProvider.getToken(), is("first token"));
+        assertThat(api.deviceCredentials().tokenProvider.getToken(), is("first token"));
+        assertThat(api.emailProvider().tokenProvider.getToken(), is("first token"));
+        assertThat(api.emailTemplates().tokenProvider.getToken(), is("first token"));
+        assertThat(api.grants().tokenProvider.getToken(), is("first token"));
+        assertThat(api.guardian().tokenProvider.getToken(), is("first token"));
+        assertThat(api.jobs().tokenProvider.getToken(), is("first token"));
+        assertThat(api.logEvents().tokenProvider.getToken(), is("first token"));
+        assertThat(api.resourceServers().tokenProvider.getToken(), is("first token"));
+        assertThat(api.rules().tokenProvider.getToken(), is("first token"));
+        assertThat(api.stats().tokenProvider.getToken(), is("first token"));
+        assertThat(api.tenants().tokenProvider.getToken(), is("first token"));
+        assertThat(api.tickets().tokenProvider.getToken(), is("first token"));
+        assertThat(api.userBlocks().tokenProvider.getToken(), is("first token"));
+        assertThat(api.users().tokenProvider.getToken(), is("first token"));
 
         //Update the token
         api.setApiToken("new token");
 
-        assertThat(api.blacklists().apiToken, is("new token"));
-        assertThat(api.clientGrants().apiToken, is("new token"));
-        assertThat(api.clients().apiToken, is("new token"));
-        assertThat(api.connections().apiToken, is("new token"));
-        assertThat(api.deviceCredentials().apiToken, is("new token"));
-        assertThat(api.emailProvider().apiToken, is("new token"));
-        assertThat(api.emailTemplates().apiToken, is("new token"));
-        assertThat(api.grants().apiToken, is("new token"));
-        assertThat(api.guardian().apiToken, is("new token"));
-        assertThat(api.jobs().apiToken, is("new token"));
-        assertThat(api.logEvents().apiToken, is("new token"));
-        assertThat(api.resourceServers().apiToken, is("new token"));
-        assertThat(api.rules().apiToken, is("new token"));
-        assertThat(api.stats().apiToken, is("new token"));
-        assertThat(api.tenants().apiToken, is("new token"));
-        assertThat(api.tickets().apiToken, is("new token"));
-        assertThat(api.userBlocks().apiToken, is("new token"));
-        assertThat(api.users().apiToken, is("new token"));
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void acceptsHttpOptions() {
-        HttpOptions httpOptions = new HttpOptions();
-        httpOptions.setConnectTimeout(15);
-        ManagementAPI api = new ManagementAPI(DOMAIN, "CLIENT_ID", httpOptions);
-        assertThat(api, is(notNullValue()));
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void httpOptionsShouldThrowWhenNull() {
-        assertThrows(IllegalArgumentException.class, () -> new ManagementAPI(DOMAIN, API_TOKEN, null));
+        assertThat(api.blacklists().tokenProvider.getToken(), is("new token"));
+        assertThat(api.clientGrants().tokenProvider.getToken(), is("new token"));
+        assertThat(api.clients().tokenProvider.getToken(), is("new token"));
+        assertThat(api.connections().tokenProvider.getToken(), is("new token"));
+        assertThat(api.deviceCredentials().tokenProvider.getToken(), is("new token"));
+        assertThat(api.emailProvider().tokenProvider.getToken(), is("new token"));
+        assertThat(api.emailTemplates().tokenProvider.getToken(), is("new token"));
+        assertThat(api.grants().tokenProvider.getToken(), is("new token"));
+        assertThat(api.guardian().tokenProvider.getToken(), is("new token"));
+        assertThat(api.jobs().tokenProvider.getToken(), is("new token"));
+        assertThat(api.logEvents().tokenProvider.getToken(), is("new token"));
+        assertThat(api.resourceServers().tokenProvider.getToken(), is("new token"));
+        assertThat(api.rules().tokenProvider.getToken(), is("new token"));
+        assertThat(api.stats().tokenProvider.getToken(), is("new token"));
+        assertThat(api.tenants().tokenProvider.getToken(), is("new token"));
+        assertThat(api.tickets().tokenProvider.getToken(), is("new token"));
+        assertThat(api.userBlocks().tokenProvider.getToken(), is("new token"));
+        assertThat(api.users().tokenProvider.getToken(), is("new token"));
     }
 
     @Test

--- a/src/test/java/com/auth0/net/BaseRequestTest.java
+++ b/src/test/java/com/auth0/net/BaseRequestTest.java
@@ -29,7 +29,7 @@ public class BaseRequestTest {
         DefaultHttpClient client = mock(DefaultHttpClient.class);
         when(client.sendRequest(any())).thenThrow(IOException.class);
 
-        BaseRequest<String> req = new BaseRequest<String>(client) {
+        BaseRequest<String> req = new BaseRequest<String>(client, null) {
             @Override
             protected Auth0HttpRequest createRequest() throws Auth0Exception {
                 return null;
@@ -49,7 +49,7 @@ public class BaseRequestTest {
     public void asyncHandlesIOExceptionWhenCreatingRequest() throws Exception {
         DefaultHttpClient client = DefaultHttpClient.newBuilder().build();
 
-        BaseRequest<String> req = new BaseRequest<String>(client) {
+        BaseRequest<String> req = new BaseRequest<String>(client, null) {
             @Override
             protected Auth0HttpRequest createRequest() throws Auth0Exception {
                 throw new Auth0Exception("error", new IOException("boom"));

--- a/src/test/java/com/auth0/net/BaseRequestTest.java
+++ b/src/test/java/com/auth0/net/BaseRequestTest.java
@@ -31,7 +31,7 @@ public class BaseRequestTest {
 
         BaseRequest<String> req = new BaseRequest<String>(client, null) {
             @Override
-            protected Auth0HttpRequest createRequest() throws Auth0Exception {
+            protected Auth0HttpRequest createRequest(String token) throws Auth0Exception {
                 return null;
             }
 
@@ -51,7 +51,7 @@ public class BaseRequestTest {
 
         BaseRequest<String> req = new BaseRequest<String>(client, null) {
             @Override
-            protected Auth0HttpRequest createRequest() throws Auth0Exception {
+            protected Auth0HttpRequest createRequest(String token) throws Auth0Exception {
                 throw new Auth0Exception("error", new IOException("boom"));
             }
 

--- a/src/test/java/com/auth0/net/CustomRequestTest.java
+++ b/src/test/java/com/auth0/net/CustomRequestTest.java
@@ -24,6 +24,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static com.auth0.client.MockServer.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,7 +56,18 @@ public class CustomRequestTest {
         };
         voidType = new TypeReference<Void>() {
         };
-        tokenProvider = () -> "Bearer xyz";
+        tokenProvider = new TokenProvider() {
+            @Override
+            public String getToken() throws Auth0Exception {
+                return "Bearer xyz";
+            }
+
+            @Override
+            public CompletableFuture<String> getTokenAsync() {
+                return CompletableFuture.completedFuture("Bearer xyz");
+            }
+        };
+//        tokenProvider = () -> "Bearer xyz";
     }
 
     @After

--- a/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
@@ -41,7 +41,7 @@ public class EmptyBodyRequestTest {
 
     @Test
     public void shouldCreateEmptyRequestBody() throws Exception {
-        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, null, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
@@ -53,7 +53,7 @@ public class EmptyBodyRequestTest {
 
     @Test
     public void shouldNotAddParameters() throws Exception {
-        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, null, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         Map mapValue = mock(Map.class);
         request.addParameter("key", "value");
         request.addParameter("map", mapValue);

--- a/src/test/java/com/auth0/net/MultipartRequestTest.java
+++ b/src/test/java/com/auth0/net/MultipartRequestTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static com.auth0.client.MockServer.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,6 +58,10 @@ public class MultipartRequestTest {
             @Override
             public String getToken() throws Auth0Exception {
                 return "xyz";
+            }
+            @Override
+            public CompletableFuture<String> getTokenAsync() {
+                return CompletableFuture.completedFuture("xyz");
             }
         };
     }

--- a/src/test/java/com/auth0/net/MultipartRequestTest.java
+++ b/src/test/java/com/auth0/net/MultipartRequestTest.java
@@ -1,6 +1,7 @@
 package com.auth0.net;
 
 import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.exception.APIException;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.exception.RateLimitException;
@@ -40,6 +41,8 @@ public class MultipartRequestTest {
     private TypeReference<List> listType;
     private TypeReference<Void> voidType;
 
+    private TokenProvider tokenProvider;
+
     @Before
     public void setUp() throws Exception {
         server = new MockServer();
@@ -49,6 +52,12 @@ public class MultipartRequestTest {
         listType = new TypeReference<List>() {
         };
         voidType = new TypeReference<Void>() {
+        };
+        tokenProvider = new TokenProvider() {
+            @Override
+            public String getToken() throws Auth0Exception {
+                return "xyz";
+            }
         };
     }
 
@@ -61,12 +70,12 @@ public class MultipartRequestTest {
     public void shouldNotSupportGETMethod() {
         exception.expect(instanceOf(IllegalArgumentException.class));
         exception.expectMessage("Multipart/form-data requests do not support the GET method.");
-        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.GET, tokenHolderType);
+        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.GET, tokenHolderType);
     }
 
     @Test
     public void shouldCreatePOSTRequest() throws Exception {
-        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         assertThat(request, is(notNullValue()));
         request.addPart("non_empty", "body");
 
@@ -83,7 +92,7 @@ public class MultipartRequestTest {
 //        MultipartBody.Builder bodyBuilder = new MultipartBody.Builder(boundary);
         Auth0MultipartRequestBody.Builder bodyBuilder = Auth0MultipartRequestBody.newBuilder();
 //        MultipartBody.Builder bodyBuilder = new MultipartBody.Builder(boundary);
-        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, new ObjectMapper(), tokenHolderType, bodyBuilder);
+        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, new ObjectMapper(), tokenHolderType, bodyBuilder);
 
         File fileValue = new File(MULTIPART_SAMPLE);
         request.addPart("keyName", "keyValue");
@@ -111,7 +120,7 @@ public class MultipartRequestTest {
     @Test
     public void shouldNotOverrideContentTypeHeader() throws Exception {
         Auth0MultipartRequestBody.Builder bodyBuilder = Auth0MultipartRequestBody.newBuilder();
-        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, new ObjectMapper(), tokenHolderType, bodyBuilder);
+        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, new ObjectMapper(), tokenHolderType, bodyBuilder);
         request.addPart("non_empty", "body");
         request.addHeader("Content-Type", "plaintext");
 
@@ -124,24 +133,25 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldAddHeaders() throws Exception {
-        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         request.addPart("non_empty", "body");
         request.addHeader("Extra-Info", "this is a test");
-        request.addHeader("Authorization", "Bearer my_access_token");
+        // TODO test that auth header cannot be overriden?
+//        request.addHeader("Authorization", "Bearer my_access_token");
 
         server.jsonResponse(AUTH_TOKENS, 200);
         request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest.getHeader("Extra-Info"), is("this is a test"));
-        assertThat(recordedRequest.getHeader("Authorization"), is("Bearer my_access_token"));
+        assertThat(recordedRequest.getHeader("Authorization"), is("Bearer xyz"));
     }
 
     @Test
     public void shouldThrowOnBodyCreationFailure() {
         Exception exception = null;
         try {
-            MultipartRequest<Void> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, voidType);
+            MultipartRequest<Void> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, voidType);
             request.execute();
         } catch (Exception e) {
             exception = e;
@@ -155,7 +165,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseSuccessfulResponse() throws Exception {
-        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        MultipartRequest<TokenHolder> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_TOKENS, 200);
         TokenHolder response = request.execute().getBody();
@@ -171,7 +181,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldThrowOnParseInvalidSuccessfulResponse() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_TOKENS, 200);
         Exception exception = null;
@@ -193,7 +203,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseJSONErrorResponseWithErrorDescription() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_ERROR_WITH_ERROR_DESCRIPTION, 400);
         Exception exception = null;
@@ -215,7 +225,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseJSONErrorResponseWithError() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_ERROR_WITH_ERROR, 400);
         Exception exception = null;
@@ -237,7 +247,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseJSONErrorResponseWithDescriptionAndExtraProperties() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_ERROR_WITH_DESCRIPTION_AND_EXTRA_PROPERTIES, 400);
         Exception exception = null;
@@ -261,7 +271,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseJSONErrorResponseWithDescription() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.jsonResponse(AUTH_ERROR_WITH_DESCRIPTION, 400);
         Exception exception = null;
@@ -283,7 +293,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseJSONErrorResponseWithMessage() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.jsonResponse(MGMT_ERROR_WITH_MESSAGE, 400);
         Exception exception = null;
@@ -305,7 +315,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParsePlainTextErrorResponse() throws Exception {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.textResponse(AUTH_ERROR_PLAINTEXT, 400);
         Exception exception = null;
@@ -328,7 +338,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldParseRateLimitsHeaders() {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.rateLimitReachedResponse(100, 10, 5);
         Exception exception = null;
@@ -354,7 +364,7 @@ public class MultipartRequestTest {
 
     @Test
     public void shouldDefaultRateLimitsHeadersWhenMissing() {
-        MultipartRequest<List> request = new MultipartRequest<>(client, server.getBaseUrl(), HttpMethod.POST, listType);
+        MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.rateLimitReachedResponse(-1, -1, -1);
         Exception exception = null;

--- a/src/test/java/com/auth0/net/VoidRequestTest.java
+++ b/src/test/java/com/auth0/net/VoidRequestTest.java
@@ -1,6 +1,8 @@
 package com.auth0.net;
 
 import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.TokenProvider;
+import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.*;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
@@ -13,16 +15,18 @@ import static org.hamcrest.Matchers.*;
 public class VoidRequestTest {
     private Auth0HttpClient client;
     private MockServer server;
+    private TokenProvider tokenProvider;
 
     @Before
     public void setUp() throws Exception {
         client = new DefaultHttpClient.Builder().build();
         server = new MockServer();
+        tokenProvider = () -> "Bearer xyz";
     }
 
     @Test
     public void shouldCreateGETRequest() throws Exception {
-        VoidRequest request = new VoidRequest(client, server.getBaseUrl(), HttpMethod.GET);
+        VoidRequest request = new VoidRequest(client, tokenProvider, server.getBaseUrl(), HttpMethod.GET);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
@@ -34,7 +38,7 @@ public class VoidRequestTest {
 
     @Test
     public void shouldCreatePOSTRequest() throws Exception {
-        VoidRequest request = new VoidRequest(client, server.getBaseUrl(), HttpMethod.POST);
+        VoidRequest request = new VoidRequest(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST);
         assertThat(request, is(notNullValue()));
         request.addParameter("non_empty", "body");
 

--- a/src/test/java/com/auth0/net/VoidRequestTest.java
+++ b/src/test/java/com/auth0/net/VoidRequestTest.java
@@ -8,6 +8,8 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.CompletableFuture;
+
 import static com.auth0.client.MockServer.AUTH_TOKENS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -21,7 +23,17 @@ public class VoidRequestTest {
     public void setUp() throws Exception {
         client = new DefaultHttpClient.Builder().build();
         server = new MockServer();
-        tokenProvider = () -> "Bearer xyz";
+        tokenProvider = new TokenProvider() {
+            @Override
+            public String getToken() throws Auth0Exception {
+                return "Bearer xyz";
+            }
+
+            @Override
+            public CompletableFuture<String> getTokenAsync() {
+                return CompletableFuture.completedFuture("Bearer xyz");
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION
This PR adds the ability for the `ManagementAPI` client to fetch, store, and renew tokens used to call the Management API. 

Prior to this change, the `ManagementAPI` client required an API token, and the consumer was responsible for obtaining this token, as well as renewing it if necessary, and then updating the API client by calling `setApiToken("new-token")`. 

As discussed in #473, for usages where the API client may be used beyond the lifespan of the token, having the library itself manage the token would be ideal. This change adds support for that by introducing a `TokenProvider`, which is used by the request classes to obtain the API token and add it to the request headers.

To use this feature, consumers can create a client with a `TokenProvider`. This change adds an implementation for managing the token, `ManagedTokenProvider`:

```java
TokenProvider provider = ManagedTokenProvider.newBuilder("domain", "client-id", "client-secret").build();
ManagementAPI api = ManagementAPI.newBuilder("domain", provider).build();
```

The provider can be further configured to support:
* a custom leeway used to calculate if the token needs to be renewed (default is 10 seconds)
* an `Auth0HttpClient` to use a custom http client implementation or to ensure only one client is used

The ability to create an API client with a token is still supported as it previously was before.

> **Note**
> A nice side-effect of this change is that it removes the responsibility of adding the authorization header from individual entities to the request classes - many of the files changed in this PR will be related to that, as every entity requires updating.