### PR TITLE
Bump jackson dependency to 2.14.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.2"
     implementation "com.auth0:java-jwt:4.3.0"
     implementation "net.jodah:failsafe:2.4.4"
 


### PR DESCRIPTION
### Changes

Update Jackson to 2.14.2 ([release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14.2))