### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [2.1.0](https://github.com/auth0/auth0-java/tree/2.1.0) (2023-03-31)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/2.0.0...2.1.0)
+
+**Added**
+- Add missing LogEvent fields [\#521](https://github.com/auth0/auth0-java/pull/521) ([jimmyjames](https://github.com/jimmyjames)) 
+
+**Changed**
+- authentication_methods is an object, not a string [\#520](https://github.com/auth0/auth0-java/pull/520) ([jimmyjames](https://github.com/jimmyjames))
+- Bump jackson dependency to 2.14.2 [\#522](https://github.com/auth0/auth0-java/pull/522) ([jimmyjames](https://github.com/jimmyjames))
+- Update java-jwt dependency to 4.4.0 [\#523](https://github.com/auth0/auth0-java/pull/523) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [2.0.0](https://github.com/auth0/auth0-java/tree/2.0.0) (2023-02-23)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.2...2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:2.0.0'
+implementation 'com.auth0:auth0:2.1.0'
 ```
 
 ### Configure the SDK


### PR DESCRIPTION
### Changes

**Added**
- Add missing LogEvent fields [\#521](https://github.com/auth0/auth0-java/pull/521) ([jimmyjames](https://github.com/jimmyjames)) 

**Changed**
- authentication_methods is an object, not a string [\#520](https://github.com/auth0/auth0-java/pull/520) ([jimmyjames](https://github.com/jimmyjames))
- Bump jackson dependency to 2.14.2 [\#522](https://github.com/auth0/auth0-java/pull/522) ([jimmyjames](https://github.com/jimmyjames))
- Update java-jwt dependency to 4.4.0 [\#523](https://github.com/auth0/auth0-java/pull/523) ([jimmyjames](https://github.com/jimmyjames))