### PR TITLE
[ESD-27129] authentication_methods is an object, not a string

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/users/authenticationmethods/AuthMethod.java
+++ b/src/main/java/com/auth0/json/mgmt/users/authenticationmethods/AuthMethod.java
@@ -1,0 +1,23 @@
+package com.auth0.json.mgmt.users.authenticationmethods;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuthMethod {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("type")
+    private String type;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/authenticationmethods/AuthenticationMethod.java
+++ b/src/main/java/com/auth0/json/mgmt/users/authenticationmethods/AuthenticationMethod.java
@@ -39,7 +39,7 @@ public class AuthenticationMethod {
     @JsonProperty("relying_party_identifier")
     private String relyingPartyIdentifier;
     @JsonProperty("authentication_methods")
-    private List<String> authenticationMethods;
+    private List<AuthMethod> authenticationMethods;
 
     /**
      * Create a new instance.
@@ -240,7 +240,7 @@ public class AuthenticationMethod {
     /**
      * @return list of authentication methods
      */
-    public List<String> getAuthenticationMethods() {
+    public List<AuthMethod> getAuthenticationMethods() {
         return authenticationMethods;
     }
 }

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -109,6 +109,7 @@ public class MockServer {
     public static final String AUTHENTICATOR_METHOD_BY_ID = "src/test/resources/mgmt/authenticator_method_by_id.json";
     public static final String AUTHENTICATOR_METHOD_CREATE = "src/test/resources/mgmt/authenticator_method_create.json";
     public static final String AUTHENTICATOR_METHOD_LIST = "src/test/resources/mgmt/authenticator_method_list.json";
+    public static final String AUTHENTICATOR_METHOD_PAGED_LIST = "src/test/resources/mgmt/authenticator_method_paged_list.json";
     public static final String AUTHENTICATOR_METHOD_UPDATE = "src/test/resources/mgmt/authenticator_method_update.json";
     public static final String AUTHENTICATOR_METHOD_UPDATE_BY_ID = "src/test/resources/mgmt/authenticator_method_update_by_id.json";
     public static final String ORGANIZATION = "src/test/resources/mgmt/organization.json";

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -1113,7 +1113,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
             new PageFilter().withPage(0, 20));
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(AUTHENTICATOR_METHOD_LIST, 200);
+        server.jsonResponse(AUTHENTICATOR_METHOD_PAGED_LIST, 200);
         AuthenticationMethodsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
@@ -1132,7 +1132,7 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
             new PageFilter().withTotals(true));
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(AUTHENTICATOR_METHOD_LIST, 200);
+        server.jsonResponse(AUTHENTICATOR_METHOD_PAGED_LIST, 200);
         AuthenticationMethodsPage response = request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
@@ -1144,8 +1144,8 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(response, is(notNullValue()));
         assertThat(response.getItems(), hasSize(1));
         assertThat(response.getStart(), is(0));
-        assertThat(response.getTotal(), is(1));
-        assertThat(response.getLimit(), is(50));
+        assertThat(response.getTotal(), is(3));
+        assertThat(response.getLimit(), is(1));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/users/authenticationmethods/AuthenticationMethodTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/authenticationmethods/AuthenticationMethodTest.java
@@ -31,7 +31,7 @@ public class AuthenticationMethodTest extends JsonTest<AuthenticationMethod> {
             "      \"totp_secret\":\"totp\",\n" +
             "      \"preferred_authentication_method\":\"phone\",\n" +
             "      \"relying_party_identifier\":\"abc\",\n" +
-            "      \"authentication_methods\":[]\n" +
+            "      \"authentication_methods\":[{\"id\": \"id\", \"type\": \"type\"}]\n" +
             "   }";
 
 
@@ -52,7 +52,9 @@ public class AuthenticationMethodTest extends JsonTest<AuthenticationMethod> {
         assertThat(authenticationMethod.getCreatedAt(), is(parseJSONDate(("2023-01-19T15:15:16.427Z"))));
         assertThat(authenticationMethod.getLastAuthedAt(), is(parseJSONDate(("2023-01-19T15:15:16.427Z"))));
         assertThat(authenticationMethod.getEnrolledAt(), is(parseJSONDate(("2023-01-19T15:15:16.427Z"))));
-        assertThat(authenticationMethod.getAuthenticationMethods(), Matchers.is(notNullValue()));
+        assertThat(authenticationMethod.getAuthenticationMethods(), hasSize(1));
+        assertThat(authenticationMethod.getAuthenticationMethods().get(0).getId(), is("id"));
+        assertThat(authenticationMethod.getAuthenticationMethods().get(0).getType(), is("type"));
 
     }
 

--- a/src/test/resources/mgmt/authenticator_method_list.json
+++ b/src/test/resources/mgmt/authenticator_method_list.json
@@ -1,15 +1,39 @@
-{
-  "authenticators":[
-    {
-      "id":"email|dev_7o0sei0Q5FJNLfk1",
-      "type":"email",
-      "confirmed":true,
-      "name":"123temp@temp123.com",
-      "email":"****@pmes****",
-      "created_at":"2023-01-19T15:26:28.887Z"
-    }
-  ],
-  "total":1,
-  "start":0,
-  "limit":50
-}
+[
+  {
+    "id": "phone|123",
+    "type": "phone",
+    "confirmed": true,
+    "phone_number": "XXXXXXXX0000",
+    "created_at": "2023-02-01T18:44:46.483Z",
+    "last_auth_at": "2023-02-07T20:29:33.547Z",
+    "preferred_authentication_method": "sms",
+    "authentication_methods": [
+      {
+        "id": "sms|id",
+        "type": "sms"
+      }
+    ]
+  },
+  {
+    "id": "webauthn-platform|id",
+    "type": "webauthn-platform",
+    "confirmed": true,
+    "name": "name",
+    "created_at": "2023-02-01T18:44:50.304Z",
+    "last_auth_at": "2023-02-01T18:45:10.817Z",
+    "key_id": "xxxxxx-xxxx_xxxxxxxxxxxxxxx",
+    "public_key": "pubkey",
+    "relying_party_identifier": "tenant.auth0.com"
+  },
+  {
+    "id": "webauthn-platform|id",
+    "type": "webauthn-platform",
+    "confirmed": true,
+    "name": "name",
+    "created_at": "2023-03-14T20:13:25.541Z",
+    "last_auth_at": "2023-03-14T20:13:32.834Z",
+    "key_id": "keyid",
+    "public_key": "pubkey",
+    "relying_party_identifier": "tenant.auth0.com"
+  }
+]

--- a/src/test/resources/mgmt/authenticator_method_paged_list.json
+++ b/src/test/resources/mgmt/authenticator_method_paged_list.json
@@ -1,0 +1,22 @@
+{
+  "authenticators": [
+    {
+      "id": "phone|id",
+      "type": "phone",
+      "confirmed": true,
+      "phone_number": "XXXXXXXX0000",
+      "created_at": "2023-02-01T18:44:46.483Z",
+      "last_auth_at": "2023-02-07T20:29:33.547Z",
+      "preferred_authentication_method": "sms",
+      "authentication_methods": [
+        {
+          "id": "sms|id",
+          "type": "sms"
+        }
+      ]
+    }
+  ],
+  "total": 3,
+  "start": 0,
+  "limit": 1
+}


### PR DESCRIPTION
### Changes

The get authentication methods endpoint returns an `authentication_methods` field, which is an array of objects. Prior to this PR, it was defined as an array of strings.

### References

ESD-27129

### Testing

Updated the existing test json to reflect actual data shape from API call, and added a paged list result JSON as well.
