### PR TITLE
Enable ability to specify client ID on reset password request

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -274,8 +274,8 @@ public class AuthAPI {
     }
 
     /**
-     * Request a password reset for the given email and database connection. The response will always be successful even if
-     * there's no user associated to the given email for that database connection.
+     * Request a password reset for the given email and database connection, using the client ID configured for this client instance.
+     * The response will always be successful even if there's no user associated to the given email for that database connection.
      * i.e.:
      * <pre>
      * {@code
@@ -293,15 +293,39 @@ public class AuthAPI {
      * @return a Request to execute.
      */
     public Request<Void> resetPassword(String email, String connection) {
+        return resetPassword(this.clientId, email, connection);
+    }
+
+    /**
+     * Request a password reset for the given client ID, email, and database connection. The response will always be successful even if
+     * there's no user associated to the given email for that database connection.
+     * i.e.:
+     * <pre>
+     * {@code
+     * try {
+     *      authAPI.resetPassword("CLIENT-ID", "me@auth0.com", "db-connection").execute().getBody();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @see <a href="https://auth0.com/docs/api/authentication#change-password">Change Password API docs</a>
+     * @param clientId   the client ID of your client.
+     * @param email      the email associated to the database user.
+     * @param connection the database connection where the user was created.
+     * @return a Request to execute.
+     */
+    public Request<Void> resetPassword(String clientId, String email, String connection) {
         Asserts.assertNotNull(email, "email");
         Asserts.assertNotNull(connection, "connection");
 
         String url = baseUrl
-                .newBuilder()
-                .addPathSegment(PATH_DBCONNECTIONS)
-                .addPathSegment("change_password")
-                .build()
-                .toString();
+            .newBuilder()
+            .addPathSegment(PATH_DBCONNECTIONS)
+            .addPathSegment("change_password")
+            .build()
+            .toString();
         VoidRequest request = new VoidRequest(client, null, url, HttpMethod.POST);
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_EMAIL, email);

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -308,6 +308,26 @@ public class AuthAPITest {
         assertThat(response, is(nullValue()));
     }
 
+    @Test
+    public void shouldCreateResetPasswordRequestWithSpecifiedClientId() throws Exception {
+        Request<Void> request = api.resetPassword("CLIENT-ID", "me@auth0.com", "db-connection");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_RESET_PASSWORD, 200);
+        Void response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/dbconnections/change_password"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("email", "me@auth0.com"));
+        assertThat(body, hasEntry("connection", "db-connection"));
+        assertThat(body, hasEntry("client_id", "CLIENT-ID"));
+        assertThat(body, not(hasKey("password")));
+
+        assertThat(response, is(nullValue()));
+    }
 
     //Sign Up
 


### PR DESCRIPTION
Adds the ability to make a request to the reset password API specifying a client ID that may be different from the client's configured client ID.

Fixes #510.