### PR TITLE
Release 1.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.44.2](https://github.com/auth0/auth0-java/tree/1.44.2) (2023-01-11)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.1...1.44.2)
+
+This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
+Please review [the README note for additional details.](https://github.com/auth0/auth0-java/blob/master/README.md)
+
+**Security**
+- Bump java-jwt dependency to 3.19.4 [\#498](https://github.com/auth0/auth0-java/pull/498) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [1.44.1](https://github.com/auth0/auth0-java/tree/1.44.1) (2022-10-25)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.0...1.44.1)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **Note**
+> As part of our ongoing commitment to best security practices, we have rotated the signing keys used to sign previous releases of this SDK. As a result, new patch builds have been released using the new signing key. Please upgrade at your earliest convenience.
+>
+> While this change won't affect most developers, if you have implemented a dependency signature validation step in your build process, you may notice a warning that past releases can't be verified. This is expected, and a result of the key rotation process. Updating to the latest version will resolve this for you.
+
 ![A Java client library for the Auth0 Authentication and Management APIs.](https://cdn.auth0.com/website/sdks/banners/auth0-java-banner.png)
 
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/auth0-java.svg?style=flat-square)](https://circleci.com/gh/auth0/auth0-java/tree/master)
@@ -28,14 +33,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>1.44.1</version>
+  <version>1.44.2</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:1.44.1'
+implementation 'com.auth0:auth0:1.44.2'
 ```
 
 ### Configure the SDK


### PR DESCRIPTION
## [1.44.2](https://github.com/auth0/auth0-java/tree/1.44.2) (2023-01-11)
[Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.1...1.44.2)

This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
Please review [the README note for additional details.](https://github.com/auth0/auth0-java/blob/master/README.md)

**Security**
- Bump java-jwt dependency to 3.19.4 [\#498](https://github.com/auth0/auth0-java/pull/498) ([jimmyjames](https://github.com/jimmyjames))
