### PR TITLE
Avoid unnecessary http client creation

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -933,7 +933,7 @@ public class AuthAPI {
         private final String domain;
         private final String clientId;
         private final String clientSecret;
-        private Auth0HttpClient httpClient = DefaultHttpClient.newBuilder().build();
+        private Auth0HttpClient httpClient;
 
         /**
          * Create a new Builder
@@ -969,7 +969,8 @@ public class AuthAPI {
          * @return the configured {@code AuthAPI} instance.
          */
         public AuthAPI build() {
-            return new AuthAPI(domain, clientId, clientSecret, httpClient);
+            return new AuthAPI(domain, clientId, clientSecret,
+                Objects.nonNull(httpClient) ? httpClient : DefaultHttpClient.newBuilder().build());
         }
     }
 }


### PR DESCRIPTION
The `AuthAPI` client builder set the value of the httpClient to an instantiated http client, which could then be overridden by callers. This would result in unnecessarily creating an httpClient if it were to be overridden; this change fixes that by only creating an httpClient if one was not specified.