### PR TITLE
Add missing LogEvent fields

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
@@ -39,6 +39,16 @@ public class LogEvent {
     private Map<String, Object> locationInfo;
     @JsonProperty("details")
     private Map<String, Object> details;
+    @JsonProperty("connection")
+    private String connection;
+    @JsonProperty("connection_id")
+    private String connectionId;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("hostname")
+    private String hostName;
+    @JsonProperty("audience")
+    private String audience;
 
     /**
      * Getter for the id of this event.
@@ -149,5 +159,40 @@ public class LogEvent {
     @JsonProperty("details")
     public Map<String, Object> getDetails() {
         return details;
+    }
+
+    /**
+     * @return the connection.
+     */
+    public String getConnection() {
+        return connection;
+    }
+
+    /**
+     * @return the connection ID
+     */
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    /**
+     * @return the description.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @return the hostname.
+     */
+    public String getHostName() {
+        return hostName;
+    }
+
+    /**
+     * @return the audience.
+     */
+    public String getAudience() {
+        return audience;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
+++ b/src/main/java/com/auth0/json/mgmt/logevents/LogEvent.java
@@ -46,7 +46,7 @@ public class LogEvent {
     @JsonProperty("description")
     private String description;
     @JsonProperty("hostname")
-    private String hostName;
+    private String hostname;
     @JsonProperty("audience")
     private String audience;
 
@@ -185,8 +185,8 @@ public class LogEvent {
     /**
      * @return the hostname.
      */
-    public String getHostName() {
-        return hostName;
+    public String getHostname() {
+        return hostname;
     }
 
     /**

--- a/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
+++ b/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
@@ -47,7 +47,7 @@ public class LogEventTest extends JsonTest<LogEvent> {
         assertThat(logEvent.getAudience(), is("audience"));
         assertThat(logEvent.getConnection(), is("connection"));
         assertThat(logEvent.getConnectionId(), is("connectionId"));
-        assertThat(logEvent.getHostName(), is("hostname"));
+        assertThat(logEvent.getHostname(), is("hostname"));
         assertThat(logEvent.getDescription(), is("description"));
 
     }

--- a/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
+++ b/src/test/java/com/auth0/json/mgmt/logevents/LogEventTest.java
@@ -9,7 +9,24 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class LogEventTest extends JsonTest<LogEvent> {
 
-    private static final String json = "{\"_id\":\"123\", \"log_id\":\"123\", \"date\":\"2016-02-23T19:57:29.532Z\",\"type\":\"thetype\",\"location_info\":{},\"details\":{},\"client_id\":\"clientId\",\"client_name\":\"clientName\",\"ip\":\"233.233.233.11\",\"user_id\":\"userId\",\"user_name\":\"userName\"}";
+    private static final String json = "{\n" +
+        "  \"_id\": \"123\",\n" +
+        "  \"log_id\": \"123\",\n" +
+        "  \"date\": \"2016-02-23T19:57:29.532Z\",\n" +
+        "  \"type\": \"thetype\",\n" +
+        "  \"location_info\": {},\n" +
+        "  \"details\": {},\n" +
+        "  \"client_id\": \"clientId\",\n" +
+        "  \"client_name\": \"clientName\",\n" +
+        "  \"ip\": \"233.233.233.11\",\n" +
+        "  \"user_id\": \"userId\",\n" +
+        "  \"user_name\": \"userName\",\n" +
+        "  \"connection\": \"connection\",\n" +
+        "  \"connection_id\": \"connectionId\",\n" +
+        "  \"description\": \"description\",\n" +
+        "  \"hostname\": \"hostname\",\n" +
+        "  \"audience\": \"audience\"\n" +
+        "}";
 
     @Test
     public void shouldDeserialize() throws Exception {
@@ -27,5 +44,11 @@ public class LogEventTest extends JsonTest<LogEvent> {
         assertThat(logEvent.getUserName(), is("userName"));
         assertThat(logEvent.getLocationInfo(), is(notNullValue()));
         assertThat(logEvent.getDetails(), is(notNullValue()));
+        assertThat(logEvent.getAudience(), is("audience"));
+        assertThat(logEvent.getConnection(), is("connection"));
+        assertThat(logEvent.getConnectionId(), is("connectionId"));
+        assertThat(logEvent.getHostName(), is("hostname"));
+        assertThat(logEvent.getDescription(), is("description"));
+
     }
 }


### PR DESCRIPTION
Fixes #519 

Adds support for the following fields to `LogEvent`:
- `hostname`
- `audience`
- `connection`
- `connection_id`
- `description`