### PR TITLE
Remove deprecated methods

### DIFF
--- a/src/main/java/com/auth0/client/HttpOptions.java
+++ b/src/main/java/com/auth0/client/HttpOptions.java
@@ -2,7 +2,9 @@ package com.auth0.client;
 
 /**
  * Used to configure additional configuration options when customizing the API client instance.
+ * @deprecated use the {@link com.auth0.net.client.DefaultHttpClient} to configure HTTP client behavior
  */
+@Deprecated
 public class HttpOptions {
 
     private ProxyOptions proxyOptions;

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1,6 +1,5 @@
 package com.auth0.client.auth;
 
-import com.auth0.client.HttpOptions;
 import com.auth0.client.mgmt.ManagementAPI;
 import com.auth0.json.auth.PasswordlessEmailResponse;
 import com.auth0.json.auth.PasswordlessSmsResponse;
@@ -71,7 +70,7 @@ public class AuthAPI {
     /**
      * Create a new instance with the given tenant's domain, application's client id and client secret.
      * These values can be obtained at {@code https://manage.auth0.com/#/applications/{YOUR_CLIENT_ID}/settings}.
-     * In addition, accepts an {@link HttpOptions} that will be used to configure the networking client.
+     * In addition, accepts an {@link com.auth0.client.HttpOptions} that will be used to configure the networking client.
      *
      * @deprecated Use the {@link Builder} to configure and create instances.
      *
@@ -82,7 +81,8 @@ public class AuthAPI {
      * @see #AuthAPI(String, String, String)
      */
     @Deprecated
-    public AuthAPI(String domain, String clientId, String clientSecret, HttpOptions options) {
+    @SuppressWarnings("deprecation")
+    public AuthAPI(String domain, String clientId, String clientSecret, com.auth0.client.HttpOptions options) {
         this(domain, clientId, clientSecret, buildNetworkingClient(options));
     }
 
@@ -98,7 +98,7 @@ public class AuthAPI {
      */
     @Deprecated
     public AuthAPI(String domain, String clientId, String clientSecret) {
-        this(domain, clientId, clientSecret, new HttpOptions());
+        this(domain, clientId, clientSecret, new com.auth0.client.HttpOptions());
     }
 
     /**
@@ -145,7 +145,8 @@ public class AuthAPI {
      * @param options the options to set to the client.
      * @return a new networking client instance configured as requested.
      */
-    private static Auth0HttpClient buildNetworkingClient(HttpOptions options) {
+    @SuppressWarnings("deprecation")
+    private static Auth0HttpClient buildNetworkingClient(com.auth0.client.HttpOptions options) {
         Asserts.assertNotNull(options, "Http options");
         return DefaultHttpClient.newBuilder()
             .withLogging(options.getLoggingOptions())

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -52,25 +52,6 @@ public class ClientGrantsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Request all the Client Grants. A token with scope read:client_grants is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
-     *
-     * @return a Request to execute.
-     * @deprecated Calling this method will soon stop returning the complete list of client grants and instead, limit to the first page of results.
-     * Please use {@link #list(ClientGrantsFilter)} instead as it provides pagination support.
-     */
-    @Deprecated
-    public Request<List<ClientGrant>> list() {
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/client-grants")
-                .build()
-                .toString();
-        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<ClientGrant>>() {
-        });
-    }
-
-    /**
      * Create a Client Grant. A token with scope create:client_grants is needed.
      * See https://auth0.com/docs/api/management/v2#!/Client_Grants/post_client_grants
      *

--- a/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientsEntity.java
@@ -35,25 +35,6 @@ public class ClientsEntity extends BaseManagementEntity {
      * Request all the Applications. A token with scope read:clients is needed. If you also need the client_secret and encryption_key attributes the token must have read:client_keys scope.
      * See https://auth0.com/docs/api/management/v2#!/Clients/get_clients
      *
-     * @return a Request to execute.
-     * @deprecated Calling this method will soon stop returning the complete list of clients and instead, limit to the first page of results.
-     * Please use {@link #list(ClientFilter)} instead as it provides pagination support.
-     */
-    @Deprecated
-    public Request<List<Client>> list() {
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/clients")
-                .build()
-                .toString();
-        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Client>>() {
-        });
-    }
-
-    /**
-     * Request all the Applications. A token with scope read:clients is needed. If you also need the client_secret and encryption_key attributes the token must have read:client_keys scope.
-     * See https://auth0.com/docs/api/management/v2#!/Clients/get_clients
-     *
      * @param filter the filter to use. Can be null.
      * @return a Request to execute.
      */

--- a/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ConnectionsEntity.java
@@ -53,33 +53,6 @@ public class ConnectionsEntity extends BaseManagementEntity {
 
 
     /**
-     * Request all the ConnectionsEntity. A token with scope read:connections is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Connections/get_connections
-     *
-     * @param filter the filter to use. Can be null.
-     * @return a Request to execute.
-     * @deprecated Calling this method will soon stop returning the complete list of connections and instead, limit to the first page of results.
-     * Please use {@link #listAll(ConnectionFilter)} instead as it provides pagination support.
-     */
-    @Deprecated
-    public Request<List<Connection>> list(ConnectionFilter filter) {
-        HttpUrl.Builder builder = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/connections");
-        if (filter != null) {
-            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
-                //This check below is to prevent JSON parsing errors
-                if (!e.getKey().equalsIgnoreCase("include_totals")) {
-                    builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
-                }
-            }
-        }
-        String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Connection>>() {
-        });
-    }
-
-    /**
      * Request a Connection. A token with scope read:connections is needed.
      * See https://auth0.com/docs/api/management/v2#!/Connections/get_connections_by_id
      *

--- a/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/GrantsEntity.java
@@ -56,29 +56,6 @@ public class GrantsEntity extends BaseManagementEntity {
     }
 
     /**
-     * Request all Grants. A token with scope read:grants is needed
-     * See https://auth0.com/docs/api/management/v2#!/Grants/get_grants
-     *
-     * @param userId The user id of the grants to retrieve
-     * @return a Request to execute.
-     * @deprecated Calling this method will soon stop returning the complete list of grants and instead, limit to the first page of results.
-     * Please use {@link #list(String, GrantsFilter)} instead as it provides pagination support.
-     */
-    @Deprecated
-    public Request<List<Grant>> list(String userId) {
-        Asserts.assertNotNull(userId, "user id");
-
-        String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/grants")
-                .addQueryParameter("user_id", userId)
-                .build()
-                .toString();
-        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Grant>>() {
-        });
-    }
-
-    /**
      * Delete an existing Grant. A token with scope delete:grants is needed.
      * See https://auth0.com/docs/api/management/v2#!/Grants/delete_grants_by_id<br>
      *

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -1,6 +1,5 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.client.HttpOptions;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.DefaultHttpClient;
 import com.auth0.utils.Asserts;
@@ -37,7 +36,8 @@ public class ManagementAPI {
      * @see #ManagementAPI(String, String)
      */
     @Deprecated
-    public ManagementAPI(String domain, String apiToken, HttpOptions options) {
+    @SuppressWarnings("baz")
+    public ManagementAPI(String domain, String apiToken, com.auth0.client.HttpOptions options) {
         this(domain, SimpleTokenProvider.create(apiToken), buildNetworkingClient(options));
     }
 
@@ -86,7 +86,8 @@ public class ManagementAPI {
      * @param options the options to set to the client.
      * @return a new networking client instance configured as requested.
      */
-    private static DefaultHttpClient buildNetworkingClient(HttpOptions options) {
+    @SuppressWarnings("deprecation")
+    private static DefaultHttpClient buildNetworkingClient(com.auth0.client.HttpOptions options) {
         Asserts.assertNotNull(options, "Http options");
         return DefaultHttpClient.newBuilder()
             .withLogging(options.getLoggingOptions())

--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -24,7 +24,7 @@ public class ManagementAPI {
 
     /**
      * Create an instance with the given tenant's domain and API token.
-     * In addition, accepts an {@link HttpOptions} that will be used to configure the networking client.
+     * In addition, accepts an {@link com.auth0.client.HttpOptions} that will be used to configure the networking client.
      * See the Management API section in the readme or visit https://auth0.com/docs/api/management/v2/tokens
      * to learn how to obtain a token.
      *

--- a/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ResourceServerEntity.java
@@ -52,26 +52,6 @@ public class ResourceServerEntity extends BaseManagementEntity {
     }
 
     /**
-     * Creates request to fetch all resource servers.
-     * See <a href=https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers>API documentation</a>
-     *
-     * @return request to execute
-     * @deprecated Calling this method will soon stop returning the complete list of resource servers and instead, limit to the first page of results.
-     * Please use {@link #list(ResourceServersFilter)} instead as it provides pagination support.
-     */
-    @Deprecated
-    public Request<List<ResourceServer>> list() {
-        HttpUrl.Builder builder = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/resource-servers");
-
-        String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET,
-                new TypeReference<List<ResourceServer>>() {
-                });
-    }
-
-    /**
      * Cretes request for fetching single resource server by it's ID.
      * See <a href=https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers_by_id>API documentation</a>
      *

--- a/src/main/java/com/auth0/client/mgmt/RulesEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/RulesEntity.java
@@ -51,33 +51,6 @@ public class RulesEntity extends BaseManagementEntity {
     }
 
     /**
-     * Request all the Rules. A token with scope read:rules is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Rules/get_rules
-     *
-     * @param filter the filter to use. Can be null.
-     * @return a Request to execute.
-     * @deprecated Calling this method will soon stop returning the complete list of rules and instead, limit to the first page of results.
-     * Please use {@link #listAll(RulesFilter)} instead as it provides pagination support.
-     */
-    @Deprecated
-    public Request<List<Rule>> list(RulesFilter filter) {
-        HttpUrl.Builder builder = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/rules");
-        if (filter != null) {
-            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
-                //This check below is to prevent JSON parsing errors
-                if (!e.getKey().equalsIgnoreCase("include_totals")) {
-                    builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
-                }
-            }
-        }
-        String url = builder.build().toString();
-        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<List<Rule>>() {
-        });
-    }
-
-    /**
      * Request a Rule. A token with scope read:rules is needed.
      * See https://auth0.com/docs/api/management/v2#!/Rules/get_rules_by_id
      *

--- a/src/main/java/com/auth0/json/mgmt/guardian/EnrollmentTicket.java
+++ b/src/main/java/com/auth0/json/mgmt/guardian/EnrollmentTicket.java
@@ -75,18 +75,6 @@ public class EnrollmentTicket {
     }
 
     /**
-     * Setter for the id of the user this ticket is meant to.
-     *
-     * @param userId the user id to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("user_id")
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
-    /**
      * Whether to send and email for enrollment or not.
      *
      * @return true is this ticket will send an email upon enrollment, false otherwise.
@@ -97,18 +85,6 @@ public class EnrollmentTicket {
     }
 
     /**
-     * Sets whether to send and email for enrollment or not.
-     *
-     * @param sendEmail whether this ticket will send an email upon enrollment or not.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("send_mail")
-    public void setSendEmail(Boolean sendEmail) {
-        this.sendEmail = sendEmail;
-    }
-
-    /**
      * Getter for the email to which the ticket will be sent.
      *
      * @return the email.
@@ -116,18 +92,6 @@ public class EnrollmentTicket {
     @JsonProperty("email")
     public String getEmail() {
         return email;
-    }
-
-    /**
-     * Setter for the email to which the ticket will be sent.
-     *
-     * @param email the email to sent the ticket to.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("email")
-    public void setEmail(String email) {
-        this.email = email;
     }
 
     /**

--- a/src/main/java/com/auth0/json/mgmt/guardian/SNSFactorProvider.java
+++ b/src/main/java/com/auth0/json/mgmt/guardian/SNSFactorProvider.java
@@ -26,15 +26,6 @@ public class SNSFactorProvider {
     private String snsGCMPlatformApplicationArn;
 
     /**
-     * Creates an empty SNS settings object
-     *
-     * @deprecated use the full constructor instead
-     */
-    @Deprecated
-    public SNSFactorProvider() {
-    }
-
-    /**
      * Creates a SNS settings object
      *
      * @param awsAccessKeyId the Amazon Web Services access key id.
@@ -63,18 +54,6 @@ public class SNSFactorProvider {
     }
 
     /**
-     * Setter for the Amazon Web Services access key id.
-     *
-     * @param awsAccessKeyId the AWS access key id to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("aws_access_key_id")
-    public void setAWSAccessKeyId(String awsAccessKeyId) {
-        this.awsAccessKeyId = awsAccessKeyId;
-    }
-
-    /**
      * Getter for the Amazon Web Services secret access key.
      *
      * @return the AWS secret access key.
@@ -82,18 +61,6 @@ public class SNSFactorProvider {
     @JsonProperty("aws_secret_access_key")
     public String getAWSSecretAccessKey() {
         return awsSecretAccessKey;
-    }
-
-    /**
-     * Setter for the Amazon Web Services secret access key.
-     *
-     * @param awsSecretAccessKey the AWS secret access key to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("aws_secret_access_key")
-    public void setAWSSecretAccessKey(String awsSecretAccessKey) {
-        this.awsSecretAccessKey = awsSecretAccessKey;
     }
 
     /**
@@ -107,18 +74,6 @@ public class SNSFactorProvider {
     }
 
     /**
-     * Setter for the Amazon Web Services region.
-     *
-     * @param awsRegion the AWS region to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("aws_region")
-    public void setAWSRegion(String awsRegion) {
-        this.awsRegion = awsRegion;
-    }
-
-    /**
      * Getter for the Simple Notification Service Apple Push Notification service platform application Amazon Resource Name.
      *
      * @return the SNS APNs ARN.
@@ -126,18 +81,6 @@ public class SNSFactorProvider {
     @JsonProperty("sns_apns_platform_application_arn")
     public String getSNSAPNSPlatformApplicationARN() {
         return snsAPNSPlatformApplicationArn;
-    }
-
-    /**
-     * Setter for the Simple Notification Service Apple Push Notification service platform application Amazon Resource Name.
-     *
-     * @param apnARN the SNS APNs ARN to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("sns_apns_platform_application_arn")
-    public void setSNSAPNSPlatformApplicationARN(String apnARN) {
-        this.snsAPNSPlatformApplicationArn = apnARN;
     }
 
     /**
@@ -150,15 +93,4 @@ public class SNSFactorProvider {
         return snsGCMPlatformApplicationArn;
     }
 
-    /**
-     * Setter for the Simple Notification Service Google Cloud Messaging platform application Amazon Resource Name.
-     *
-     * @param gcmARN the SNS GCM ARN to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("sns_gcm_platform_application_arn")
-    public void setSNSGCMPlatformApplicationARN(String gcmARN) {
-        this.snsGCMPlatformApplicationArn = gcmARN;
-    }
 }

--- a/src/main/java/com/auth0/json/mgmt/guardian/TwilioFactorProvider.java
+++ b/src/main/java/com/auth0/json/mgmt/guardian/TwilioFactorProvider.java
@@ -24,15 +24,6 @@ public class TwilioFactorProvider {
     private String sid;
 
     /**
-     * Creates an empty Twilio settings object
-     *
-     * @deprecated use the full constructor instead
-     */
-    @Deprecated
-    public TwilioFactorProvider() {
-    }
-
-    /**
      * Creates a Twilio settings object
      *
      * You must only specify either a non-null `from` or `messagingServiceSID`, but not both.
@@ -66,22 +57,6 @@ public class TwilioFactorProvider {
     }
 
     /**
-     * Setter for the Twilio From number.
-     *
-     * @param from the from number to set.
-     * @throws IllegalArgumentException when both `from` and `messagingServiceSID` are set
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("from")
-    public void setFrom(String from) throws IllegalArgumentException {
-        if (messagingServiceSID != null) {
-            throw new IllegalArgumentException("You must specify either `from` or `messagingServiceSID`, but not both");
-        }
-        this.from = from;
-    }
-
-    /**
      * Getter for the Twilio Messaging Service SID.
      *
      * @return the messaging service SID.
@@ -89,22 +64,6 @@ public class TwilioFactorProvider {
     @JsonProperty("messaging_service_sid")
     public String getMessagingServiceSID() {
         return messagingServiceSID;
-    }
-
-    /**
-     * Setter for the Twilio Messaging Service SID.
-     *
-     * @param messagingServiceSID the messaging service SID.
-     * @throws IllegalArgumentException when both `from` and `messagingServiceSID` are set
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("messaging_service_sid")
-    public void setMessagingServiceSID(String messagingServiceSID) throws IllegalArgumentException {
-        if (from != null) {
-            throw new IllegalArgumentException("You must specify either `from` or `messagingServiceSID`, but not both");
-        }
-        this.messagingServiceSID = messagingServiceSID;
     }
 
     /**
@@ -118,18 +77,6 @@ public class TwilioFactorProvider {
     }
 
     /**
-     * Setter for the Twilio auth token.
-     *
-     * @param authToken the Twilio auth token to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("auth_token")
-    public void setAuthToken(String authToken) {
-        this.authToken = authToken;
-    }
-
-    /**
      * Getter for the Twilio SID
      *
      * @return the Twilio SID.
@@ -139,15 +86,4 @@ public class TwilioFactorProvider {
         return sid;
     }
 
-    /**
-     * Setter for the Twilio SID
-     *
-     * @param SID the Twilio SID to set.
-     * @deprecated use the constructor instead
-     */
-    @Deprecated
-    @JsonProperty("sid")
-    public void setSID(String SID) {
-        this.sid = SID;
-    }
 }

--- a/src/main/java/com/auth0/net/RateLimitInterceptor.java
+++ b/src/main/java/com/auth0/net/RateLimitInterceptor.java
@@ -1,6 +1,6 @@
 package com.auth0.net;
 
-import com.auth0.client.HttpOptions;
+import com.auth0.net.client.DefaultHttpClient;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.event.ExecutionAttemptedEvent;
@@ -16,11 +16,9 @@ import java.time.temporal.ChronoUnit;
  * An OkHttp {@linkplain Interceptor} responsible for retrying rate-limit errors (429) using a configurable maximum
  * number of retries, and an exponential backoff on retry attempts.
  * <p>
- * See {@link com.auth0.client.HttpOptions#setManagementAPIMaxRetries(int)} and {@link com.auth0.client.mgmt.ManagementAPI#ManagementAPI(String, String, HttpOptions)}
- * </p>
- * <p>
  * <strong>Note: This class is not intended for general use or extension, and may change at any time.</strong>
  * </p>
+ * @see DefaultHttpClient
  */
 public class RateLimitInterceptor implements Interceptor {
 

--- a/src/test/java/com/auth0/client/HttpOptionsTest.java
+++ b/src/test/java/com/auth0/client/HttpOptionsTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+@SuppressWarnings("deprecation")
 public class HttpOptionsTest {
 
     @Test

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1,6 +1,5 @@
 package com.auth0.client.auth;
 
-import com.auth0.client.HttpOptions;
 import com.auth0.client.MockServer;
 import com.auth0.exception.APIException;
 import com.auth0.json.auth.*;
@@ -69,7 +68,7 @@ public class AuthAPITest {
     @Test
     @SuppressWarnings("deprecation")
     public void shouldAcceptHttpOptions() {
-        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, new HttpOptions());
+        AuthAPI api = new AuthAPI(DOMAIN, CLIENT_ID, CLIENT_SECRET, new com.auth0.client.HttpOptions());
         assertThat(api, is(notNullValue()));
     }
 
@@ -139,11 +138,12 @@ public class AuthAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldThrowOnInValidMaxRequestsPerHostConfiguration() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("maxRequestsPerHost must be one or greater.");
 
-        HttpOptions options = new HttpOptions();
+        com.auth0.client.HttpOptions options = new com.auth0.client.HttpOptions();
         options.setMaxRequestsPerHost(0);
     }
 

--- a/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientGrantsEntityTest.java
@@ -101,38 +101,6 @@ public class ClientGrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(response.getItems(), hasSize(2));
     }
 
-
-    @Test
-    public void shouldListClientGrants() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<ClientGrant>> request = api.clientGrants().list();
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CLIENT_GRANTS_LIST, 200);
-        List<ClientGrant> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/client-grants"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldReturnEmptyClientGrants() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<ClientGrant>> request = api.clientGrants().list();
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<ClientGrant> response = request.execute().getBody();
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, is(emptyCollectionOf(ClientGrant.class)));
-    }
-
     @Test
     public void shouldThrowOnCreateClientGrantWithNullClientId() {
         exception.expect(IllegalArgumentException.class);

--- a/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ClientsEntityTest.java
@@ -124,37 +124,6 @@ public class ClientsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
-    public void shouldListClients() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Client>> request = api.clients().list();
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CLIENTS_LIST, 200);
-        List<Client> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/clients"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldReturnEmptyClients() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Client>> request = api.clients().list();
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Client> response = request.execute().getBody();
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, is(emptyCollectionOf(Client.class)));
-    }
-
-    @Test
     public void shouldThrowOnGetClientWithNullId() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'client id' cannot be null!");

--- a/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
@@ -19,88 +19,6 @@ import static org.hamcrest.Matchers.*;
 public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
-    public void shouldListConnections() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Connection>> request = api.connections().list(null);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/connections"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldListConnectionsWithStrategy() throws Exception {
-        ConnectionFilter filter = new ConnectionFilter().withStrategy("auth0");
-
-        @SuppressWarnings("deprecation")
-        Request<List<Connection>> request = api.connections().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/connections"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("strategy", "auth0"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldListConnectionsWithName() throws Exception {
-        ConnectionFilter filter = new ConnectionFilter().withName("my-connection");
-
-        @SuppressWarnings("deprecation")
-        Request<List<Connection>> request = api.connections().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/connections"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("name", "my-connection"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldListConnectionsWithFields() throws Exception {
-        ConnectionFilter filter = new ConnectionFilter().withFields("some,random,fields", true);
-
-        @SuppressWarnings("deprecation")
-        Request<List<Connection>> request = api.connections().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/connections"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("fields", "some,random,fields"));
-        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
     public void shouldListConnectionsWithoutFilter() throws Exception {
         Request<ConnectionsPage> request = api.connections().listAll(null);
         assertThat(request, is(notNullValue()));
@@ -115,27 +33,6 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(2));
-    }
-
-    @Test
-    public void shouldNotListConnectionsWithTotals() throws Exception {
-        ConnectionFilter filter = new ConnectionFilter().withTotals(true);
-
-        @SuppressWarnings("deprecation")
-        Request<List<Connection>> request = api.connections().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_CONNECTIONS_LIST, 200);
-        List<Connection> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/connections"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, not(hasQueryParameter("include_totals")));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
     }
 
     @Test
@@ -179,20 +76,6 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(response.getLength(), is(14));
         assertThat(response.getTotal(), is(14));
         assertThat(response.getLimit(), is(50));
-    }
-
-
-    @Test
-    public void shouldReturnEmptyConnections() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Connection>> request = api.connections().list(null);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Connection> response = request.execute().getBody();
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, is(emptyCollectionOf(Connection.class)));
     }
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/GrantsEntityTest.java
@@ -110,55 +110,6 @@ public class GrantsEntityTest extends BaseMgmtEntityTest {
         assertThat(response.getItems(), hasSize(2));
     }
 
-
-    @Test
-    public void shouldListGrants() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Grant>> request = api.grants().list("userId");
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_GRANTS_LIST, 200);
-        List<Grant> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/grants"));
-        assertThat(recordedRequest, hasQueryParameter("user_id", "userId"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-        for (Grant grant : response) {
-            assertThat(grant.getAudience(), notNullValue());
-            assertThat(grant.getClientId(), notNullValue());
-            assertThat(grant.getId(), notNullValue());
-            assertThat(grant.getScope(), notNullValue());
-            assertThat(grant.getScope(), hasSize(2));
-            assertThat(grant.getUserId(), equalTo("userId"));
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldThrowOnListGrantsWithNullUserId() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'user id' cannot be null!");
-        api.grants().list(null);
-    }
-
-    @Test
-    public void shouldReturnEmptyGrants() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Grant>> request = api.grants().list("userId");
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Grant> response = request.execute().getBody();
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, is(emptyCollectionOf(Grant.class)));
-    }
-
     @Test
     public void shouldThrowOnDeleteGrantWithNullId() {
         exception.expect(IllegalArgumentException.class);

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -1,6 +1,5 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.client.HttpOptions;
 import com.auth0.client.MockServer;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.net.client.Auth0HttpClient;
@@ -168,7 +167,7 @@ public class ManagementAPITest {
     @Test
     @SuppressWarnings("deprecation")
     public void acceptsHttpOptions() {
-        HttpOptions httpOptions = new HttpOptions();
+        com.auth0.client.HttpOptions httpOptions = new com.auth0.client.HttpOptions();
         httpOptions.setConnectTimeout(15);
         ManagementAPI api = new ManagementAPI(DOMAIN, "CLIENT_ID", httpOptions);
         assertThat(api, is(notNullValue()));
@@ -181,11 +180,12 @@ public class ManagementAPITest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldThrowOnInValidMaxRequestsPerHostConfiguration() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("maxRequestsPerHost must be one or greater.");
 
-        HttpOptions options = new HttpOptions();
+        com.auth0.client.HttpOptions options = new com.auth0.client.HttpOptions();
         options.setMaxRequestsPerHost(0);
     }
 

--- a/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ResourceServerEntityTest.java
@@ -82,25 +82,6 @@ public class ResourceServerEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
-    public void shouldListResourceServers() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<ResourceServer>> request = api.resourceServers().list();
-
-        assertThat(request, is(notNullValue()));
-        server.jsonResponse(MGMT_RESOURCE_SERVERS_LIST, 200);
-
-        List<ResourceServer> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/resource-servers"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
     public void shouldUpdateResourceServer() throws Exception {
         ResourceServer resourceServer = new ResourceServer("https://api.my-company.com/api/v2/");
         resourceServer.setId("23445566abab");

--- a/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/RulesEntityTest.java
@@ -19,24 +19,6 @@ import static org.hamcrest.Matchers.*;
 public class RulesEntityTest extends BaseMgmtEntityTest {
 
     @Test
-    public void shouldListRules() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Rule>> request = api.rules().list(null);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/rules"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
     public void shouldListRulesWithoutFilter() throws Exception {
         Request<RulesPage> request = api.rules().listAll(null);
         assertThat(request, is(notNullValue()));
@@ -51,70 +33,6 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(2));
-    }
-
-    @Test
-    public void shouldListRulesWithEnabled() throws Exception {
-        RulesFilter filter = new RulesFilter().withEnabled(true);
-
-        @SuppressWarnings("deprecation")
-        Request<List<Rule>> request = api.rules().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/rules"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("enabled", "true"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldListRulesWithFields() throws Exception {
-        RulesFilter filter = new RulesFilter().withFields("some,random,fields", true);
-
-        @SuppressWarnings("deprecation")
-        Request<List<Rule>> request = api.rules().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/rules"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, hasQueryParameter("fields", "some,random,fields"));
-        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
-    }
-
-    @Test
-    public void shouldNotListRulesWithTotals() throws Exception {
-        RulesFilter filter = new RulesFilter().withTotals(true);
-
-        @SuppressWarnings("deprecation")
-        Request<List<Rule>> request = api.rules().list(filter);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_RULES_LIST, 200);
-        List<Rule> response = request.execute().getBody();
-        RecordedRequest recordedRequest = server.takeRequest();
-
-        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/rules"));
-        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
-        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        assertThat(recordedRequest, not(hasQueryParameter("include_totals")));
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, hasSize(2));
     }
 
     @Test
@@ -158,19 +76,6 @@ public class RulesEntityTest extends BaseMgmtEntityTest {
         assertThat(response.getLength(), is(14));
         assertThat(response.getTotal(), is(14));
         assertThat(response.getLimit(), is(50));
-    }
-
-    @Test
-    public void shouldReturnEmptyRules() throws Exception {
-        @SuppressWarnings("deprecation")
-        Request<List<Rule>> request = api.rules().list(null);
-        assertThat(request, is(notNullValue()));
-
-        server.jsonResponse(MGMT_EMPTY_LIST, 200);
-        List<Rule> response = request.execute().getBody();
-
-        assertThat(response, is(notNullValue()));
-        assertThat(response, is(emptyCollectionOf(Rule.class)));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/guardian/SNSFactorProviderTest.java
+++ b/src/test/java/com/auth0/json/mgmt/guardian/SNSFactorProviderTest.java
@@ -15,12 +15,7 @@ public class SNSFactorProviderTest extends JsonTest<SNSFactorProvider> {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldSerializeWithDeprecatedSetters() throws Exception {
-        SNSFactorProvider provider = new SNSFactorProvider();
-        provider.setAWSRegion("ar");
-        provider.setAWSAccessKeyId("akey");
-        provider.setAWSSecretAccessKey("secretakey");
-        provider.setSNSAPNSPlatformApplicationARN("arn1");
-        provider.setSNSGCMPlatformApplicationARN("arn2");
+        SNSFactorProvider provider = new SNSFactorProvider("akey", "secretakey", "ar", "arn1", "arn2");
 
         String serialized = toJSON(provider);
         assertThat(serialized, is(notNullValue()));

--- a/src/test/java/com/auth0/json/mgmt/guardian/TwilioFactorProviderTest.java
+++ b/src/test/java/com/auth0/json/mgmt/guardian/TwilioFactorProviderTest.java
@@ -28,33 +28,8 @@ public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void shouldFailWhenSettingFromAndMessagingServiceSIDWasAlreadySet() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("You must specify either `from` or `messagingServiceSID`, but not both");
-
-        TwilioFactorProvider provider = new TwilioFactorProvider();
-        provider.setFrom("+12356789");
-        provider.setMessagingServiceSID("id321");
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldFailWhenSettingMessagingServiceSIDAndFromWasAlreadySet() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("You must specify either `from` or `messagingServiceSID`, but not both");
-
-        TwilioFactorProvider provider = new TwilioFactorProvider();
-        provider.setMessagingServiceSID("id321");
-        provider.setFrom("+12356789");
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
     public void shouldSerializeWithDeprecatedSettersWithFrom() throws Exception {
-        TwilioFactorProvider provider = new TwilioFactorProvider();
-        provider.setAuthToken("atokEn");
-        provider.setFrom("+12356789");
-        provider.setSID("id123");
+        TwilioFactorProvider provider = new TwilioFactorProvider("+12356789", null, "atokEn", "id123");
 
         String serialized = toJSON(provider);
         assertThat(serialized, is(notNullValue()));
@@ -67,10 +42,7 @@ public class TwilioFactorProviderTest extends JsonTest<TwilioFactorProvider> {
     @SuppressWarnings("deprecation")
     @Test
     public void shouldSerializeWithDeprecatedSettersWithMessagingServiceSID() throws Exception {
-        TwilioFactorProvider provider = new TwilioFactorProvider();
-        provider.setAuthToken("atokEn");
-        provider.setMessagingServiceSID("id321");
-        provider.setSID("id123");
+        TwilioFactorProvider provider = new TwilioFactorProvider(null, "id321", "atokEn", "id123");
 
         String serialized = toJSON(provider);
         assertThat(serialized, is(notNullValue()));


### PR DESCRIPTION
This PR removes existing deprecated methods, and deprecates `HttpOptions` in favor of `DefaultHttpClient` configuration.