### PR TITLE
[SDK-3746] Add support for MFA APIs

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1,9 +1,7 @@
 package com.auth0.client.auth;
 
 import com.auth0.client.mgmt.ManagementAPI;
-import com.auth0.json.auth.PasswordlessEmailResponse;
-import com.auth0.json.auth.PasswordlessSmsResponse;
-import com.auth0.json.auth.UserInfo;
+import com.auth0.json.auth.*;
 import com.auth0.net.*;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.DefaultHttpClient;
@@ -14,6 +12,9 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.TestOnly;
 
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -895,6 +896,216 @@ public class AuthAPI {
         addSecret(request, false);
         return request;
     }
+
+    /**
+     * Creates a request to exchange the mfa token and an out-of-band (OOB) challenge (either Push notification, SMS, or Voice).
+     * Confidential clients (Regular Web Apps) <strong>must</strong> have a client secret configured on this {@code AuthAPI} instance.
+     * <pre>
+     * {@code
+     * try {
+     *      TokenHolder result = authAPI.exchangeMfaOOB("the-mfa-token", new char[]{'a','n','o','t','p'}, new char[]{'b','i','n','d','c','o','d','e'})
+     *          .execute()
+     *          .getBody();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param mfaToken the mfa_token received from the mfa_required error that occurred during login. Must not be null.
+     * @param oobCode  the OOB Code provided by the user. Must not be null.
+     * @param bindingCode A code used to bind the side channel (used to deliver the challenge) with the main channel you are using to authenticate. This is usually an OTP-like code delivered as part of the challenge message. May be null.
+     *
+     * @return a Request to configure and execute.
+     *
+     * @see <a href="https://auth0.com/docs/api/authentication#verify-with-out-of-band-oob-">Verify with Out-of-band (OOB) API documentation</a>
+     */
+    public TokenRequest exchangeMfaOob(String mfaToken, char[] oobCode, char[] bindingCode) {
+        Asserts.assertNotNull(mfaToken, "mfa token");
+        Asserts.assertNotNull(oobCode, "OOB code");
+
+        TokenRequest request = new TokenRequest(client, getTokenUrl());
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        request.addParameter(KEY_GRANT_TYPE, "http://auth0.com/oauth/grant-type/mfa-oob");
+        request.addParameter(KEY_MFA_TOKEN, mfaToken);
+        request.addParameter("oob_code", oobCode);
+
+        if (Objects.nonNull(bindingCode) && bindingCode.length > 0) {
+            request.addParameter("binding_code", bindingCode);
+        }
+
+        addSecret(request, false);
+        return request;
+    }
+
+    /**
+     * Creates a request to exchange the mfa token using a recovery code.
+     * Confidential clients (Regular Web Apps) <strong>must</strong> have a client secret configured on this {@code AuthAPI} instance.
+     * <pre>
+     * {@code
+     * try {
+     *      TokenHolder result = authAPI.exchangeMfaRecoveryCode("the-mfa-token", new char[]{'c','o','d','e'})
+     *          .execute()
+     *          .getBody();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param mfaToken the mfa_token received from the mfa_required error that occurred during login. Must not be null.
+     * @param recoveryCode  the recovery code provided by the user. Must not be null.
+     * @return a Request to configure and execute.
+     *
+     * @see <a href="https://auth0.com/docs/api/authentication#verify-with-recovery-code">Verify with a recovery code API documentation</a>
+     */
+    public TokenRequest exchangeMfaRecoveryCode(String mfaToken, char[] recoveryCode) {
+        Asserts.assertNotNull(mfaToken, "mfa token");
+        Asserts.assertNotNull(recoveryCode, "recovery code");
+
+        TokenRequest request = new TokenRequest(client, getTokenUrl());
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        request.addParameter(KEY_GRANT_TYPE, "http://auth0.com/oauth/grant-type/mfa-recovery-code");
+        request.addParameter(KEY_MFA_TOKEN, mfaToken);
+        request.addParameter("recovery_code", recoveryCode);
+
+        addSecret(request, false);
+        return request;
+    }
+
+    //  https://auth0.com/docs/api/authentication#challenge-request
+    public Request<MfaChallengeResponse> mfaChallengeRequest(String token, String challengeType, String authenticatorId) {
+        Asserts.assertNotNull(token, "token");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegment("mfa")
+            .addPathSegment("challenge")
+            .build()
+            .toString();
+
+        CustomRequest<MfaChallengeResponse> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<MfaChallengeResponse>() {
+        });
+
+        request.addParameter(KEY_MFA_TOKEN, token);
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        addSecret(request, false);
+        if (Objects.nonNull(challengeType)) {
+            request.addParameter("challenge_type", challengeType);
+        }
+        if (Objects.nonNull(authenticatorId)) {
+            request.addParameter("authenticator_id", authenticatorId);
+        }
+        return request;
+    }
+
+
+
+
+
+    //  https://auth0.com/docs/api/authentication#add-an-authenticator
+    public Request<CreatedOTPResponse> addOTPAuthenticator(String token) {
+        Asserts.assertNotNull(token, "token");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegment("mfa")
+            .addPathSegment("associate")
+            .build()
+            .toString();
+
+        CustomRequest<CreatedOTPResponse> request = new CustomRequest<>(client, url, HttpMethod.POST, new TypeReference<CreatedOTPResponse>() {
+        });
+
+        request.addParameter("authenticator_types", Collections.singletonList("otp"));
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        addSecret(request, false);
+        request.addHeader("Authorization", "Bearer " + token);
+        return request;
+    }
+
+    //  https://auth0.com/docs/api/authentication#list-authenticators
+    // token requires read:authenticators scope and audience claim of https://YOUR_DOMAIN/mfa/
+    // TODO token has audience claim or needs to be added in request??
+    //  token has it. Login request would need to specify scope and audience for access token
+    public Request<List<MfaAuthenticator>> listAuthenticators(String accessToken) {
+        Asserts.assertNotNull(accessToken, "access token");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegment("mfa")
+            .addPathSegment("authenticators")
+            .build()
+            .toString();
+
+        CustomRequest<List<MfaAuthenticator>> request = new CustomRequest<>(client, url, HttpMethod.GET, new TypeReference<List<MfaAuthenticator>>() {
+        });
+
+        request.addHeader("Authorization", "Bearer " + accessToken);
+        return request;
+        // MfaAuthenticator:
+        //  id: String
+        //  authenticator_tyupe: String
+        //  active: boolean
+        //  name: String (may be null)
+        //  oob_channel: String (may be null)
+        //
+        // add access token header?
+        /*
+        [
+          {
+            "id":"recovery-code|dev_DsvzGfZw2Fg5N3rI",
+            "authenticator_type":"recovery-code",
+            "active":true
+          },
+          {
+            "id":"sms|dev_gB342kcL2K22S4yB",
+            "authenticator_type":"oob",
+            "oob_channel":"sms",
+            "name":"+X XXXX1234",
+            "active":true
+          },
+          {
+            "id":"sms|dev_gB342kcL2K22S4yB",
+            "authenticator_type":"oob",
+            "oob_channel":"sms",
+            "name":"+X XXXX1234",
+            "active":false
+          },
+          {
+            "id":"push|dev_433sJ7Mcwj9P794y",
+            "authenticator_type":"oob",
+            "oob_channel":"auth0",
+            "name":"John's Device",
+            "active":true
+          },
+            {
+            "id":"totp|dev_LJaKaN5O3tjRFOw2",
+            "authenticator_type":"otp",
+            "active":true
+          }
+        ]
+         */
+    }
+
+    //  https://auth0.com/docs/api/authentication#delete-an-authenticator
+    public Request<Void> deleteAuthenticator(String accessToken, String authenticatorId) {
+        Asserts.assertNotNull(accessToken, "access token");
+        Asserts.assertNotNull(authenticatorId, "authenticator ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegment("mfa")
+            .addPathSegment("authenticators")
+            .addPathSegment(authenticatorId)
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, url, HttpMethod.DELETE);
+        request.addHeader("Authorization", "Bearer " + accessToken);
+        return request;
+    }
+
 
     private TokenRequest exchangeCode(String code, String redirectUri, boolean secretRequired) {
         Asserts.assertNotNull(code, "code");

--- a/src/main/java/com/auth0/json/auth/CreatedOTPResponse.java
+++ b/src/main/java/com/auth0/json/auth/CreatedOTPResponse.java
@@ -1,0 +1,48 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreatedOTPResponse {
+
+    @JsonProperty("secret")
+    private String secret;
+
+    @JsonProperty("barcode_uri")
+    private String barcodeUri;
+
+    @JsonProperty("authenticator_type")
+    private String authenticatorType;
+
+    @JsonProperty("recovery_codes")
+    private List<String> recoveryCodes;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public String getBarcodeUri() {
+        return barcodeUri;
+    }
+
+    public String getAuthenticatorType() {
+        return authenticatorType;
+    }
+
+    public List<String> getRecoveryCodes() {
+        return recoveryCodes;
+    }
+
+
+    /*
+    "secret": "ABCDEFGMK5CE6WTZKRTTQRKUJVFXOVRF",
+  "barcode_uri":"otpauth://...",
+  "authenticator_type":"otp",
+  "recovery_codes":["ABCDEFGDRFK75ABYR7PH8TJA"],
+     */
+}

--- a/src/main/java/com/auth0/json/auth/CreatedOobResponse.java
+++ b/src/main/java/com/auth0/json/auth/CreatedOobResponse.java
@@ -1,0 +1,47 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreatedOobResponse {
+
+    @JsonProperty("oob_code")
+    private String oobCode;
+
+    @JsonProperty("barcode_uri")
+    private String barcodeUri;
+
+    @JsonProperty("authenticator_type")
+    private String authenticatorType;
+
+    @JsonProperty("oob_channel")
+    private String oobChannel;
+
+    @JsonProperty("recovery_codes")
+    private List<String> recoveryCodes;
+
+    public String getOobCode() {
+        return oobCode;
+    }
+
+    public String getBarcodeUri() {
+        return barcodeUri;
+    }
+
+    public String getAuthenticatorType() {
+        return authenticatorType;
+    }
+
+    public List<String> getRecoveryCodes() {
+        return recoveryCodes;
+    }
+
+    public String getOobChannel() {
+        return oobChannel;
+    }
+}

--- a/src/main/java/com/auth0/json/auth/CreatedOtpResponse.java
+++ b/src/main/java/com/auth0/json/auth/CreatedOtpResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CreatedOTPResponse {
+public class CreatedOtpResponse {
 
     @JsonProperty("secret")
     private String secret;
@@ -38,11 +38,4 @@ public class CreatedOTPResponse {
         return recoveryCodes;
     }
 
-
-    /*
-    "secret": "ABCDEFGMK5CE6WTZKRTTQRKUJVFXOVRF",
-  "barcode_uri":"otpauth://...",
-  "authenticator_type":"otp",
-  "recovery_codes":["ABCDEFGDRFK75ABYR7PH8TJA"],
-     */
 }

--- a/src/main/java/com/auth0/json/auth/MfaAuthenticator.java
+++ b/src/main/java/com/auth0/json/auth/MfaAuthenticator.java
@@ -8,26 +8,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MfaAuthenticator {
 
-    //  id: String
     @JsonProperty("id")
     private String id;
 
-    //  authenticator_tyupe: String
     @JsonProperty("authenticator_type")
     private String authenticatorType;
 
-    //  active: boolean
     @JsonProperty("active")
     private boolean active;
 
-    //  name: String (may be null)
     @JsonProperty("name")
     private String name;
 
-    //  oob_channel: String (may be null)
     @JsonProperty("oob_channel")
     private String oobChannel;
-
 
     public String getId() {
         return id;

--- a/src/main/java/com/auth0/json/auth/MfaAuthenticator.java
+++ b/src/main/java/com/auth0/json/auth/MfaAuthenticator.java
@@ -1,0 +1,51 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MfaAuthenticator {
+
+    //  id: String
+    @JsonProperty("id")
+    private String id;
+
+    //  authenticator_tyupe: String
+    @JsonProperty("authenticator_type")
+    private String authenticatorType;
+
+    //  active: boolean
+    @JsonProperty("active")
+    private boolean active;
+
+    //  name: String (may be null)
+    @JsonProperty("name")
+    private String name;
+
+    //  oob_channel: String (may be null)
+    @JsonProperty("oob_channel")
+    private String oobChannel;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAuthenticatorType() {
+        return authenticatorType;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getOobChannel() {
+        return oobChannel;
+    }
+}

--- a/src/main/java/com/auth0/json/auth/MfaChallengeResponse.java
+++ b/src/main/java/com/auth0/json/auth/MfaChallengeResponse.java
@@ -1,0 +1,31 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MfaChallengeResponse {
+
+    @JsonProperty("challenge_type")
+    private String challengeType;
+
+    @JsonProperty("binding_method")
+    private String bindingMethod;
+
+    @JsonProperty("oob_code")
+    private String oobCode;
+
+    public String getChallengeType() {
+        return challengeType;
+    }
+
+    public String getBindingMethod() {
+        return bindingMethod;
+    }
+
+    public String getOobCode() {
+        return oobCode;
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -28,6 +28,10 @@ public class MockServer {
     public static final String AUTH_ERROR_WITH_DESCRIPTION = "src/test/resources/auth/error_with_description.json";
     public static final String AUTH_ERROR_WITH_DESCRIPTION_AND_EXTRA_PROPERTIES = "src/test/resources/auth/error_with_description_and_extra_properties.json";
     public static final String AUTH_ERROR_PLAINTEXT = "src/test/resources/auth/error_plaintext.json";
+    public static final String AUTH_OOB_AUTHENTICATOR_RESPONSE = "src/test/resources/auth/add_oob_authenticator_response.json";
+    public static final String AUTH_OTP_AUTHENTICATOR_RESPONSE = "src/test/resources/auth/add_otp_authenticator_response.json";
+    public static final String AUTH_LIST_AUTHENTICATORS_RESPONSE = "src/test/resources/auth/list_authenticators_response.json";
+    public static final String AUTH_CHALLENGE_RESPONSE = "src/test/resources/auth/mfa_challenge_request_response.json";
     public static final String MGMT_ERROR_WITH_MESSAGE = "src/test/resources/mgmt/error_with_message.json";
     public static final String MGMT_CLIENT_GRANTS_LIST = "src/test/resources/mgmt/client_grants_list.json";
     public static final String MGMT_CLIENT_GRANTS_PAGED_LIST = "src/test/resources/mgmt/client_grants_paged_list.json";

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1215,6 +1215,9 @@ public class AuthAPITest {
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
+
+    // PKCE
+
     @Test
     public void shouldCreateLogInWithAuthorizationCodeGrantWithPKCERequest() throws Exception {
         TokenRequest request = api.exchangeCodeWithVerifier("code123", "verifier", "https://domain.auth0.com/callback");

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1156,7 +1157,44 @@ public class AuthAPITest {
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
-    // MFA grant
+    // PKCE
+
+    @Test
+    public void shouldCreateLogInWithAuthorizationCodeGrantWithPKCERequest() throws Exception {
+        TokenRequest request = api.exchangeCodeWithVerifier("code123", "verifier", "https://domain.auth0.com/callback");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("code", "code123"));
+        assertThat(body, hasEntry("code_verifier", "verifier"));
+        assertThat(body, hasEntry("redirect_uri", "https://domain.auth0.com/callback"));
+        assertThat(body, hasEntry("grant_type", "authorization_code"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldThrowWhenVerifierNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'verifier' cannot be null!");
+        api.exchangeCodeWithVerifier("code", null,"https://domain.auth0.com/callback");
+    }
+
+    // MFA
 
     @Test
     public void shouldThrowWhenExchangeMfaOtpCalledWithNullMfaToken() {
@@ -1215,14 +1253,37 @@ public class AuthAPITest {
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
 
-
-    // PKCE
+    @Test
+    public void shouldThrowWhenExchangeMfaOobCalledWithNullMfaToken() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'mfa token' cannot be null!");
+        api.exchangeMfaOob(null, new char[]{'o','t','p'}, null);
+    }
 
     @Test
-    public void shouldCreateLogInWithAuthorizationCodeGrantWithPKCERequest() throws Exception {
-        TokenRequest request = api.exchangeCodeWithVerifier("code123", "verifier", "https://domain.auth0.com/callback");
+    public void shouldThrowWhenExchangeMfaOobCalledWithNullOoob() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'OOB code' cannot be null!");
+        api.exchangeMfaOob("mfaToken", null, null);
+    }
+
+    @Test
+    public void shouldCreateExchangeMfaOobRequest() throws Exception {
+        TokenRequest request = api.exchangeMfaOob("mfaToken", new char[]{'o','o','b'}, null);
         assertThat(request, is(notNullValue()));
 
+        mfaOobExchangeRequest(request, null, true);
+    }
+
+    @Test
+    public void shouldCreateExchangeMfaOobRequestWithoutSecret() throws Exception {
+        TokenRequest request = apiNoSecret.exchangeMfaOob("mfaToken", new char[]{'o','o','b'}, new char[]{'b','o','b'});
+        assertThat(request, is(notNullValue()));
+
+        mfaOobExchangeRequest(request, "bob", false);
+    }
+
+    private void mfaOobExchangeRequest(TokenRequest request, String bindingCode, boolean secretSent) throws Exception {
         server.jsonResponse(AUTH_TOKENS, 200);
         TokenHolder response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
@@ -1231,12 +1292,22 @@ public class AuthAPITest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body, hasEntry("code", "code123"));
-        assertThat(body, hasEntry("code_verifier", "verifier"));
-        assertThat(body, hasEntry("redirect_uri", "https://domain.auth0.com/callback"));
-        assertThat(body, hasEntry("grant_type", "authorization_code"));
+        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/mfa-oob"));
         assertThat(body, hasEntry("client_id", CLIENT_ID));
-        assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+
+        if (bindingCode != null) {
+            assertThat(body, hasEntry("binding_code", bindingCode));
+        } else {
+            assertThat(body, not(hasKey("binding_code")));
+        }
+
+        if (secretSent) {
+            assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+        } else {
+            assertThat(body, not(hasKey("client_secret")));
+        }
+        assertThat(body, hasEntry("mfa_token", "mfaToken"));
+        assertThat(body, hasEntry("oob_code", "oob"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getAccessToken(), not(emptyOrNullString()));
@@ -1247,9 +1318,179 @@ public class AuthAPITest {
     }
 
     @Test
-    public void shouldThrowWhenVerifierNull() {
+    public void shouldThrowWhenExchangeMfaRecoveryCodeCalledWithNullMfaToken() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("'verifier' cannot be null!");
-        api.exchangeCodeWithVerifier("code", null,"https://domain.auth0.com/callback");
+        exception.expectMessage("'mfa token' cannot be null!");
+        api.exchangeMfaRecoveryCode(null, new char[]{'c','o','d','e'});
+    }
+
+    @Test
+    public void shouldThrowWhenExchangeMfaRecoveryCodeCalledWithNullCode() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'recovery code' cannot be null!");
+        api.exchangeMfaRecoveryCode("mfaToken", null);
+    }
+
+    @Test
+    public void shouldCreateExchangeMfaRecoveryCodeRequest() throws Exception {
+        TokenRequest request = api.exchangeMfaRecoveryCode("mfaToken", new char[]{'c','o','d','e'});
+        assertThat(request, is(notNullValue()));
+
+        mfaRecoveryCodeExchangeRequest(request, true);
+    }
+
+    @Test
+    public void shouldCreateExchangeMfaRecoveryCodeRequestWithoutSecret() throws Exception {
+        TokenRequest request = apiNoSecret.exchangeMfaRecoveryCode("mfaToken", new char[]{'c','o','d','e'});
+        assertThat(request, is(notNullValue()));
+
+        mfaRecoveryCodeExchangeRequest(request, false);
+    }
+
+    private void mfaRecoveryCodeExchangeRequest(TokenRequest request, boolean secretSent) throws Exception {
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("grant_type", "http://auth0.com/oauth/grant-type/mfa-recovery-code"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+
+        if (secretSent) {
+            assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+        } else {
+            assertThat(body, not(hasKey("client_secret")));
+        }
+        assertThat(body, hasEntry("mfa_token", "mfaToken"));
+        assertThat(body, hasEntry("recovery_code", "code"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), is(notNullValue()));
+    }
+
+    @Test
+    public void addOtpAuthenticatorThrowsWhenTokenNull() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'mfa token' cannot be null!");
+        api.addOtpAuthenticator(null);
+    }
+
+    @Test
+    public void addOtpAuthenticatorRequest() throws Exception {
+        Request<CreatedOtpResponse> request = api.addOtpAuthenticator("mfaToken");
+
+        server.jsonResponse(AUTH_OTP_AUTHENTICATOR_RESPONSE, 200);
+        CreatedOtpResponse response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/mfa/associate"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("authenticator_types", Collections.singletonList("otp")));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAuthenticatorType(), not(emptyOrNullString()));
+        assertThat(response.getSecret(), not(emptyOrNullString()));
+        assertThat(response.getBarcodeUri(), not(emptyOrNullString()));
+        assertThat(response.getRecoveryCodes(), notNullValue());
+    }
+
+    @Test
+    public void addOobAuthenticatorThrowsWhenTokenNull() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'mfa token' cannot be null!");
+        api.addOobAuthenticator(null, Collections.singletonList("otp"), null);
+    }
+
+    @Test
+    public void addOobAuthenticatorThrowsWhenChannelsNull() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'OOB channels' cannot be null!");
+        api.addOobAuthenticator("mfaToken", null, null);
+    }
+
+    @Test
+    public void addOobAuthenticatorRequest() throws Exception {
+        Request<CreatedOobResponse> request = api.addOobAuthenticator("mfaToken", Collections.singletonList("sms"), "phone-number");
+
+        server.jsonResponse(AUTH_OOB_AUTHENTICATOR_RESPONSE, 200);
+        CreatedOobResponse response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/mfa/associate"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("authenticator_types", Collections.singletonList("oob")));
+        assertThat(body, hasEntry("oob_channels", Collections.singletonList("sms")));
+        assertThat(body, hasEntry("phone_number", "phone-number"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAuthenticatorType(), not(emptyOrNullString()));
+        assertThat(response.getOobChannel(), not(emptyOrNullString()));
+        assertThat(response.getOobCode(), not(emptyOrNullString()));
+        assertThat(response.getBarcodeUri(), not(emptyOrNullString()));
+        assertThat(response.getRecoveryCodes(), notNullValue());
+    }
+
+    @Test
+    public void listAuthenticatorsThrowsWhenTokenNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'access token' cannot be null!");
+        api.listAuthenticators(null);
+    }
+
+    @Test
+    public void listAuthenticatorsRequest() throws Exception {
+        Request<List<MfaAuthenticator>> request = api.listAuthenticators("token");
+
+        server.jsonResponse(AUTH_LIST_AUTHENTICATORS_RESPONSE, 200);
+        List<MfaAuthenticator> response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/mfa/authenticators"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer token"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void challengeRequestThrowsWhenTokenNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'mfa token' cannot be null!");
+        api.mfaChallengeRequest(null, "otp", "authenticatorId");
+    }
+
+    @Test
+    public void challengeRequest() throws Exception {
+        Request<MfaChallengeResponse> request = api.mfaChallengeRequest("mfaToken", "otp", "authenticatorId");
+
+        server.jsonResponse(AUTH_CHALLENGE_RESPONSE, 200);
+        MfaChallengeResponse response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/mfa/challenge"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("mfa_token", "mfaToken"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+        assertThat(body, hasEntry("challenge_type", "otp"));
+        assertThat(body, hasEntry("authenticator_id", "authenticatorId"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getChallengeType(), not(emptyOrNullString()));
+        assertThat(response.getBindingMethod(), not(emptyOrNullString()));
+        assertThat(response.getOobCode(), not(emptyOrNullString()));
     }
 }

--- a/src/test/resources/auth/add_oob_authenticator_response.json
+++ b/src/test/resources/auth/add_oob_authenticator_response.json
@@ -1,0 +1,8 @@
+{
+  "oob_code": "Fe26.2**da6....",
+  "binding_method":"prompt",
+  "authenticator_type":"oob",
+  "oob_channel":"sms",
+  "recovery_codes":["ABCDEFGDRFK75ABYR7PH8TJA"],
+  "barcode_uri":"otpauth://..."
+}

--- a/src/test/resources/auth/add_otp_authenticator_response.json
+++ b/src/test/resources/auth/add_otp_authenticator_response.json
@@ -1,0 +1,6 @@
+{
+  "secret": "ABCDEFGMK5CE6WTZKRTTQRKUJVFXOVRF",
+  "barcode_uri":"otpauth://...",
+  "authenticator_type":"otp",
+  "recovery_codes":["ABCDEFGDRFK75ABYR7PH8TJA"]
+}

--- a/src/test/resources/auth/list_authenticators_response.json
+++ b/src/test/resources/auth/list_authenticators_response.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id":"recovery-code|dev_DsvzGfZw2Fg5N3rI",
+    "authenticator_type":"recovery-code",
+    "active":true
+  },
+  {
+    "id":"sms|dev_gB342kcL2K22S4yB",
+    "authenticator_type":"oob",
+    "oob_channel":"sms",
+    "name":"+X XXXX1234",
+    "active":true
+  },
+  {
+    "id":"sms|dev_gB342kcL2K22S4yB",
+    "authenticator_type":"oob",
+    "oob_channel":"sms",
+    "name":"+X XXXX1234",
+    "active":false
+  },
+  {
+    "id":"totp|dev_LJaKaN5O3tjRFOw2",
+    "authenticator_type":"otp",
+    "active":true
+  }
+]

--- a/src/test/resources/auth/mfa_challenge_request_response.json
+++ b/src/test/resources/auth/mfa_challenge_request_response.json
@@ -1,0 +1,5 @@
+{
+  "challenge_type":"oob",
+  "binding_method":"prompt",
+  "oob_code": "abcde...dasg"
+}


### PR DESCRIPTION
This change adds support for the following MFA APIs to the AuthAPI client:

- [Challenge request](https://auth0.com/docs/api/authentication#challenge-request)
- [Verify with OTP](https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-)
- [Verify with OOB](https://auth0.com/docs/api/authentication#verify-with-out-of-band-oob-)
- [Verify with recovery code](https://auth0.com/docs/api/authentication#verify-with-recovery-code)
- [Add an authenticator](https://auth0.com/docs/api/authentication#add-an-authenticator)
- [List authenticators](https://auth0.com/docs/api/authentication#list-authenticators)

Note that this PR does not include the DELETE endpoint, as it [appears to not be working as documented](https://community.auth0.com/t/when-deleting-authenticator-it-says-mfa-token-is-invalid/94672). I've reached out to that team; once we hear back we can add support for that endpoint later.

This PR cherry-picks from [here](https://github.com/auth0/auth0-java/pull/484)