### PR TITLE
Support Pushed Authorize Requests (PAR)

### DIFF
--- a/src/main/java/com/auth0/json/auth/PushedAuthorizationResponse.java
+++ b/src/main/java/com/auth0/json/auth/PushedAuthorizationResponse.java
@@ -1,0 +1,33 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the response from a Pushed Authorization Request (PAR).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PushedAuthorizationResponse {
+
+    @JsonProperty("request_uri")
+    private String requestURI;
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonCreator
+    public PushedAuthorizationResponse(@JsonProperty("request_uri") String requestURI, @JsonProperty("expires_in") Integer expiresIn) {
+        this.requestURI = requestURI;
+        this.expiresIn = expiresIn;
+    }
+
+    public String getRequestURI() {
+        return requestURI;
+    }
+
+    public Integer getExpiresIn() {
+        return expiresIn;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -92,6 +92,8 @@ public class Client {
     private String crossOriginLoc;
     @JsonProperty("client_authentication_methods")
     private ClientAuthenticationMethods clientAuthenticationMethods;
+    @JsonProperty("require_pushed_authorization_requests")
+    private Boolean requiresPushedAuthorizationRequests;
 
     /**
      * Getter for the name of the tenant this client belongs to.
@@ -802,6 +804,21 @@ public class Client {
 
     public ClientAuthenticationMethods getClientAuthenticationMethods() {
         return clientAuthenticationMethods;
+    }
+
+    /**
+     * @return whether this client requires pushed authorization requests or not.
+     */
+    public Boolean getRequiresPushedAuthorizationRequests() {
+        return requiresPushedAuthorizationRequests;
+    }
+
+    /**
+     * Sets whether the client requires pushed authorization requests or not.
+     * @param requiresPushedAuthorizationRequests true if the client should require pushed authorization requests, false if not.
+     */
+    public void setRequiresPushedAuthorizationRequests(Boolean requiresPushedAuthorizationRequests) {
+        this.requiresPushedAuthorizationRequests = requiresPushedAuthorizationRequests;
     }
 }
 

--- a/src/main/java/com/auth0/net/BaseRequest.java
+++ b/src/main/java/com/auth0/net/BaseRequest.java
@@ -118,6 +118,9 @@ public class BaseRequest<T> implements Request<T> {
         return mapper.readValue(payload, tType);
     }
 
+    protected Map<String, Object> getParameters() {
+        return this.parameters;
+    }
     /**
      * Executes this request.
      *

--- a/src/main/java/com/auth0/net/FormBodyRequest.java
+++ b/src/main/java/com/auth0/net/FormBodyRequest.java
@@ -1,0 +1,40 @@
+package com.auth0.net;
+
+import com.auth0.client.mgmt.TokenProvider;
+import com.auth0.json.ObjectMapperProvider;
+import com.auth0.json.auth.PushedAuthorizationResponse;
+import com.auth0.net.client.*;
+import com.auth0.utils.Asserts;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.FormBody;
+import okhttp3.RequestBody;
+
+import java.io.IOException;
+
+/**
+ * Represents a form request.
+ * @param <T> The type expected to be received as part of the response.
+ */
+public class FormBodyRequest<T> extends BaseRequest<T> {
+
+    private static final String CONTENT_TYPE_FORM_DATA = "application/x-www-form-urlencoded";
+
+    FormBodyRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, ObjectMapper mapper, TypeReference<T> tType) {
+        super(client, tokenProvider, url, method, mapper, tType);
+    }
+
+    public FormBodyRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        this(client, tokenProvider, url, method, ObjectMapperProvider.getMapper(), tType);
+    }
+
+    @Override
+    protected HttpRequestBody createRequestBody() throws IOException {
+        return HttpRequestBody.create(CONTENT_TYPE_FORM_DATA, new Auth0FormRequestBody(super.getParameters()));
+    }
+
+    @Override
+    protected String getContentType() {
+        return CONTENT_TYPE_FORM_DATA;
+    }
+}

--- a/src/main/java/com/auth0/net/client/Auth0FormRequestBody.java
+++ b/src/main/java/com/auth0/net/client/Auth0FormRequestBody.java
@@ -1,0 +1,19 @@
+package com.auth0.net.client;
+
+import java.util.Map;
+
+/**
+ * Represents the body of a application/x-www-form-urlencoded request
+ */
+public class Auth0FormRequestBody {
+
+    private final Map<String, Object> params;
+
+    public Auth0FormRequestBody(Map<String, Object> params) {
+        this.params = params;
+    }
+
+    public Map<String, Object> getParams() {
+        return params;
+    }
+}

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -161,7 +161,16 @@ public class DefaultHttpClient implements Auth0HttpClient {
         HttpRequestBody body = request.getBody();
         RequestBody okBody;
 
-        if (Objects.nonNull(body.getMultipartRequestBody())) {
+        if (Objects.nonNull(body.getFormRequestBody())) {
+            Auth0FormRequestBody formData = body.getFormRequestBody();
+            FormBody.Builder builder = new FormBody.Builder();
+            for (Map.Entry<String, Object> entry : formData.getParams().entrySet()) {
+                Object val = entry.getValue();
+                builder.add(entry.getKey(), val instanceof String ? (String) val : val.toString());
+            }
+            okBody = builder.build();
+        }
+        else if (Objects.nonNull(body.getMultipartRequestBody())) {
             Auth0MultipartRequestBody multipartRequestBody = body.getMultipartRequestBody();
             MultipartBody.Builder bodyBuilder = new MultipartBody.Builder()
                 .setType(MultipartBody.FORM);

--- a/src/main/java/com/auth0/net/client/HttpRequestBody.java
+++ b/src/main/java/com/auth0/net/client/HttpRequestBody.java
@@ -5,6 +5,7 @@ public class HttpRequestBody {
     private byte[] content;
     private String contentType;
     private Auth0MultipartRequestBody multipartRequestBody;
+    private Auth0FormRequestBody formRequestBody;
 
     public static HttpRequestBody create(String contentType, byte[] content) {
         return new HttpRequestBody(contentType, content);
@@ -14,12 +15,20 @@ public class HttpRequestBody {
         return new HttpRequestBody(contentType, multipartRequestBody);
     }
 
+    public static HttpRequestBody create(String contentType, Auth0FormRequestBody formRequestBody) {
+        return new HttpRequestBody(contentType, formRequestBody);
+    }
+
     public byte[] getContent() {
         return this.content;
     }
 
     public Auth0MultipartRequestBody getMultipartRequestBody() {
         return this.multipartRequestBody;
+    }
+
+    public Auth0FormRequestBody getFormRequestBody() {
+        return this.formRequestBody;
     }
 
     public String getContentType() {
@@ -34,5 +43,10 @@ public class HttpRequestBody {
     private HttpRequestBody(String contentType, Auth0MultipartRequestBody multipartRequestBody) {
         this.contentType = contentType;
         this.multipartRequestBody = multipartRequestBody;
+    }
+
+    private HttpRequestBody(String contentType, Auth0FormRequestBody formRequestBody) {
+        this.contentType = contentType;
+        this.formRequestBody = formRequestBody;
     }
 }

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -108,6 +108,7 @@ public class MockServer {
     public static final String MULTIPART_SAMPLE = "src/test/resources/mgmt/multipart_sample.json";
     public static final String PASSWORDLESS_EMAIL_RESPONSE = "src/test/resources/auth/passwordless_email.json";
     public static final String PASSWORDLESS_SMS_RESPONSE = "src/test/resources/auth/passwordless_sms.json";
+    public static final String PUSHED_AUTHORIZATION_RESPONSE = "src/test/resources/auth/pushed_authorization_response.json";
     public static final String AUTHENTICATOR_METHOD_BY_ID = "src/test/resources/mgmt/authenticator_method_by_id.json";
     public static final String AUTHENTICATOR_METHOD_CREATE = "src/test/resources/mgmt/authenticator_method_create.json";
     public static final String AUTHENTICATOR_METHOD_LIST = "src/test/resources/mgmt/authenticator_method_list.json";

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -98,7 +98,8 @@ public class ClientTest extends JsonTest<Client> {
         "        }\n" +
         "      ]\n" +
         "    }\n" +
-        "  }\n" +
+        "  },\n" +
+        "  \"require_pushed_authorization_requests\": true\n" +
         "}";
 
     @Test
@@ -146,6 +147,7 @@ public class ClientTest extends JsonTest<Client> {
         PrivateKeyJwt privateKeyJwt = new PrivateKeyJwt(Collections.singletonList(credential));
         ClientAuthenticationMethods cam = new ClientAuthenticationMethods(privateKeyJwt);
         client.setClientAuthenticationMethods(cam);
+        client.setRequiresPushedAuthorizationRequests(true);
 
         String serialized = toJSON(client);
         assertThat(serialized, is(notNullValue()));
@@ -181,6 +183,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("organization_require_behavior", "pre_login_prompt"));
         assertThat(serialized, JsonMatcher.hasEntry("client_authentication_methods", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("client_authentication_methods", containsString("{\"private_key_jwt\":{\"credentials\":[{\"credential_type\":\"public_key\",\"pem\":\"PEM\"}]}}")));
+        assertThat(serialized, JsonMatcher.hasEntry("require_pushed_authorization_requests", true));
     }
 
     @Test
@@ -231,6 +234,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getClientAuthenticationMethods().getPrivateKeyJwt().getCredentials().size(), is(2));
         assertThat(client.getClientAuthenticationMethods().getPrivateKeyJwt().getCredentials().get(0).getId(), is("cred_abc"));
         assertThat(client.getClientAuthenticationMethods().getPrivateKeyJwt().getCredentials().get(1).getId(), is("cred_123"));
+        assertThat(client.getRequiresPushedAuthorizationRequests(), is(true));
     }
 
     @Test

--- a/src/test/java/com/auth0/net/FormBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/FormBodyRequestTest.java
@@ -1,0 +1,98 @@
+package com.auth0.net;
+
+import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.TokenProvider;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.json.auth.PushedAuthorizationResponse;
+import com.auth0.net.client.Auth0HttpClient;
+import com.auth0.net.client.DefaultHttpClient;
+import com.auth0.net.client.HttpMethod;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.auth0.client.MockServer.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+
+public class FormBodyRequestTest {
+    private MockServer server;
+    private Auth0HttpClient client;
+    private TokenProvider tokenProvider;
+
+    @SuppressWarnings("deprecation")
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    private TypeReference<PushedAuthorizationResponse> pushedAuthorizationResponseTypeReference;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockServer();
+        client = new DefaultHttpClient.Builder().withMaxRetries(0).build();
+        pushedAuthorizationResponseTypeReference = new TypeReference<PushedAuthorizationResponse>() {
+        };
+        tokenProvider = new TokenProvider() {
+            @Override
+            public String getToken() throws Auth0Exception {
+                return "xyz";
+            }
+
+            @Override
+            public CompletableFuture<String> getTokenAsync() {
+                return CompletableFuture.completedFuture("xyz");
+            }
+        };
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void shouldCreatePOSTRequest() throws Exception {
+        FormBodyRequest<PushedAuthorizationResponse> request = new FormBodyRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, pushedAuthorizationResponseTypeReference);
+        assertThat(request, is(notNullValue()));
+        request.addParameter("audience", "aud");
+        request.addParameter("connection", "conn");
+
+        server.jsonResponse(PUSHED_AUTHORIZATION_RESPONSE, 201);
+        PushedAuthorizationResponse execute = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod(), is(HttpMethod.POST.toString()));
+        assertThat(execute, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldNotOverrideContentTypeHeader() throws Exception {
+        FormBodyRequest<PushedAuthorizationResponse> request = new FormBodyRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, pushedAuthorizationResponseTypeReference);
+        request.addHeader("Content-Type", "plaintext");
+
+        server.jsonResponse(PUSHED_AUTHORIZATION_RESPONSE, 201);
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest.getHeader("Content-Type"), containsString("application/x-www-form-urlencoded"));
+    }
+
+    @Test
+    public void shouldAddHeaders() throws Exception {
+        FormBodyRequest<PushedAuthorizationResponse> request = new FormBodyRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, pushedAuthorizationResponseTypeReference);
+        request.addHeader("Extra-Info", "this is a test");
+        request.addHeader("Authorization", "Bearer my_access_token");
+
+        server.jsonResponse(PUSHED_AUTHORIZATION_RESPONSE, 200);
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest.getHeader("Extra-Info"), is("this is a test"));
+        assertThat(recordedRequest.getHeader("Authorization"), is("Bearer xyz"));
+    }
+}

--- a/src/test/resources/auth/pushed_authorization_response.json
+++ b/src/test/resources/auth/pushed_authorization_response.json
@@ -1,0 +1,4 @@
+{
+  "request_uri": "urn:example:bwc4JK-ESC0w8acc191e-Y1LTC2",
+  "expires_in": 90
+}


### PR DESCRIPTION
### Changes

Adds support for PAR by introducing two new methods on `AuthAPI`:

- `public Request<PushedAuthorizationResponse> pushedAuthorizationRequest(String redirectUri, String responseType, Map<String, String> params)` - Builds a request to make the pushed authorization request.
- `public String authorizeUrlWithPAR(String requestUri)`: Given the `request_uri` obtained from a PAR, constructs the authorize URL.

### References

- https://github.com/auth0/auth0-java/pull/531
- https://www.rfc-editor.org/rfc/rfc6749

### Testing

In addition to the unit tests, manually tested using a tenant with PAR enabled to verify.

