### PR TITLE
Use TokenProvider instead of plain string token

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -249,7 +249,7 @@ public class AuthAPI {
                 .addPathSegment("userinfo")
                 .build()
                 .toString();
-        BaseRequest<UserInfo> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<UserInfo>() {
+        BaseRequest<UserInfo> request = new BaseRequest<>(client, null, url, HttpMethod.GET, new TypeReference<UserInfo>() {
         });
         request.addHeader("Authorization", "Bearer " + accessToken);
         return request;
@@ -284,7 +284,7 @@ public class AuthAPI {
                 .addPathSegment("change_password")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(client, null, url, HttpMethod.POST);
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_EMAIL, email);
         request.addParameter(KEY_CONNECTION, connection);
@@ -659,7 +659,7 @@ public class AuthAPI {
                 .addPathSegment(PATH_REVOKE)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(client, null, url, HttpMethod.POST);
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_TOKEN, refreshToken);
         addSecret(request, false);
@@ -809,7 +809,7 @@ public class AuthAPI {
                 .build()
                 .toString();
 
-        BaseRequest<PasswordlessEmailResponse> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<PasswordlessEmailResponse>() {
+        BaseRequest<PasswordlessEmailResponse> request = new BaseRequest<>(client, null, url, HttpMethod.POST, new TypeReference<PasswordlessEmailResponse>() {
         });
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_CONNECTION, "email");
@@ -851,7 +851,7 @@ public class AuthAPI {
                 .build()
                 .toString();
 
-        BaseRequest<PasswordlessSmsResponse> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<PasswordlessSmsResponse>() {
+        BaseRequest<PasswordlessSmsResponse> request = new BaseRequest<>(client, null, url, HttpMethod.POST, new TypeReference<PasswordlessSmsResponse>() {
         });
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_CONNECTION, "sms");

--- a/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
@@ -35,8 +35,8 @@ public class ActionsEntity extends BaseManagementEntity {
 
     private final static String AUTHORIZATION_HEADER = "Authorization";
 
-    ActionsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ActionsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -57,10 +57,9 @@ public class ActionsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        BaseRequest<Action> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<Action>() {
+        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Action>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(action);
         return request;
     }
@@ -84,10 +83,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Action> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Action>() {
+        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Action>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -125,8 +123,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest = new VoidRequest(client, url, HttpMethod.DELETE);
-        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest voidRequest =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return voidRequest;
     }
 
@@ -144,10 +141,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Triggers> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Triggers>() {
+        BaseRequest<Triggers> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Triggers>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -173,11 +169,10 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Action> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<Action>() {
+        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Action>() {
         });
 
         request.setBody(action);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -204,10 +199,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        EmptyBodyRequest<Version> request = new EmptyBodyRequest<>(client, url, HttpMethod.POST, new TypeReference<Version>() {
+        EmptyBodyRequest<Version> request =  new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Version>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -235,10 +229,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Version> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Version>() {
+        BaseRequest<Version> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Version>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -269,10 +262,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .toString();
 
         // Needed to successfully call the roll-back endpoint until DXEX-1738 is resolved.
-        EmptyObjectRequest<Version> request = new EmptyObjectRequest<>(client, url, HttpMethod.POST, new TypeReference<Version>() {
+        EmptyObjectRequest<Version> request = new EmptyObjectRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Version>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -297,10 +289,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Execution> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Execution>() {
+        BaseRequest<Execution> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Execution>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -321,10 +312,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<ActionsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<ActionsPage>() {
+        BaseRequest<ActionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ActionsPage>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -353,10 +343,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<VersionsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<VersionsPage>() {
+        BaseRequest<VersionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<VersionsPage>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -386,10 +375,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<BindingsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<BindingsPage>() {
+        BaseRequest<BindingsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<BindingsPage>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -418,11 +406,10 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<BindingsPage> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<BindingsPage>() {
+        BaseRequest<BindingsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<BindingsPage>() {
         });
 
         request.setBody(bindingsUpdateRequest);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -434,8 +421,8 @@ public class ActionsEntity extends BaseManagementEntity {
 
     // Temporary request implementation to send an empty json object on the request body.
     private static class EmptyObjectRequest<T> extends EmptyBodyRequest<T> {
-        EmptyObjectRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-            super(client, url, method, tType);
+        EmptyObjectRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+            super(client, tokenProvider, url, method, tType);
         }
 
         @Override

--- a/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
@@ -55,7 +55,7 @@ public class ActionsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Action>() {
+        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Action>() {
         });
 
         request.setBody(action);
@@ -81,7 +81,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Action>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Action>() {
         });
     }
 
@@ -136,7 +136,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Triggers>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Triggers>() {
         });
     }
 
@@ -162,7 +162,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Action>() {
+        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Action>() {
         });
 
         request.setBody(action);
@@ -192,7 +192,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Version>() {
+        return new EmptyBodyRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Version>() {
         });
     }
 
@@ -220,7 +220,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Version>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Version>() {
         });
     }
 
@@ -277,7 +277,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Execution>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Execution>() {
         });
     }
 
@@ -299,7 +299,7 @@ public class ActionsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ActionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ActionsPage>() {
         });
     }
 
@@ -329,7 +329,7 @@ public class ActionsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<VersionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<VersionsPage>() {
         });
     }
 
@@ -360,7 +360,7 @@ public class ActionsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<BindingsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<BindingsPage>() {
         });
     }
 
@@ -389,7 +389,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<BindingsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<BindingsPage>() {
+        BaseRequest<BindingsPage> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<BindingsPage>() {
         });
 
         request.setBody(bindingsUpdateRequest);

--- a/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ActionsEntity.java
@@ -33,8 +33,6 @@ public class ActionsEntity extends BaseManagementEntity {
     private final static String EXECUTIONS_PATH = "executions";
     private final static String BINDINGS_PATH = "bindings";
 
-    private final static String AUTHORIZATION_HEADER = "Authorization";
-
     ActionsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
         super(client, baseUrl, tokenProvider);
     }
@@ -83,10 +81,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Action> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Action>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Action>() {
         });
-
-        return request;
     }
 
     /**
@@ -123,8 +119,7 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return voidRequest;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -141,10 +136,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Triggers> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Triggers>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Triggers>() {
         });
-
-        return request;
     }
 
     /**
@@ -199,10 +192,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        EmptyBodyRequest<Version> request =  new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Version>() {
+        return new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Version>() {
         });
-
-        return request;
     }
 
     /**
@@ -229,10 +220,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Version> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Version>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Version>() {
         });
-
-        return request;
     }
 
     /**
@@ -262,10 +251,9 @@ public class ActionsEntity extends BaseManagementEntity {
             .toString();
 
         // Needed to successfully call the roll-back endpoint until DXEX-1738 is resolved.
-        EmptyObjectRequest<Version> request = new EmptyObjectRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Version>() {
-        });
 
-        return request;
+        return new EmptyObjectRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Version>() {
+        });
     }
 
     /**
@@ -289,10 +277,8 @@ public class ActionsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Execution> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Execution>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Execution>() {
         });
-
-        return request;
     }
 
     /**
@@ -312,10 +298,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<ActionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ActionsPage>() {
-        });
 
-        return request;
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ActionsPage>() {
+        });
     }
 
     /**
@@ -343,10 +328,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<VersionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<VersionsPage>() {
-        });
 
-        return request;
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<VersionsPage>() {
+        });
     }
 
     /**
@@ -375,10 +359,9 @@ public class ActionsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<BindingsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<BindingsPage>() {
-        });
 
-        return request;
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<BindingsPage>() {
+        });
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/AttackProtectionEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/AttackProtectionEntity.java
@@ -15,8 +15,8 @@ import okhttp3.HttpUrl;
  * @see ManagementAPI
  */
 public class AttackProtectionEntity extends BaseManagementEntity {
-    AttackProtectionEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    AttackProtectionEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BaseManagementEntity.java
@@ -10,19 +10,18 @@ import java.util.function.Consumer;
 
 abstract class BaseManagementEntity {
     protected final Auth0HttpClient client;
-    // TODO decouple from OkHttp!!
     protected final HttpUrl baseUrl;
-    protected final String apiToken;
+    protected final TokenProvider tokenProvider;
 
-    BaseManagementEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
+    BaseManagementEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
         this.client = client;
         this.baseUrl = baseUrl;
-        this.apiToken = apiToken;
+        this.tokenProvider = tokenProvider;
     }
 
     protected Request<Void> voidRequest(HttpMethod method, Consumer<RequestBuilder<Void>> customizer) {
         return customizeRequest(
-            new RequestBuilder<>(client, method, baseUrl, new TypeReference<Void>() {
+            new RequestBuilder<>(client, tokenProvider, method, baseUrl, new TypeReference<Void>() {
             }),
             customizer
         );
@@ -30,13 +29,12 @@ abstract class BaseManagementEntity {
 
     protected <T> Request<T> request(HttpMethod method, TypeReference<T> target, Consumer<RequestBuilder<T>> customizer) {
         return customizeRequest(
-            new RequestBuilder<>(client, method, baseUrl, target),
+            new RequestBuilder<>(client, tokenProvider, method, baseUrl, target),
             customizer
         );
     }
 
     private <T> Request<T> customizeRequest(RequestBuilder<T> builder, Consumer<RequestBuilder<T>> customizer) {
-        builder.withHeader("Authorization", "Bearer " + apiToken);
         customizer.accept(builder);
         return builder.build();
     }

--- a/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
@@ -22,8 +22,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class BlacklistsEntity extends BaseManagementEntity {
 
-    BlacklistsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    BlacklistsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -42,9 +42,8 @@ public class BlacklistsEntity extends BaseManagementEntity {
                 .addQueryParameter("aud", audience)
                 .build()
                 .toString();
-        BaseRequest<List<Token>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Token>>() {
+        BaseRequest<List<Token>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Token>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -63,8 +62,7 @@ public class BlacklistsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/blacklists/tokens")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.POST);
         request.setBody(token);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
@@ -42,7 +42,7 @@ public class BlacklistsEntity extends BaseManagementEntity {
                 .addQueryParameter("aud", audience)
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Token>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Token>>() {
         });
     }
 

--- a/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BlacklistsEntity.java
@@ -42,9 +42,8 @@ public class BlacklistsEntity extends BaseManagementEntity {
                 .addQueryParameter("aud", audience)
                 .build()
                 .toString();
-        BaseRequest<List<Token>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Token>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Token>>() {
         });
-        return request;
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/BrandingEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/BrandingEntity.java
@@ -20,8 +20,8 @@ import okhttp3.HttpUrl;
 @SuppressWarnings("WeakerAccess")
 public class BrandingEntity extends BaseManagementEntity {
 
-    BrandingEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    BrandingEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -47,9 +47,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<ClientGrantsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
         });
-        return request;
     }
 
     /**
@@ -67,9 +66,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        BaseRequest<List<ClientGrant>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
         });
-        return request;
     }
 
     /**
@@ -116,8 +114,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegment(clientGrantId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class ClientGrantsEntity extends BaseManagementEntity {
 
-    ClientGrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ClientGrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -47,9 +47,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<ClientGrantsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
+        BaseRequest<ClientGrantsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -68,9 +67,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        BaseRequest<List<ClientGrant>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
+        BaseRequest<List<ClientGrant>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -93,9 +91,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        BaseRequest<ClientGrant> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<ClientGrant>() {
+        BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<ClientGrant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("client_id", clientId);
         request.addParameter("audience", audience);
         request.addParameter("scope", scope);
@@ -119,8 +116,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegment(clientGrantId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -142,9 +138,8 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegment(clientGrantId)
                 .build()
                 .toString();
-        BaseRequest<ClientGrant> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<ClientGrant>() {
+        BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<ClientGrant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("scope", scope);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -47,7 +47,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ClientGrantsPage>() {
         });
     }
 
@@ -66,7 +66,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
         });
     }
 
@@ -89,7 +89,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/client-grants")
                 .build()
                 .toString();
-        BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<ClientGrant>() {
+        BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<ClientGrant>() {
         });
         request.addParameter("client_id", clientId);
         request.addParameter("audience", audience);
@@ -135,7 +135,7 @@ public class ClientGrantsEntity extends BaseManagementEntity {
                 .addPathSegment(clientGrantId)
                 .build()
                 .toString();
-        BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<ClientGrant>() {
+        BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<ClientGrant>() {
         });
         request.addParameter("scope", scope);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -27,8 +27,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class ClientsEntity extends BaseManagementEntity {
 
-    ClientsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ClientsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -46,9 +46,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        BaseRequest<List<Client>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Client>>() {
+        BaseRequest<List<Client>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Client>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -69,9 +68,8 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<ClientsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<ClientsPage>() {
+        BaseRequest<ClientsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -91,9 +89,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        BaseRequest<Client> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Client>() {
+        BaseRequest<Client> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -118,9 +115,8 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Client> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Client>() {
+        BaseRequest<Client> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -139,9 +135,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        BaseRequest<Client> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Client>() {
+        BaseRequest<Client> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(client);
         return request;
     }
@@ -162,8 +157,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -185,9 +179,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        BaseRequest<Client> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Client>() {
+        BaseRequest<Client> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(client);
         return request;
     }
@@ -210,9 +203,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment("rotate-secret")
                 .build()
                 .toString();
-        BaseRequest<Client> request = new EmptyBodyRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Client>() {
+        BaseRequest<Client> request = new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Client>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -46,7 +46,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Client>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Client>>() {
         });
     }
 
@@ -67,7 +67,7 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ClientsPage>() {
         });
     }
 
@@ -87,7 +87,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Client>() {
         });
     }
 
@@ -112,7 +112,7 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Client>() {
         });
     }
 
@@ -131,7 +131,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        BaseRequest<Client> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Client>() {
+        BaseRequest<Client> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Client>() {
         });
         request.setBody(client);
         return request;
@@ -174,7 +174,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        BaseRequest<Client> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Client>() {
+        BaseRequest<Client> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Client>() {
         });
         request.setBody(client);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -46,9 +46,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/clients")
                 .build()
                 .toString();
-        BaseRequest<List<Client>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Client>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Client>>() {
         });
-        return request;
     }
 
     /**
@@ -68,9 +67,8 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<ClientsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ClientsPage>() {
         });
-        return request;
     }
 
     /**
@@ -89,9 +87,8 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        BaseRequest<Client> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
         });
-        return request;
     }
 
     /**
@@ -115,9 +112,8 @@ public class ClientsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Client> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Client>() {
         });
-        return request;
     }
 
     /**
@@ -157,8 +153,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment(clientId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -203,8 +198,7 @@ public class ClientsEntity extends BaseManagementEntity {
                 .addPathSegment("rotate-secret")
                 .build()
                 .toString();
-        BaseRequest<Client> request = new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Client>() {
+        return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Client>() {
         });
-        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
@@ -47,7 +47,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ConnectionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<ConnectionsPage>() {
         });
     }
 
@@ -75,7 +75,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Connection>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Connection>>() {
         });
     }
 
@@ -100,7 +100,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Connection>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Connection>() {
         });
     }
 
@@ -119,7 +119,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/connections")
                 .build()
                 .toString();
-        BaseRequest<Connection> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Connection>() {
+        BaseRequest<Connection> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Connection>() {
         });
         request.setBody(connection);
         return request;
@@ -162,7 +162,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegment(connectionId)
                 .build()
                 .toString();
-        BaseRequest<Connection> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Connection>() {
+        BaseRequest<Connection> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Connection>() {
         });
         request.setBody(connection);
         return request;
@@ -188,6 +188,6 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addQueryParameter("email", email)
                 .build()
                 .toString();
-        return new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
+        return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class ConnectionsEntity extends BaseManagementEntity {
 
-    ConnectionsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ConnectionsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
 
@@ -47,9 +47,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<ConnectionsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<ConnectionsPage>() {
+        BaseRequest<ConnectionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ConnectionsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -77,9 +76,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<List<Connection>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Connection>>() {
+        BaseRequest<List<Connection>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Connection>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -104,9 +102,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Connection> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Connection>() {
+        BaseRequest<Connection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Connection>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -125,9 +122,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/connections")
                 .build()
                 .toString();
-        BaseRequest<Connection> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Connection>() {
+        BaseRequest<Connection> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Connection>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -148,8 +144,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegment(connectionId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -171,9 +166,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegment(connectionId)
                 .build()
                 .toString();
-        BaseRequest<Connection> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Connection>() {
+        BaseRequest<Connection> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Connection>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -198,8 +192,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addQueryParameter("email", email)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
@@ -47,9 +47,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<ConnectionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ConnectionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<ConnectionsPage>() {
         });
-        return request;
     }
 
 
@@ -76,9 +75,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<List<Connection>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Connection>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Connection>>() {
         });
-        return request;
     }
 
     /**
@@ -102,9 +100,8 @@ public class ConnectionsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Connection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Connection>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Connection>() {
         });
-        return request;
     }
 
     /**
@@ -144,8 +141,7 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addPathSegment(connectionId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -192,7 +188,6 @@ public class ConnectionsEntity extends BaseManagementEntity {
                 .addQueryParameter("email", email)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
@@ -45,9 +45,8 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<List<DeviceCredentials>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
         });
-        return request;
     }
 
     /**
@@ -87,7 +86,6 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
                 .addPathSegment(deviceCredentialsId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
@@ -24,8 +24,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class DeviceCredentialsEntity extends BaseManagementEntity {
 
-    DeviceCredentialsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    DeviceCredentialsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -45,9 +45,8 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<List<DeviceCredentials>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
+        BaseRequest<List<DeviceCredentials>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -66,9 +65,8 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/device-credentials")
                 .build()
                 .toString();
-        BaseRequest<DeviceCredentials> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<DeviceCredentials>() {
+        BaseRequest<DeviceCredentials> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<DeviceCredentials>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(deviceCredentials);
         return request;
     }
@@ -89,8 +87,7 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
                 .addPathSegment(deviceCredentialsId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/DeviceCredentialsEntity.java
@@ -45,7 +45,7 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<DeviceCredentials>>() {
         });
     }
 
@@ -64,7 +64,7 @@ public class DeviceCredentialsEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/device-credentials")
                 .build()
                 .toString();
-        BaseRequest<DeviceCredentials> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<DeviceCredentials>() {
+        BaseRequest<DeviceCredentials> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<DeviceCredentials>() {
         });
         request.setBody(deviceCredentials);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
@@ -22,8 +22,8 @@ import java.util.Map;
  */
 @SuppressWarnings("WeakerAccess")
 public class EmailProviderEntity extends BaseManagementEntity {
-    EmailProviderEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    EmailProviderEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -43,9 +43,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<EmailProvider> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<EmailProvider>() {
+        BaseRequest<EmailProvider> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailProvider>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -64,9 +63,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<EmailProvider>() {
+        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EmailProvider>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(emailProvider);
         return request;
     }
@@ -83,8 +81,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -103,9 +100,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<EmailProvider>() {
+        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<EmailProvider>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(emailProvider);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
@@ -43,9 +43,8 @@ public class EmailProviderEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<EmailProvider> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailProvider>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailProvider>() {
         });
-        return request;
     }
 
     /**
@@ -81,8 +80,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailProviderEntity.java
@@ -43,7 +43,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailProvider>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EmailProvider>() {
         });
     }
 
@@ -62,7 +62,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EmailProvider>() {
+        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<EmailProvider>() {
         });
         request.setBody(emailProvider);
         return request;
@@ -98,7 +98,7 @@ public class EmailProviderEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/emails/provider")
                 .build()
                 .toString();
-        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<EmailProvider>() {
+        BaseRequest<EmailProvider> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<EmailProvider>() {
         });
         request.setBody(emailProvider);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -47,9 +47,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .addPathSegment(templateName);
         String url = builder.build().toString();
-        BaseRequest<EmailTemplate> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailTemplate>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailTemplate>() {
         });
-        return request;
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -47,7 +47,7 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .addPathSegment(templateName);
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailTemplate>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EmailTemplate>() {
         });
     }
 
@@ -66,7 +66,7 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .build()
                 .toString();
-        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EmailTemplate>() {
+        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<EmailTemplate>() {
         });
         request.setBody(template);
         return request;
@@ -90,7 +90,7 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegment(templateName)
                 .build()
                 .toString();
-        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<EmailTemplate>() {
+        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<EmailTemplate>() {
         });
         request.setBody(template);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/EmailTemplatesEntity.java
@@ -29,8 +29,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
     public static final String TEMPLATE_PASSWORD_RESET = "password_reset";
     public static final String TEMPLATE_MFA_OOB_CODE = "mfa_oob_code";
 
-    EmailTemplatesEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    EmailTemplatesEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -47,9 +47,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .addPathSegment(templateName);
         String url = builder.build().toString();
-        BaseRequest<EmailTemplate> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<EmailTemplate>() {
+        BaseRequest<EmailTemplate> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EmailTemplate>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -68,9 +67,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/email-templates")
                 .build()
                 .toString();
-        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<EmailTemplate>() {
+        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EmailTemplate>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(template);
         return request;
     }
@@ -93,9 +91,8 @@ public class EmailTemplatesEntity extends BaseManagementEntity {
                 .addPathSegment(templateName)
                 .build()
                 .toString();
-        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<EmailTemplate>() {
+        BaseRequest<EmailTemplate> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<EmailTemplate>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(template);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -51,7 +51,7 @@ public class GrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<GrantsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<GrantsPage>() {
         });
     }
 
@@ -74,7 +74,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Grant>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Grant>>() {
         });
     }
 

--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class GrantsEntity extends BaseManagementEntity {
 
-    GrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    GrantsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -51,9 +51,8 @@ public class GrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<GrantsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<GrantsPage>() {
+        BaseRequest<GrantsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<GrantsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -76,9 +75,8 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        BaseRequest<List<Grant>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Grant>>() {
+        BaseRequest<List<Grant>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Grant>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -98,8 +96,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addPathSegment(grantId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -119,8 +116,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 

--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -51,9 +51,8 @@ public class GrantsEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<GrantsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<GrantsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<GrantsPage>() {
         });
-        return request;
     }
 
     /**
@@ -75,9 +74,8 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        BaseRequest<List<Grant>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Grant>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Grant>>() {
         });
-        return request;
     }
 
     /**
@@ -96,8 +94,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addPathSegment(grantId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -116,8 +113,7 @@ public class GrantsEntity extends BaseManagementEntity {
                 .addQueryParameter("user_id", userId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
 }

--- a/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GuardianEntity.java
@@ -20,8 +20,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class GuardianEntity extends BaseManagementEntity {
 
-    GuardianEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    GuardianEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -53,7 +53,7 @@ public class JobsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Job>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Job>() {
         });
     }
 
@@ -154,7 +154,7 @@ public class JobsEntity extends BaseManagementEntity {
             Asserts.assertNotNull(emailVerificationIdentity.getUserId(), "identity user id");
             requestBody.put("identity", emailVerificationIdentity);
         }
-        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Job>() {
+        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
         });
         request.setBody(requestBody);
         return request;
@@ -184,7 +184,7 @@ public class JobsEntity extends BaseManagementEntity {
             requestBody.putAll(filter.getAsMap());
         }
 
-        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Job>() {
+        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
         });
         request.setBody(requestBody);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -53,9 +53,8 @@ public class JobsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Job>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Job>() {
         });
-        return request;
     }
 
     /**
@@ -78,7 +77,7 @@ public class JobsEntity extends BaseManagementEntity {
 
         TypeReference<List<JobErrorDetails>> jobErrorDetailsListType = new TypeReference<List<JobErrorDetails>>() {
         };
-        BaseRequest<List<JobErrorDetails>> request = new BaseRequest<List<JobErrorDetails>>(client, tokenProvider, url, HttpMethod.GET, jobErrorDetailsListType) {
+        return new BaseRequest<List<JobErrorDetails>>(client, tokenProvider, url, HttpMethod.GET, jobErrorDetailsListType) {
             @Override
             protected List<JobErrorDetails> readResponseBody(Auth0HttpResponse response) throws IOException {
                 if (response.getBody() == null || response.getBody().length() == 0) {
@@ -87,7 +86,6 @@ public class JobsEntity extends BaseManagementEntity {
                 return super.readResponseBody(response);
             }
         };
-        return request;
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -32,8 +32,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class JobsEntity extends BaseManagementEntity {
 
-    JobsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    JobsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -53,9 +53,8 @@ public class JobsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<Job> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Job>() {
+        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Job>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -79,7 +78,7 @@ public class JobsEntity extends BaseManagementEntity {
 
         TypeReference<List<JobErrorDetails>> jobErrorDetailsListType = new TypeReference<List<JobErrorDetails>>() {
         };
-        BaseRequest<List<JobErrorDetails>> request = new BaseRequest<List<JobErrorDetails>>(client, url, HttpMethod.GET, jobErrorDetailsListType) {
+        BaseRequest<List<JobErrorDetails>> request = new BaseRequest<List<JobErrorDetails>>(client, tokenProvider, url, HttpMethod.GET, jobErrorDetailsListType) {
             @Override
             protected List<JobErrorDetails> readResponseBody(Auth0HttpResponse response) throws IOException {
                 if (response.getBody() == null || response.getBody().length() == 0) {
@@ -88,7 +87,6 @@ public class JobsEntity extends BaseManagementEntity {
                 return super.readResponseBody(response);
             }
         };
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -158,9 +156,8 @@ public class JobsEntity extends BaseManagementEntity {
             Asserts.assertNotNull(emailVerificationIdentity.getUserId(), "identity user id");
             requestBody.put("identity", emailVerificationIdentity);
         }
-        BaseRequest<Job> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<Job>() {
+        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Job>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(requestBody);
         return request;
     }
@@ -189,9 +186,8 @@ public class JobsEntity extends BaseManagementEntity {
             requestBody.putAll(filter.getAsMap());
         }
 
-        BaseRequest<Job> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<Job>() {
+        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Job>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(requestBody);
         return request;
     }
@@ -217,7 +213,7 @@ public class JobsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        MultipartRequest<Job> request = new MultipartRequest<>(client, url, HttpMethod.POST, new TypeReference<Job>() {
+        MultipartRequest<Job> request = new MultipartRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
         });
         if (options != null) {
             for (Map.Entry<String, Object> e : options.getAsMap().entrySet()) {
@@ -226,7 +222,6 @@ public class JobsEntity extends BaseManagementEntity {
         }
         request.addPart("connection_id", connectionId);
         request.addPart("users", users, "text/json");
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/KeysEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/KeysEntity.java
@@ -38,9 +38,8 @@ public class KeysEntity extends BaseManagementEntity {
             .newBuilder()
             .addEncodedPathSegments("api/v2/keys/signing");
         String url = builder.build().toString();
-        BaseRequest<List<Key>> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Key>>() {
+        return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Key>>() {
         });
-        return request;
     }
 
 
@@ -59,9 +58,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing")
             .addPathSegment(kid);
         String url = builder.build().toString();
-        BaseRequest<Key> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Key>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Key>() {
         });
-        return request;
     }
 
     /**
@@ -77,9 +75,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing/rotate")
             .build()
             .toString();
-        BaseRequest<Key> request = new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Key>() {
+        return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Key>() {
         });
-        return request;
     }
 
     /**
@@ -100,8 +97,7 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegment("revoke")
             .build()
             .toString();
-        BaseRequest<Key> request = new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<Key>() {
+        return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<Key>() {
         });
-        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/KeysEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/KeysEntity.java
@@ -22,8 +22,8 @@ import java.util.List;
 public class KeysEntity extends BaseManagementEntity {
 
     KeysEntity(Auth0HttpClient client, HttpUrl baseUrl,
-               String apiToken) {
-        super(client, baseUrl, apiToken);
+               TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -38,9 +38,8 @@ public class KeysEntity extends BaseManagementEntity {
             .newBuilder()
             .addEncodedPathSegments("api/v2/keys/signing");
         String url = builder.build().toString();
-        BaseRequest<List<Key>> request = new BaseRequest<>(this.client, url, HttpMethod.GET, new TypeReference<List<Key>>() {
+        BaseRequest<List<Key>> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Key>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -60,9 +59,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing")
             .addPathSegment(kid);
         String url = builder.build().toString();
-        BaseRequest<Key> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Key>() {
+        BaseRequest<Key> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Key>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -79,9 +77,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing/rotate")
             .build()
             .toString();
-        BaseRequest<Key> request = new EmptyBodyRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Key>() {
+        BaseRequest<Key> request = new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Key>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -103,9 +100,8 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegment("revoke")
             .build()
             .toString();
-        BaseRequest<Key> request = new EmptyBodyRequest<>(this.client, url, HttpMethod.PUT, new TypeReference<Key>() {
+        BaseRequest<Key> request = new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<Key>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/KeysEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/KeysEntity.java
@@ -38,7 +38,7 @@ public class KeysEntity extends BaseManagementEntity {
             .newBuilder()
             .addEncodedPathSegments("api/v2/keys/signing");
         String url = builder.build().toString();
-        return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Key>>() {
+        return new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Key>>() {
         });
     }
 
@@ -58,7 +58,7 @@ public class KeysEntity extends BaseManagementEntity {
             .addPathSegments("api/v2/keys/signing")
             .addPathSegment(kid);
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Key>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Key>() {
         });
     }
 

--- a/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
@@ -50,9 +50,8 @@ public class LogEventsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<LogEventsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
-        return request;
     }
 
     /**
@@ -71,8 +70,7 @@ public class LogEventsEntity extends BaseManagementEntity {
                 .addPathSegment(logEventId)
                 .build()
                 .toString();
-        BaseRequest<LogEvent> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEvent>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEvent>() {
         });
-        return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
@@ -25,8 +25,8 @@ import static com.auth0.client.mgmt.filter.QueryFilter.KEY_QUERY;
 @SuppressWarnings("WeakerAccess")
 public class LogEventsEntity extends BaseManagementEntity {
 
-    LogEventsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    LogEventsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -50,9 +50,8 @@ public class LogEventsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<LogEventsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        BaseRequest<LogEventsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -72,9 +71,8 @@ public class LogEventsEntity extends BaseManagementEntity {
                 .addPathSegment(logEventId)
                 .build()
                 .toString();
-        BaseRequest<LogEvent> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<LogEvent>() {
+        BaseRequest<LogEvent> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEvent>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogEventsEntity.java
@@ -50,7 +50,7 @@ public class LogEventsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
     }
 
@@ -70,7 +70,7 @@ public class LogEventsEntity extends BaseManagementEntity {
                 .addPathSegment(logEventId)
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEvent>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogEvent>() {
         });
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -40,7 +40,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<LogStream>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<LogStream>>() {
         });
     }
 
@@ -61,7 +61,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogStream>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogStream>() {
         });
     }
 
@@ -81,7 +81,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<LogStream>(){});
+        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<LogStream>(){});
         request.setBody(logStream);
         return request;
     }
@@ -105,7 +105,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<LogStream>(){
+        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<LogStream>(){
         });
         request.setBody(logStream);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -22,7 +22,6 @@ import java.util.List;
 public class LogStreamsEntity extends BaseManagementEntity {
 
     private final static String LOG_STREAMS_PATH = "api/v2/log-streams";
-    private final static String AUTHORIZATION_HEADER = "Authorization";
 
     LogStreamsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
         super(client, baseUrl, tokenProvider);
@@ -41,9 +40,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<LogStream>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<LogStream>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<LogStream>>() {
         });
-        return request;
     }
 
     /**
@@ -63,9 +61,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogStream>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogStream>() {
         });
-        return request;
     }
 
     /**
@@ -131,7 +128,6 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/LogStreamsEntity.java
@@ -24,8 +24,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
     private final static String LOG_STREAMS_PATH = "api/v2/log-streams";
     private final static String AUTHORIZATION_HEADER = "Authorization";
 
-    LogStreamsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    LogStreamsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -41,9 +41,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<LogStream>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<LogStream>>() {
+        BaseRequest<List<LogStream>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<LogStream>>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -64,9 +63,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<LogStream> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<LogStream>() {
+        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogStream>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -86,8 +84,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<LogStream> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<LogStream>(){});
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<LogStream>(){});
         request.setBody(logStream);
         return request;
     }
@@ -111,9 +108,8 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<LogStream> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<LogStream>(){
+        BaseRequest<LogStream> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<LogStream>(){
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(logStream);
         return request;
     }
@@ -135,8 +131,7 @@ public class LogStreamsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -1,16 +1,11 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.HttpOptions;
-import com.auth0.client.LoggingOptions;
-import com.auth0.net.Telemetry;
-import com.auth0.net.TelemetryInterceptor;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.DefaultHttpClient;
 import com.auth0.utils.Asserts;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import okhttp3.logging.HttpLoggingInterceptor;
-import okhttp3.logging.HttpLoggingInterceptor.Level;
 import org.jetbrains.annotations.TestOnly;
 
 /**
@@ -25,7 +20,7 @@ import org.jetbrains.annotations.TestOnly;
 public class ManagementAPI {
 
     private final HttpUrl baseUrl;
-    private String apiToken;
+    private TokenProvider tokenProvider;
     private final Auth0HttpClient client;
 
     /**
@@ -43,7 +38,7 @@ public class ManagementAPI {
      */
     @Deprecated
     public ManagementAPI(String domain, String apiToken, HttpOptions options) {
-        this(domain, apiToken, buildNetworkingClient(options));
+        this(domain, SimpleTokenProvider.create(apiToken), buildNetworkingClient(options));
     }
 
     /**
@@ -58,7 +53,7 @@ public class ManagementAPI {
      */
     @Deprecated
     public ManagementAPI(String domain, String apiToken) {
-        this(domain, apiToken, DefaultHttpClient.newBuilder().build());
+        this(domain, SimpleTokenProvider.create(apiToken), DefaultHttpClient.newBuilder().build());
     }
 
     /**
@@ -72,15 +67,15 @@ public class ManagementAPI {
         return new ManagementAPI.Builder(domain, apiToken);
     }
 
-    private ManagementAPI(String domain, String apiToken, Auth0HttpClient httpClient) {
+    private ManagementAPI(String domain, TokenProvider tokenProvider, Auth0HttpClient httpClient) {
         Asserts.assertNotNull(domain, "domain");
-        Asserts.assertNotNull(apiToken, "api token");
+        Asserts.assertNotNull(tokenProvider, "token provider");
 
         this.baseUrl = createBaseUrl(domain);
         if (baseUrl == null) {
             throw new IllegalArgumentException("The domain had an invalid format and couldn't be parsed as an URL.");
         }
-        this.apiToken = apiToken;
+        this.tokenProvider = tokenProvider;
         this.client = httpClient;
     }
 
@@ -113,7 +108,7 @@ public class ManagementAPI {
      */
     public void setApiToken(String apiToken) {
         Asserts.assertNotNull(apiToken, "api token");
-        this.apiToken = apiToken;
+        this.tokenProvider = SimpleTokenProvider.create(apiToken);
     }
 
     @TestOnly
@@ -140,7 +135,7 @@ public class ManagementAPI {
      * @return the Branding entity.
      */
     public BrandingEntity branding() {
-        return new BrandingEntity(client, baseUrl, apiToken);
+        return new BrandingEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -149,7 +144,7 @@ public class ManagementAPI {
      * @return the Client Grants entity.
      */
     public ClientGrantsEntity clientGrants() {
-        return new ClientGrantsEntity(client, baseUrl, apiToken);
+        return new ClientGrantsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -158,7 +153,7 @@ public class ManagementAPI {
      * @return the Applications entity.
      */
     public ClientsEntity clients() {
-        return new ClientsEntity(client, baseUrl, apiToken);
+        return new ClientsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -167,7 +162,7 @@ public class ManagementAPI {
      * @return the Connections entity.
      */
     public ConnectionsEntity connections() {
-        return new ConnectionsEntity(client, baseUrl, apiToken);
+        return new ConnectionsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -176,7 +171,7 @@ public class ManagementAPI {
      * @return the Device Credentials entity.
      */
     public DeviceCredentialsEntity deviceCredentials() {
-        return new DeviceCredentialsEntity(client, baseUrl, apiToken);
+        return new DeviceCredentialsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -185,7 +180,7 @@ public class ManagementAPI {
      * @return the Grants entity.
      */
     public GrantsEntity grants() {
-        return new GrantsEntity(client, baseUrl, apiToken);
+        return new GrantsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -194,7 +189,7 @@ public class ManagementAPI {
      * @return the Log Events entity.
      */
     public LogEventsEntity logEvents() {
-        return new LogEventsEntity(client, baseUrl, apiToken);
+        return new LogEventsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -203,7 +198,7 @@ public class ManagementAPI {
      * @return the Log Streams entity.
      */
     public LogStreamsEntity logStreams() {
-        return new LogStreamsEntity(client, baseUrl, apiToken);
+        return new LogStreamsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -212,7 +207,7 @@ public class ManagementAPI {
      * @return the Rules entity.
      */
     public RulesEntity rules() {
-        return new RulesEntity(client, baseUrl, apiToken);
+        return new RulesEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -221,7 +216,7 @@ public class ManagementAPI {
      * @return the Rules Configs entity.
      */
     public RulesConfigsEntity rulesConfigs() {
-        return new RulesConfigsEntity(client, baseUrl, apiToken);
+        return new RulesConfigsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -230,7 +225,7 @@ public class ManagementAPI {
      * @return the User Blocks entity.
      */
     public UserBlocksEntity userBlocks() {
-        return new UserBlocksEntity(client, baseUrl, apiToken);
+        return new UserBlocksEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -239,7 +234,7 @@ public class ManagementAPI {
      * @return the Users entity.
      */
     public UsersEntity users() {
-        return new UsersEntity(client, baseUrl, apiToken);
+        return new UsersEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -248,7 +243,7 @@ public class ManagementAPI {
      * @return the Blacklists entity.
      */
     public BlacklistsEntity blacklists() {
-        return new BlacklistsEntity(client, baseUrl, apiToken);
+        return new BlacklistsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -257,7 +252,7 @@ public class ManagementAPI {
      * @return the Email Templates entity.
      */
     public EmailTemplatesEntity emailTemplates() {
-        return new EmailTemplatesEntity(client, baseUrl, apiToken);
+        return new EmailTemplatesEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -266,7 +261,7 @@ public class ManagementAPI {
      * @return the Email Provider entity.
      */
     public EmailProviderEntity emailProvider() {
-        return new EmailProviderEntity(client, baseUrl, apiToken);
+        return new EmailProviderEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -275,7 +270,7 @@ public class ManagementAPI {
      * @return the Guardian entity.
      */
     public GuardianEntity guardian() {
-        return new GuardianEntity(client, baseUrl, apiToken);
+        return new GuardianEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -284,7 +279,7 @@ public class ManagementAPI {
      * @return the Stats entity.
      */
     public StatsEntity stats() {
-        return new StatsEntity(client, baseUrl, apiToken);
+        return new StatsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -293,7 +288,7 @@ public class ManagementAPI {
      * @return the Tenants entity.
      */
     public TenantsEntity tenants() {
-        return new TenantsEntity(client, baseUrl, apiToken);
+        return new TenantsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -302,7 +297,7 @@ public class ManagementAPI {
      * @return the Tickets entity.
      */
     public TicketsEntity tickets() {
-        return new TicketsEntity(client, baseUrl, apiToken);
+        return new TicketsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -311,7 +306,7 @@ public class ManagementAPI {
      * @return the Resource Servers entity.
      */
     public ResourceServerEntity resourceServers() {
-        return new ResourceServerEntity(client, baseUrl, apiToken);
+        return new ResourceServerEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -320,7 +315,7 @@ public class ManagementAPI {
      * @return the Jobs entity.
      */
     public JobsEntity jobs() {
-        return new JobsEntity(client, baseUrl, apiToken);
+        return new JobsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -329,7 +324,7 @@ public class ManagementAPI {
      * @return the Roles entity.
      */
     public RolesEntity roles() {
-        return new RolesEntity(client, baseUrl, apiToken);
+        return new RolesEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -338,7 +333,7 @@ public class ManagementAPI {
      * @return the Organizations entity.
      */
     public OrganizationsEntity organizations() {
-        return new OrganizationsEntity(client, baseUrl, apiToken);
+        return new OrganizationsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -347,7 +342,7 @@ public class ManagementAPI {
      * @return the Actions entity.
      */
     public ActionsEntity actions() {
-        return new ActionsEntity(client, baseUrl, apiToken);
+        return new ActionsEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -356,7 +351,7 @@ public class ManagementAPI {
      * @return the Attack Protection Entity
      */
     public AttackProtectionEntity attackProtection() {
-        return new AttackProtectionEntity(client, baseUrl, apiToken);
+        return new AttackProtectionEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -365,7 +360,7 @@ public class ManagementAPI {
      * @return the Keys Entity
      */
     public KeysEntity keys() {
-        return new KeysEntity(client, baseUrl, apiToken);
+        return new KeysEntity(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -402,7 +397,7 @@ public class ManagementAPI {
          * @return the configured {@code ManagementAPI} instance.
          */
         public ManagementAPI build() {
-            return new ManagementAPI(domain, apiToken, httpClient);
+            return new ManagementAPI(domain, SimpleTokenProvider.create(apiToken), httpClient);
         }
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -29,8 +29,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
     private final static String ORGS_PATH = "api/v2/organizations";
     private final static String AUTHORIZATION_HEADER = "Authorization";
 
-    OrganizationsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    OrganizationsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     // Organizations Entity
@@ -51,10 +51,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<OrganizationsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        BaseRequest<OrganizationsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -76,10 +75,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Organization>() {
+        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -102,10 +100,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Organization>() {
+        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -126,10 +123,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<Organization>() {
+        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Organization>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(organization);
         return request;
     }
@@ -154,10 +150,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<Organization>() {
+        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Organization>() {
         });
 
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(organization);
         return request;
     }
@@ -180,8 +175,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest = new VoidRequest(client, url, HttpMethod.DELETE);
-        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest voidRequest =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return voidRequest;
     }
 
@@ -208,9 +202,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<MembersPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<MembersPage>() {
+        BaseRequest<MembersPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<MembersPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -235,8 +228,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.POST);
         request.setBody(members);
         return request;
     }
@@ -262,8 +254,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         request.setBody(members);
         return request;
     }
@@ -291,9 +282,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<EnabledConnectionsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
+        BaseRequest<EnabledConnectionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -319,9 +309,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<EnabledConnection> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<EnabledConnection>() {
+        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnection>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -346,9 +335,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<EnabledConnection> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<EnabledConnection>() {
+        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EnabledConnection>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -375,8 +363,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest = new VoidRequest(client, url, HttpMethod.DELETE);
-        voidRequest.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest voidRequest =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return voidRequest;
     }
 
@@ -404,9 +391,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<EnabledConnection> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<EnabledConnection>() {
+        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<EnabledConnection>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(connection);
         return request;
     }
@@ -438,9 +424,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<RolesPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<RolesPage>() {
+        BaseRequest<RolesPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -469,8 +454,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.POST);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.POST);
         request.setBody(roles);
         return request;
     }
@@ -500,8 +484,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         request.setBody(roles);
         return request;
     }
@@ -529,9 +512,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Invitation> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<Invitation>() {
+        BaseRequest<Invitation> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Invitation>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         request.setBody(invitation);
         return request;
 
@@ -561,9 +543,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<Invitation> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Invitation>() {
+        BaseRequest<Invitation> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Invitation>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -588,9 +569,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<InvitationsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<InvitationsPage>() {
+        BaseRequest<InvitationsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<InvitationsPage>() {
         });
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
         return request;
     }
 
@@ -616,8 +596,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader(AUTHORIZATION_HEADER, "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -51,7 +51,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
 
         String url = builder.build().toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
         });
     }
 
@@ -73,7 +73,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Organization>() {
         });
     }
 
@@ -96,7 +96,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Organization>() {
         });
     }
 
@@ -117,7 +117,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Organization>() {
+        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Organization>() {
         });
 
         request.setBody(organization);
@@ -144,7 +144,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Organization>() {
+        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Organization>() {
         });
 
         request.setBody(organization);
@@ -195,7 +195,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<MembersPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<MembersPage>() {
         });
     }
 
@@ -274,7 +274,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
         });
     }
 
@@ -300,7 +300,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnection>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<EnabledConnection>() {
         });
     }
 
@@ -325,7 +325,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EnabledConnection>() {
+        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<EnabledConnection>() {
         });
         request.setBody(connection);
         return request;
@@ -380,7 +380,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<EnabledConnection>() {
+        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<EnabledConnection>() {
         });
         request.setBody(connection);
         return request;
@@ -413,7 +413,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RolesPage>() {
         });
     }
 
@@ -500,7 +500,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Invitation> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Invitation>() {
+        BaseRequest<Invitation> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Invitation>() {
         });
         request.setBody(invitation);
         return request;
@@ -531,7 +531,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Invitation>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Invitation>() {
         });
     }
 
@@ -556,7 +556,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<InvitationsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<InvitationsPage>() {
         });
     }
 

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -27,7 +27,6 @@ import java.util.Map;
 public class OrganizationsEntity extends BaseManagementEntity {
 
     private final static String ORGS_PATH = "api/v2/organizations";
-    private final static String AUTHORIZATION_HEADER = "Authorization";
 
     OrganizationsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
         super(client, baseUrl, tokenProvider);
@@ -51,10 +50,9 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<OrganizationsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
-        });
 
-        return request;
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        });
     }
 
     /**
@@ -75,10 +73,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
         });
-
-        return request;
     }
 
     /**
@@ -100,10 +96,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<Organization> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Organization>() {
         });
-
-        return request;
     }
 
     /**
@@ -175,8 +169,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return voidRequest;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     // Organization members
@@ -202,9 +195,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<MembersPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<MembersPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<MembersPage>() {
         });
-        return request;
     }
 
     /**
@@ -282,9 +274,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<EnabledConnectionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnectionsPage>() {
         });
-        return request;
     }
 
     /**
@@ -309,9 +300,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        BaseRequest<EnabledConnection> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnection>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<EnabledConnection>() {
         });
-        return request;
     }
 
     /**
@@ -363,8 +353,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest voidRequest =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return voidRequest;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -424,9 +413,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<RolesPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
         });
-        return request;
     }
 
     /**
@@ -543,9 +531,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<Invitation> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Invitation>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Invitation>() {
         });
-        return request;
     }
 
     /**
@@ -569,9 +556,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
         applyFilter(filter, builder);
 
         String url = builder.build().toString();
-        BaseRequest<InvitationsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<InvitationsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<InvitationsPage>() {
         });
-        return request;
     }
 
     /**
@@ -596,8 +582,7 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     private void applyFilter(BaseFilter filter, HttpUrl.Builder builder) {

--- a/src/main/java/com/auth0/client/mgmt/RequestBuilder.java
+++ b/src/main/java/com/auth0/client/mgmt/RequestBuilder.java
@@ -62,7 +62,7 @@ class RequestBuilder<T> {
         if ("java.lang.Void".equals(target.getType().getTypeName())) {
             request = (BaseRequest<T>)  new VoidRequest(client, tokenProvider,  url, method);
         } else {
-            request =  new BaseRequest<>(client, tokenProvider, url,  method, target);
+            request =  new BaseRequest<>(client, tokenProvider, url, method, target);
         }
 
         if (body != null) {

--- a/src/main/java/com/auth0/client/mgmt/RequestBuilder.java
+++ b/src/main/java/com/auth0/client/mgmt/RequestBuilder.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 class RequestBuilder<T> {
     private final Auth0HttpClient client;
+    private final TokenProvider tokenProvider;
     private final HttpMethod method;
 
     // TODO decouple from OkHttp
@@ -25,8 +26,9 @@ class RequestBuilder<T> {
     private final Map<String, String> headers = new HashMap<>();
     private final Map<String, Object> parameters = new HashMap<>();
 
-    public RequestBuilder(Auth0HttpClient client, HttpMethod method, HttpUrl baseUrl, TypeReference<T> target) {
+    public RequestBuilder(Auth0HttpClient client, TokenProvider tokenProvider, HttpMethod method, HttpUrl baseUrl, TypeReference<T> target) {
         this.client = client;
+        this.tokenProvider = tokenProvider;
         this.method = method;
         this.url = baseUrl.newBuilder();
         this.target = target;
@@ -58,9 +60,9 @@ class RequestBuilder<T> {
 
         final String url = this.url.build().toString();
         if ("java.lang.Void".equals(target.getType().getTypeName())) {
-            request = (BaseRequest<T>) new VoidRequest(client, url, method);
+            request = (BaseRequest<T>)  new VoidRequest(client, tokenProvider,  url, method);
         } else {
-            request = new BaseRequest<>(client, url, method, target);
+            request =  new BaseRequest<>(client, tokenProvider, url,  method, target);
         }
 
         if (body != null) {

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -46,10 +46,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServersPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
                 new TypeReference<ResourceServersPage>() {
                 });
-        return request;
     }
 
     /**
@@ -67,10 +66,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        BaseRequest<List<ResourceServer>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
                 new TypeReference<List<ResourceServer>>() {
                 });
-        return request;
     }
 
     /**
@@ -89,10 +87,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerIdOrIdentifier);
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServer> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
                 new TypeReference<ResourceServer>() {
                 });
-        return request;
     }
 
     /**
@@ -133,8 +130,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerId);
 
         String url = builder.build().toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -155,9 +151,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerId);
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServer> request = new BaseRequest<ResourceServer>(client, tokenProvider, url, HttpMethod.PATCH,
-                new TypeReference<ResourceServer>() {
-                });
+        BaseRequest<ResourceServer> request = new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH,
+            new TypeReference<ResourceServer>() {
+            });
         request.setBody(resourceServer);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -46,7 +46,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET,
                 new TypeReference<ResourceServersPage>() {
                 });
     }
@@ -66,7 +66,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET,
                 new TypeReference<List<ResourceServer>>() {
                 });
     }
@@ -87,7 +87,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerIdOrIdentifier);
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET,
                 new TypeReference<ResourceServer>() {
                 });
     }
@@ -107,7 +107,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServer> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST,
+        BaseRequest<ResourceServer> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST,
                 new TypeReference<ResourceServer>() {
                 });
         request.setBody(resourceServer);

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -24,8 +24,8 @@ import java.util.Map;
  */
 public class ResourceServerEntity extends BaseManagementEntity {
 
-    ResourceServerEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    ResourceServerEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -46,10 +46,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServersPage> request = new BaseRequest<>(client, url, HttpMethod.GET,
+        BaseRequest<ResourceServersPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
                 new TypeReference<ResourceServersPage>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -68,10 +67,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        BaseRequest<List<ResourceServer>> request = new BaseRequest<>(client, url, HttpMethod.GET,
+        BaseRequest<List<ResourceServer>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
                 new TypeReference<List<ResourceServer>>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -91,10 +89,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerIdOrIdentifier);
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServer> request = new BaseRequest<>(client, url, HttpMethod.GET,
+        BaseRequest<ResourceServer> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET,
                 new TypeReference<ResourceServer>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -113,10 +110,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/resource-servers");
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServer> request = new BaseRequest<>(client, url, HttpMethod.POST,
+        BaseRequest<ResourceServer> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST,
                 new TypeReference<ResourceServer>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(resourceServer);
         return request;
     }
@@ -137,8 +133,7 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerId);
 
         String url = builder.build().toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -160,10 +155,9 @@ public class ResourceServerEntity extends BaseManagementEntity {
                 .addPathSegment(resourceServerId);
 
         String url = builder.build().toString();
-        BaseRequest<ResourceServer> request = new BaseRequest<ResourceServer>(client, url, HttpMethod.PATCH,
+        BaseRequest<ResourceServer> request = new BaseRequest<ResourceServer>(client, tokenProvider, url, HttpMethod.PATCH,
                 new TypeReference<ResourceServer>() {
                 });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(resourceServer);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/RolesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RolesEntity.java
@@ -52,8 +52,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    BaseRequest<RolesPage> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {});
-    return request;
+      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {});
   }
 
   /**
@@ -73,8 +72,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId);
 
     String url = builder.build().toString();
-    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Role>() {});
-    return request;
+      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Role>() {});
   }
 
 
@@ -116,8 +114,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
-    return request;
+      return new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
   }
 
   /**
@@ -167,8 +164,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    BaseRequest<UsersPage> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {});
-    return request;
+      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {});
   }
 
   /**
@@ -222,8 +218,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    BaseRequest<PermissionsPage> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {});
-    return request;
+      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {});
   }
 
   /**

--- a/src/main/java/com/auth0/client/mgmt/RolesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RolesEntity.java
@@ -30,8 +30,8 @@ import java.util.Map;
 public class RolesEntity extends BaseManagementEntity {
 
   RolesEntity(Auth0HttpClient client, HttpUrl baseUrl,
-              String apiToken) {
-    super(client, baseUrl, apiToken);
+              TokenProvider tokenProvider) {
+    super(client, baseUrl, tokenProvider);
   }
 
   /**
@@ -52,8 +52,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    BaseRequest<RolesPage> request = new BaseRequest<>(this.client, url, HttpMethod.GET, new TypeReference<RolesPage>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    BaseRequest<RolesPage> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {});
     return request;
   }
 
@@ -74,8 +73,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId);
 
     String url = builder.build().toString();
-    BaseRequest<Role> request = new BaseRequest<>(this.client, url, HttpMethod.GET, new TypeReference<Role>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Role>() {});
     return request;
   }
 
@@ -96,8 +94,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("api/v2/roles")
         .build()
         .toString();
-    BaseRequest<Role> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Role>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Role>() {});
     request.setBody(role);
     return request;
   }
@@ -119,8 +116,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
     return request;
   }
 
@@ -143,8 +139,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-    BaseRequest<Role> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Role>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Role>() {});
     request.setBody(role);
     return request;
   }
@@ -172,8 +167,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    BaseRequest<UsersPage> request = new BaseRequest<>(this.client, url, HttpMethod.GET, new TypeReference<UsersPage>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    BaseRequest<UsersPage> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {});
     return request;
   }
 
@@ -200,8 +194,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("users")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
     request.setBody(body);
     return request;
   }
@@ -229,8 +222,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-    BaseRequest<PermissionsPage> request = new BaseRequest<>(this.client, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {});
-    request.addHeader("Authorization", "Bearer " + apiToken);
+    BaseRequest<PermissionsPage> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {});
     return request;
   }
 
@@ -257,9 +249,8 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("permissions")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
     request.setBody(body);
-    request.addHeader("Authorization", "Bearer " + apiToken);
     return request;
   }
 
@@ -287,9 +278,8 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("permissions")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
     request.setBody(body);
-    request.addHeader("Authorization", "Bearer " + apiToken);
     return request;
   }
 }

--- a/src/main/java/com/auth0/client/mgmt/RolesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RolesEntity.java
@@ -52,7 +52,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {});
+      return new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<RolesPage>() {});
   }
 
   /**
@@ -72,7 +72,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId);
 
     String url = builder.build().toString();
-      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Role>() {});
+      return new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<Role>() {});
   }
 
 
@@ -92,7 +92,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("api/v2/roles")
         .build()
         .toString();
-    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Role>() {});
+    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Role>() {});
     request.setBody(role);
     return request;
   }
@@ -114,7 +114,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-      return new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
+      return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
   }
 
   /**
@@ -136,7 +136,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments(roleId)
         .build()
         .toString();
-    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Role>() {});
+    BaseRequest<Role> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Role>() {});
     request.setBody(role);
     return request;
   }
@@ -164,7 +164,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {});
+      return new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<UsersPage>() {});
   }
 
   /**
@@ -190,7 +190,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("users")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
     request.setBody(body);
     return request;
   }
@@ -218,7 +218,7 @@ public class RolesEntity extends BaseManagementEntity {
       }
     }
     String url = builder.build().toString();
-      return new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {});
+      return new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {});
   }
 
   /**
@@ -244,7 +244,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("permissions")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
     request.setBody(body);
     return request;
   }
@@ -273,7 +273,7 @@ public class RolesEntity extends BaseManagementEntity {
         .addEncodedPathSegments("permissions")
         .build()
         .toString();
-    VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
+    VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
     request.setBody(body);
     return request;
   }

--- a/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
@@ -39,7 +39,7 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .newBuilder()
                 .addPathSegments("api/v2/rules-configs");
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
         });
     }
 
@@ -80,7 +80,7 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .addPathSegment(rulesConfigKey)
                 .build()
                 .toString();
-        BaseRequest<RulesConfig> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PUT, new TypeReference<RulesConfig>() {
+        BaseRequest<RulesConfig> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<RulesConfig>() {
         });
         request.setBody(rulesConfig);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
@@ -22,8 +22,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class RulesConfigsEntity extends BaseManagementEntity {
 
-    RulesConfigsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    RulesConfigsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -39,9 +39,8 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .newBuilder()
                 .addPathSegments("api/v2/rules-configs");
         String url = builder.build().toString();
-        BaseRequest<List<RulesConfig>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
+        BaseRequest<List<RulesConfig>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -61,8 +60,7 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .addPathSegment(rulesConfigKey)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -84,9 +82,8 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .addPathSegment(rulesConfigKey)
                 .build()
                 .toString();
-        BaseRequest<RulesConfig> request = new BaseRequest<>(this.client, url, HttpMethod.PUT, new TypeReference<RulesConfig>() {
+        BaseRequest<RulesConfig> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PUT, new TypeReference<RulesConfig>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(rulesConfig);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesConfigsEntity.java
@@ -39,9 +39,8 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .newBuilder()
                 .addPathSegments("api/v2/rules-configs");
         String url = builder.build().toString();
-        BaseRequest<List<RulesConfig>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<RulesConfig>>() {
         });
-        return request;
     }
 
     /**
@@ -60,8 +59,7 @@ public class RulesConfigsEntity extends BaseManagementEntity {
                 .addPathSegment(rulesConfigKey)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/RulesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesEntity.java
@@ -46,9 +46,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<RulesPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RulesPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RulesPage>() {
         });
-        return request;
     }
 
     /**
@@ -74,9 +73,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<List<Rule>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Rule>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Rule>>() {
         });
-        return request;
     }
 
     /**
@@ -100,9 +98,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Rule> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Rule>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Rule>() {
         });
-        return request;
     }
 
     /**
@@ -142,8 +139,7 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegment(ruleId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/RulesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesEntity.java
@@ -46,7 +46,7 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RulesPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RulesPage>() {
         });
     }
 
@@ -73,7 +73,7 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Rule>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Rule>>() {
         });
     }
 
@@ -98,7 +98,7 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Rule>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Rule>() {
         });
     }
 
@@ -117,7 +117,7 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/rules")
                 .build()
                 .toString();
-        BaseRequest<Rule> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Rule>() {
+        BaseRequest<Rule> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Rule>() {
         });
         request.setBody(rule);
         return request;
@@ -160,7 +160,7 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegment(ruleId)
                 .build()
                 .toString();
-        BaseRequest<Rule> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Rule>() {
+        BaseRequest<Rule> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Rule>() {
         });
         request.setBody(rule);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/RulesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesEntity.java
@@ -25,8 +25,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class RulesEntity extends BaseManagementEntity {
 
-    RulesEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    RulesEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -46,9 +46,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<RulesPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<RulesPage>() {
+        BaseRequest<RulesPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RulesPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -75,9 +74,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<List<Rule>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Rule>>() {
+        BaseRequest<List<Rule>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Rule>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -102,9 +100,8 @@ public class RulesEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Rule> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Rule>() {
+        BaseRequest<Rule> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Rule>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -123,9 +120,8 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/rules")
                 .build()
                 .toString();
-        BaseRequest<Rule> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<Rule>() {
+        BaseRequest<Rule> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<Rule>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(rule);
         return request;
     }
@@ -146,8 +142,7 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegment(ruleId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -169,9 +164,8 @@ public class RulesEntity extends BaseManagementEntity {
                 .addPathSegment(ruleId)
                 .build()
                 .toString();
-        BaseRequest<Rule> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<Rule>() {
+        BaseRequest<Rule> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Rule>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(rule);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/SimpleTokenProvider.java
@@ -1,0 +1,33 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.utils.Asserts;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An implementation of {@link TokenProvider} that simply returns the token it is configured with. Tokens will not be renewed;
+ * consumers are responsible for renewing the token when needed and then calling {@link ManagementAPI#setApiToken(String)} with the
+ * new token.
+ */
+public class SimpleTokenProvider implements TokenProvider {
+    private final String apiToken;
+
+    public static SimpleTokenProvider create(String apiToken) {
+        return new SimpleTokenProvider(apiToken);
+    }
+
+    @Override
+    public String getToken() {
+        return apiToken;
+    }
+
+    @Override
+    public CompletableFuture<String> getTokenAsync() {
+        return CompletableFuture.supplyAsync(() -> apiToken);
+    }
+
+    private SimpleTokenProvider(String apiToken) {
+        Asserts.assertNotNull(apiToken, "api token");
+        this.apiToken = apiToken;
+    }
+}

--- a/src/main/java/com/auth0/client/mgmt/StatsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/StatsEntity.java
@@ -40,7 +40,7 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Integer>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Integer>() {
         });
     }
 
@@ -66,7 +66,7 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DailyStats>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<DailyStats>>() {
         });
     }
 

--- a/src/main/java/com/auth0/client/mgmt/StatsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/StatsEntity.java
@@ -23,8 +23,8 @@ import java.util.List;
 @SuppressWarnings("WeakerAccess")
 public class StatsEntity extends BaseManagementEntity {
 
-    StatsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    StatsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -40,9 +40,8 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<Integer> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Integer>() {
+        BaseRequest<Integer> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Integer>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -68,9 +67,8 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<DailyStats>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<DailyStats>>() {
+        BaseRequest<List<DailyStats>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DailyStats>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 

--- a/src/main/java/com/auth0/client/mgmt/StatsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/StatsEntity.java
@@ -40,9 +40,8 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<Integer> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Integer>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Integer>() {
         });
-        return request;
     }
 
     /**
@@ -67,9 +66,8 @@ public class StatsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<DailyStats>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DailyStats>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<DailyStats>>() {
         });
-        return request;
     }
 
     protected String formatDate(Date date) {

--- a/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
@@ -22,8 +22,8 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class TenantsEntity extends BaseManagementEntity {
 
-    TenantsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    TenantsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -43,9 +43,8 @@ public class TenantsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Tenant> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<Tenant>() {
+        BaseRequest<Tenant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Tenant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -65,9 +64,8 @@ public class TenantsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<Tenant> request = new BaseRequest<>(client, url, HttpMethod.PATCH, new TypeReference<Tenant>() {
+        BaseRequest<Tenant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Tenant>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(tenant);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
@@ -43,9 +43,8 @@ public class TenantsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<Tenant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Tenant>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Tenant>() {
         });
-        return request;
     }
 
     /**

--- a/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TenantsEntity.java
@@ -43,7 +43,7 @@ public class TenantsEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<Tenant>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<Tenant>() {
         });
     }
 
@@ -63,7 +63,7 @@ public class TenantsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<Tenant> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<Tenant>() {
+        BaseRequest<Tenant> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<Tenant>() {
         });
         request.setBody(tenant);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/TicketsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TicketsEntity.java
@@ -40,7 +40,7 @@ public class TicketsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<EmailVerificationTicket> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EmailVerificationTicket>() {
+        BaseRequest<EmailVerificationTicket> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<EmailVerificationTicket>() {
         });
         request.setBody(emailVerificationTicket);
         return request;
@@ -62,7 +62,7 @@ public class TicketsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<PasswordChangeTicket> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<PasswordChangeTicket>() {
+        BaseRequest<PasswordChangeTicket> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<PasswordChangeTicket>() {
         });
         request.setBody(passwordChangeTicket);
         return request;

--- a/src/main/java/com/auth0/client/mgmt/TicketsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/TicketsEntity.java
@@ -20,8 +20,8 @@ import okhttp3.HttpUrl;
 @SuppressWarnings("WeakerAccess")
 public class TicketsEntity extends BaseManagementEntity {
 
-    TicketsEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    TicketsEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -40,9 +40,8 @@ public class TicketsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<EmailVerificationTicket> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<EmailVerificationTicket>() {
+        BaseRequest<EmailVerificationTicket> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<EmailVerificationTicket>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(emailVerificationTicket);
         return request;
     }
@@ -63,9 +62,8 @@ public class TicketsEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<PasswordChangeTicket> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<PasswordChangeTicket>() {
+        BaseRequest<PasswordChangeTicket> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<PasswordChangeTicket>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(passwordChangeTicket);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/TokenProvider.java
+++ b/src/main/java/com/auth0/client/mgmt/TokenProvider.java
@@ -1,0 +1,25 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.exception.Auth0Exception;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@code TokenProvider} is responsible for providing the token used when making authorized requests to the Auth0
+ * Management API.
+ */
+public interface TokenProvider {
+
+    /**
+     * Responsible for obtaining a token for use with the {@link ManagementAPI} client for synchronous requests.
+     * @return the token required when making requests to the Auth0 Management API.
+     * @throws Auth0Exception if the token cannot be retrieved.
+     */
+    String getToken() throws Auth0Exception;
+
+    /**
+     * Responsible for obtaining a token for use with the {@link ManagementAPI} client for asynchronous requests.
+     * @return a {@link CompletableFuture} with the token required when making requests to the Auth0 Management API.
+     */
+    CompletableFuture<String> getTokenAsync();
+}

--- a/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
@@ -40,9 +40,8 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        BaseRequest<UserBlocks> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
-        return request;
     }
 
     /**
@@ -61,8 +60,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 
     /**
@@ -81,9 +79,8 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        BaseRequest<UserBlocks> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
-        return request;
     }
 
     /**
@@ -102,7 +99,6 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
@@ -20,8 +20,8 @@ import okhttp3.HttpUrl;
 @SuppressWarnings("WeakerAccess")
 public class UserBlocksEntity extends BaseManagementEntity {
 
-    UserBlocksEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    UserBlocksEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -40,9 +40,8 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        BaseRequest<UserBlocks> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
+        BaseRequest<UserBlocks> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -62,8 +61,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 
@@ -83,9 +81,8 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        BaseRequest<UserBlocks> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
+        BaseRequest<UserBlocks> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -105,8 +102,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =  new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
         return request;
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UserBlocksEntity.java
@@ -40,7 +40,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addQueryParameter("identifier", identifier)
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
     }
 
@@ -79,7 +79,7 @@ public class UserBlocksEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UserBlocks>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<UserBlocks>() {
         });
     }
 

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -37,8 +37,8 @@ import static com.auth0.client.mgmt.filter.QueryFilter.KEY_QUERY;
 @SuppressWarnings("WeakerAccess")
 public class UsersEntity extends BaseManagementEntity {
 
-    UsersEntity(Auth0HttpClient client, HttpUrl baseUrl, String apiToken) {
-        super(client, baseUrl, apiToken);
+    UsersEntity(Auth0HttpClient client, HttpUrl baseUrl, TokenProvider tokenProvider) {
+        super(client, baseUrl, tokenProvider);
     }
 
     /**
@@ -65,9 +65,8 @@ public class UsersEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<List<User>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<User>>() {
+        BaseRequest<List<User>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<User>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -86,9 +85,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users");
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        BaseRequest<UsersPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<UsersPage>() {
+        BaseRequest<UsersPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -115,9 +113,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<User> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<User>() {
+        BaseRequest<User> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<User>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -137,9 +134,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users")
                 .build()
                 .toString();
-        BaseRequest<User> request = new BaseRequest<>(this.client, url, HttpMethod.POST, new TypeReference<User>() {
+        BaseRequest<User> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<User>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(user);
         return request;
     }
@@ -161,8 +157,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =   new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
         return request;
     }
 
@@ -186,9 +181,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        BaseRequest<User> request = new BaseRequest<>(this.client, url, HttpMethod.PATCH, new TypeReference<User>() {
+        BaseRequest<User> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<User>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.setBody(user);
         return request;
     }
@@ -212,9 +206,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Enrollment>> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<List<Enrollment>>() {
+        BaseRequest<List<Enrollment>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Enrollment>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -238,9 +231,8 @@ public class UsersEntity extends BaseManagementEntity {
 
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        BaseRequest<LogEventsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        BaseRequest<LogEventsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -282,8 +274,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(provider)
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
-        request.addHeader("Authorization", "Bearer " + apiToken);
+        VoidRequest request =   new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
         return request;
     }
 
@@ -306,9 +297,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        EmptyBodyRequest<RecoveryCode> request = new EmptyBodyRequest<>(client, url, HttpMethod.POST, new TypeReference<RecoveryCode>() {
+        EmptyBodyRequest<RecoveryCode> request =  new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<RecoveryCode>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -336,9 +326,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Identity>> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
+        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<List<Identity>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("provider", provider);
         request.addParameter("user_id", secondaryUserId);
         if (connectionId != null) {
@@ -368,9 +357,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Identity>> request = new BaseRequest<>(client, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
+        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<List<Identity>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         request.addParameter("link_with", secondaryIdToken);
 
         return request;
@@ -401,9 +389,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Identity>> request = new BaseRequest<>(client, url, HttpMethod.DELETE, new TypeReference<List<Identity>>() {
+        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.DELETE, new TypeReference<List<Identity>>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -429,9 +416,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<PermissionsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {
+        BaseRequest<PermissionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -459,9 +445,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("permissions")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -488,9 +473,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("permissions")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -516,9 +500,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<RolesPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<RolesPage>() {
+        BaseRequest<RolesPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -546,9 +529,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("roles")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.DELETE);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -575,9 +557,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("roles")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, url, HttpMethod.POST);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
         request.setBody(body);
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 
@@ -606,9 +587,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<OrganizationsPage> request = new BaseRequest<>(client, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        BaseRequest<OrganizationsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
         });
-        request.addHeader("Authorization", "Bearer " + apiToken);
         return request;
     }
 

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -65,9 +65,8 @@ public class UsersEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        BaseRequest<List<User>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<User>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<User>>() {
         });
-        return request;
     }
 
     /**
@@ -85,9 +84,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users");
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        BaseRequest<UsersPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {
         });
-        return request;
     }
 
     /**
@@ -113,9 +111,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<User> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<User>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<User>() {
         });
-        return request;
     }
 
     /**
@@ -157,8 +154,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        VoidRequest request =   new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -206,9 +202,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Enrollment>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Enrollment>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Enrollment>>() {
         });
-        return request;
     }
 
     /**
@@ -231,9 +226,8 @@ public class UsersEntity extends BaseManagementEntity {
 
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        BaseRequest<LogEventsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
-        return request;
     }
 
     /**
@@ -248,9 +242,7 @@ public class UsersEntity extends BaseManagementEntity {
     public Request<Void> deleteAllAuthenticators(String userId) {
         Asserts.assertNotNull(userId, "user id");
 
-        return voidRequest(HttpMethod.DELETE, builder -> {
-            builder.withPathSegments(String.format("api/v2/users/%s/authenticators", userId));
-        });
+        return voidRequest(HttpMethod.DELETE, builder -> builder.withPathSegments(String.format("api/v2/users/%s/authenticators", userId)));
     }
     
     /**
@@ -274,8 +266,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(provider)
                 .build()
                 .toString();
-        VoidRequest request =   new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
-        return request;
+        return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**
@@ -297,9 +288,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        EmptyBodyRequest<RecoveryCode> request =  new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<RecoveryCode>() {
+        return new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<RecoveryCode>() {
         });
-        return request;
     }
 
     /**
@@ -389,9 +379,8 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.DELETE, new TypeReference<List<Identity>>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.DELETE, new TypeReference<List<Identity>>() {
         });
-        return request;
     }
 
     /**
@@ -416,9 +405,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<PermissionsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {
         });
-        return request;
     }
 
 
@@ -500,9 +488,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<RolesPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
         });
-        return request;
     }
 
 
@@ -587,9 +574,8 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        BaseRequest<OrganizationsPage> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
         });
-        return request;
     }
 
     private static void encodeAndAddQueryParam(HttpUrl.Builder builder, BaseFilter filter) {

--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -65,7 +65,7 @@ public class UsersEntity extends BaseManagementEntity {
         }
 
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<User>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<User>>() {
         });
     }
 
@@ -84,7 +84,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users");
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<UsersPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<UsersPage>() {
         });
     }
 
@@ -111,7 +111,7 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<User>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<User>() {
         });
     }
 
@@ -131,7 +131,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("api/v2/users")
                 .build()
                 .toString();
-        BaseRequest<User> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.POST, new TypeReference<User>() {
+        BaseRequest<User> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<User>() {
         });
         request.setBody(user);
         return request;
@@ -177,7 +177,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegment(userId)
                 .build()
                 .toString();
-        BaseRequest<User> request = new BaseRequest<>(this.client, tokenProvider, url,  HttpMethod.PATCH, new TypeReference<User>() {
+        BaseRequest<User> request = new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<User>() {
         });
         request.setBody(user);
         return request;
@@ -202,7 +202,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<List<Enrollment>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Enrollment>>() {
         });
     }
 
@@ -226,7 +226,7 @@ public class UsersEntity extends BaseManagementEntity {
 
         encodeAndAddQueryParam(builder, filter);
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<LogEventsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<LogEventsPage>() {
         });
     }
 
@@ -288,7 +288,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new EmptyBodyRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<RecoveryCode>() {
+        return new EmptyBodyRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<RecoveryCode>() {
         });
     }
 
@@ -316,7 +316,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<List<Identity>>() {
+        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
         });
         request.addParameter("provider", provider);
         request.addParameter("user_id", secondaryUserId);
@@ -347,7 +347,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url,  HttpMethod.POST, new TypeReference<List<Identity>>() {
+        BaseRequest<List<Identity>> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<List<Identity>>() {
         });
         request.addParameter("link_with", secondaryIdToken);
 
@@ -379,7 +379,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .build()
                 .toString();
 
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.DELETE, new TypeReference<List<Identity>>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.DELETE, new TypeReference<List<Identity>>() {
         });
     }
 
@@ -405,7 +405,7 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<PermissionsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<PermissionsPage>() {
         });
     }
 
@@ -433,7 +433,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("permissions")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
         request.setBody(body);
         return request;
     }
@@ -461,7 +461,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("permissions")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
         request.setBody(body);
         return request;
     }
@@ -488,7 +488,7 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<RolesPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RolesPage>() {
         });
     }
 
@@ -516,7 +516,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("roles")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.DELETE);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
         request.setBody(body);
         return request;
     }
@@ -544,7 +544,7 @@ public class UsersEntity extends BaseManagementEntity {
                 .addPathSegments("roles")
                 .build()
                 .toString();
-        VoidRequest request = new VoidRequest(this.client, tokenProvider, url,  HttpMethod.POST);
+        VoidRequest request = new VoidRequest(this.client, tokenProvider, url, HttpMethod.POST);
         request.setBody(body);
         return request;
     }
@@ -574,7 +574,7 @@ public class UsersEntity extends BaseManagementEntity {
             }
         }
         String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url,  HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/EmptyBodyRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.HttpMethod;
 import com.auth0.net.client.HttpRequestBody;
@@ -15,8 +16,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class EmptyBodyRequest<T> extends BaseRequest<T> {
 
-    public EmptyBodyRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-        super(client, url, method, tType);
+    public EmptyBodyRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        super(client, tokenProvider, url, method, tType);
     }
 
     @Override

--- a/src/main/java/com/auth0/net/MultipartRequest.java
+++ b/src/main/java/com/auth0/net/MultipartRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.json.ObjectMapperProvider;
 import com.auth0.net.client.*;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -32,8 +33,8 @@ public class MultipartRequest<T> extends BaseRequest<T> {
     private int partsCount;
 
     //TODO multipartBuilder is not used? Refactor it?
-    MultipartRequest(Auth0HttpClient client, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType, Auth0MultipartRequestBody.Builder multipartBuilder) {
-        super(client, url, method, mapper, tType);
+    MultipartRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType, Auth0MultipartRequestBody.Builder multipartBuilder) {
+        super(client, tokenProvider, url, method, mapper, tType);
         if (HttpMethod.GET.equals(method)) {
             throw new IllegalArgumentException("Multipart/form-data requests do not support the GET method.");
         }
@@ -42,8 +43,8 @@ public class MultipartRequest<T> extends BaseRequest<T> {
         this.bodyBuilder = Auth0MultipartRequestBody.newBuilder();
     }
 
-    public MultipartRequest(Auth0HttpClient client, String url, HttpMethod method, TypeReference<T> tType) {
-        this(client, url, method, ObjectMapperProvider.getMapper(), tType, Auth0MultipartRequestBody.newBuilder());
+    public MultipartRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        this(client, tokenProvider, url, method, ObjectMapperProvider.getMapper(), tType, Auth0MultipartRequestBody.newBuilder());
     }
 
     @Override

--- a/src/main/java/com/auth0/net/SignUpRequest.java
+++ b/src/main/java/com/auth0/net/SignUpRequest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class SignUpRequest extends BaseRequest<CreatedUser> {
 
     public SignUpRequest(Auth0HttpClient client, String url) {
-        super(client, url, HttpMethod.POST, new TypeReference<CreatedUser>() {
+        super(client, null, url, HttpMethod.POST, new TypeReference<CreatedUser>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/TokenRequest.java
+++ b/src/main/java/com/auth0/net/TokenRequest.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 public class TokenRequest extends BaseRequest<TokenHolder> {
 
     public TokenRequest(Auth0HttpClient client, String url) {
-        super(client, url, HttpMethod.POST, new TypeReference<TokenHolder>() {
+        super(client, null, url, HttpMethod.POST, new TypeReference<TokenHolder>() {
         });
     }
 

--- a/src/main/java/com/auth0/net/VoidRequest.java
+++ b/src/main/java/com/auth0/net/VoidRequest.java
@@ -1,5 +1,6 @@
 package com.auth0.net;
 
+import com.auth0.client.mgmt.TokenProvider;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpResponse;
@@ -19,8 +20,8 @@ import java.util.HashMap;
  */
 public class VoidRequest extends BaseRequest<Void> {
 
-    public VoidRequest(Auth0HttpClient client, String url, HttpMethod method) {
-        super(client, url, method, new TypeReference<Void>() {
+    public VoidRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method) {
+        super(client, tokenProvider, url, method, new TypeReference<Void>() {
         });
     }
 

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -2,6 +2,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.client.HttpOptions;
 import com.auth0.client.MockServer;
+import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpRequest;
 import com.auth0.net.client.Auth0HttpResponse;
@@ -118,50 +119,50 @@ public class ManagementAPITest {
     }
 
     @Test
-    public void shouldUpdateApiToken() {
+    public void shouldUpdateApiToken() throws Auth0Exception {
         //Initialize with a token
         ManagementAPI api = ManagementAPI.newBuilder(DOMAIN, "first token").build();
 
-        assertThat(api.blacklists().apiToken, is("first token"));
-        assertThat(api.clientGrants().apiToken, is("first token"));
-        assertThat(api.clients().apiToken, is("first token"));
-        assertThat(api.connections().apiToken, is("first token"));
-        assertThat(api.deviceCredentials().apiToken, is("first token"));
-        assertThat(api.emailProvider().apiToken, is("first token"));
-        assertThat(api.emailTemplates().apiToken, is("first token"));
-        assertThat(api.grants().apiToken, is("first token"));
-        assertThat(api.guardian().apiToken, is("first token"));
-        assertThat(api.jobs().apiToken, is("first token"));
-        assertThat(api.logEvents().apiToken, is("first token"));
-        assertThat(api.resourceServers().apiToken, is("first token"));
-        assertThat(api.rules().apiToken, is("first token"));
-        assertThat(api.stats().apiToken, is("first token"));
-        assertThat(api.tenants().apiToken, is("first token"));
-        assertThat(api.tickets().apiToken, is("first token"));
-        assertThat(api.userBlocks().apiToken, is("first token"));
-        assertThat(api.users().apiToken, is("first token"));
+        assertThat(api.blacklists().tokenProvider.getToken(), is("first token"));
+        assertThat(api.clientGrants().tokenProvider.getToken(), is("first token"));
+        assertThat(api.clients().tokenProvider.getToken(), is("first token"));
+        assertThat(api.connections().tokenProvider.getToken(), is("first token"));
+        assertThat(api.deviceCredentials().tokenProvider.getToken(), is("first token"));
+        assertThat(api.emailProvider().tokenProvider.getToken(), is("first token"));
+        assertThat(api.emailTemplates().tokenProvider.getToken(), is("first token"));
+        assertThat(api.grants().tokenProvider.getToken(), is("first token"));
+        assertThat(api.guardian().tokenProvider.getToken(), is("first token"));
+        assertThat(api.jobs().tokenProvider.getToken(), is("first token"));
+        assertThat(api.logEvents().tokenProvider.getToken(), is("first token"));
+        assertThat(api.resourceServers().tokenProvider.getToken(), is("first token"));
+        assertThat(api.rules().tokenProvider.getToken(), is("first token"));
+        assertThat(api.stats().tokenProvider.getToken(), is("first token"));
+        assertThat(api.tenants().tokenProvider.getToken(), is("first token"));
+        assertThat(api.tickets().tokenProvider.getToken(), is("first token"));
+        assertThat(api.userBlocks().tokenProvider.getToken(), is("first token"));
+        assertThat(api.users().tokenProvider.getToken(), is("first token"));
 
         //Update the token
         api.setApiToken("new token");
 
-        assertThat(api.blacklists().apiToken, is("new token"));
-        assertThat(api.clientGrants().apiToken, is("new token"));
-        assertThat(api.clients().apiToken, is("new token"));
-        assertThat(api.connections().apiToken, is("new token"));
-        assertThat(api.deviceCredentials().apiToken, is("new token"));
-        assertThat(api.emailProvider().apiToken, is("new token"));
-        assertThat(api.emailTemplates().apiToken, is("new token"));
-        assertThat(api.grants().apiToken, is("new token"));
-        assertThat(api.guardian().apiToken, is("new token"));
-        assertThat(api.jobs().apiToken, is("new token"));
-        assertThat(api.logEvents().apiToken, is("new token"));
-        assertThat(api.resourceServers().apiToken, is("new token"));
-        assertThat(api.rules().apiToken, is("new token"));
-        assertThat(api.stats().apiToken, is("new token"));
-        assertThat(api.tenants().apiToken, is("new token"));
-        assertThat(api.tickets().apiToken, is("new token"));
-        assertThat(api.userBlocks().apiToken, is("new token"));
-        assertThat(api.users().apiToken, is("new token"));
+        assertThat(api.blacklists().tokenProvider.getToken(), is("new token"));
+        assertThat(api.clientGrants().tokenProvider.getToken(), is("new token"));
+        assertThat(api.clients().tokenProvider.getToken(), is("new token"));
+        assertThat(api.connections().tokenProvider.getToken(), is("new token"));
+        assertThat(api.deviceCredentials().tokenProvider.getToken(), is("new token"));
+        assertThat(api.emailProvider().tokenProvider.getToken(), is("new token"));
+        assertThat(api.emailTemplates().tokenProvider.getToken(), is("new token"));
+        assertThat(api.grants().tokenProvider.getToken(), is("new token"));
+        assertThat(api.guardian().tokenProvider.getToken(), is("new token"));
+        assertThat(api.jobs().tokenProvider.getToken(), is("new token"));
+        assertThat(api.logEvents().tokenProvider.getToken(), is("new token"));
+        assertThat(api.resourceServers().tokenProvider.getToken(), is("new token"));
+        assertThat(api.rules().tokenProvider.getToken(), is("new token"));
+        assertThat(api.stats().tokenProvider.getToken(), is("new token"));
+        assertThat(api.tenants().tokenProvider.getToken(), is("new token"));
+        assertThat(api.tickets().tokenProvider.getToken(), is("new token"));
+        assertThat(api.userBlocks().tokenProvider.getToken(), is("new token"));
+        assertThat(api.users().tokenProvider.getToken(), is("new token"));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/SimpleTokenProviderTest.java
+++ b/src/test/java/com/auth0/client/mgmt/SimpleTokenProviderTest.java
@@ -1,0 +1,31 @@
+package com.auth0.client.mgmt;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
+
+public class SimpleTokenProviderTest {
+
+    @Test
+    public void throwsWhenTokenNull() {
+        IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, () -> SimpleTokenProvider.create(null));
+        assertThat(iae.getMessage(), is("'api token' cannot be null!"));
+    }
+
+    @Test
+    public void getTokenReturnsToken() throws Exception {
+        TokenProvider provider = SimpleTokenProvider.create("token");
+        assertThat(provider.getToken(), is("token"));
+    }
+
+    @Test
+    public void getTokenAsyncReturnsTokenFuture() throws Exception {
+        TokenProvider provider = SimpleTokenProvider.create("token");
+        CompletableFuture<String> future = provider.getTokenAsync();
+        assertThat(future.get(), is("token"));
+    }
+}

--- a/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/EmptyBodyRequestTest.java
@@ -1,6 +1,7 @@
 package com.auth0.net;
 
 import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.SimpleTokenProvider;
 import com.auth0.json.auth.TokenHolder;
 import com.auth0.net.client.DefaultHttpClient;
 import com.auth0.net.client.Auth0HttpClient;
@@ -41,7 +42,7 @@ public class EmptyBodyRequestTest {
 
     @Test
     public void shouldCreateEmptyRequestBody() throws Exception {
-        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, SimpleTokenProvider.create("apiToken"), server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
@@ -53,7 +54,7 @@ public class EmptyBodyRequestTest {
 
     @Test
     public void shouldNotAddParameters() throws Exception {
-        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
+        EmptyBodyRequest<TokenHolder> request = new EmptyBodyRequest<>(client, SimpleTokenProvider.create("apiToken"), server.getBaseUrl(), HttpMethod.POST, tokenHolderType);
         Map mapValue = mock(Map.class);
         request.addParameter("key", "value");
         request.addParameter("map", mapValue);

--- a/src/test/java/com/auth0/net/VoidRequestTest.java
+++ b/src/test/java/com/auth0/net/VoidRequestTest.java
@@ -1,10 +1,14 @@
 package com.auth0.net;
 
 import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.TokenProvider;
+import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.*;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
 
 import static com.auth0.client.MockServer.AUTH_TOKENS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,17 +16,29 @@ import static org.hamcrest.Matchers.*;
 
 public class VoidRequestTest {
     private Auth0HttpClient client;
+    private TokenProvider tokenProvider;
     private MockServer server;
 
     @Before
     public void setUp() throws Exception {
         client = new DefaultHttpClient.Builder().build();
         server = new MockServer();
+        tokenProvider = new TokenProvider() {
+            @Override
+            public String getToken() throws Auth0Exception {
+                return "Bearer xyz";
+            }
+
+            @Override
+            public CompletableFuture<String> getTokenAsync() {
+                return CompletableFuture.completedFuture("Bearer xyz");
+            }
+        };
     }
 
     @Test
     public void shouldCreateGETRequest() throws Exception {
-        VoidRequest request = new VoidRequest(client, server.getBaseUrl(), HttpMethod.GET);
+        VoidRequest request = new VoidRequest(client, tokenProvider, server.getBaseUrl(), HttpMethod.GET);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
@@ -34,7 +50,7 @@ public class VoidRequestTest {
 
     @Test
     public void shouldCreatePOSTRequest() throws Exception {
-        VoidRequest request = new VoidRequest(client, server.getBaseUrl(), HttpMethod.POST);
+        VoidRequest request = new VoidRequest(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST);
         assertThat(request, is(notNullValue()));
         request.addParameter("non_empty", "body");
 


### PR DESCRIPTION
As discussed in #479, we should provide the ability to fetch and renew management API tokens, as `node-auth0` does. There are some additional considerations we need to consider, such as good async support and additional configurations like `node-auth0` (cache ttl, scope configurations, support for private jwt key).

This PR adds support for the `TokenProvider` interface and the `SimpleTokenProvider` concrete type, which does not change current behavior of requiring an API token for the `ManagementAPI`, but does enable fetch/renew in the future through a new implementation of the `TokenProvider` interface that would not require a breaking change in the entities or API clients.

Note that the majority of changes are to the entity classes, which will accept a `TokenProvider` instead of an API token upon creation, and to corresponding tests. The key changes in this PR are:

- new `TokenProvider` interface
- new `SImpleTokenProvider` type
- updates to `BaseRequest` to get token for both sync/async use cases
- updates to `ManagementAPI` client to construct `SimpleTokenProvider` from provided String API token