### PR TITLE
Export users does not require connection_id

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/JobsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/JobsEntity.java
@@ -38,7 +38,7 @@ public class JobsEntity extends BaseManagementEntity {
 
     /**
      * Request a Job. A token with scope create:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id">GET Jobs by ID</a>.
      *
      * @param jobId the id of the job to retrieve.
      * @return a Request to execute.
@@ -59,7 +59,7 @@ public class JobsEntity extends BaseManagementEntity {
 
     /**
      * Get error details of a failed job. A token with scope create:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/get_errors.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/get_errors">GET Job Errors</a>.
      *
      * @param jobId the id of the job to retrieve.
      * @return a Request to execute.
@@ -90,7 +90,7 @@ public class JobsEntity extends BaseManagementEntity {
 
     /**
      * Sends an Email Verification. A token with scope update:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email">POST Verification Email</a>.
      *
      * @param userId   The user_id of the user to whom the email will be sent.
      * @param clientId The id of the client, if not provided the global one will be used.
@@ -105,7 +105,7 @@ public class JobsEntity extends BaseManagementEntity {
 
     /**
      * Sends an Email Verification. A token with scope update:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email">POST Verification Email</a>.
      *
      * @param userId   The user_id of the user to whom the email will be sent.
      * @param clientId The id of the client, if not provided the global one will be used.
@@ -121,7 +121,7 @@ public class JobsEntity extends BaseManagementEntity {
 
     /**
      * Sends an Email Verification. A token with scope update:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email">POST Verification Email</a>.
      *
      * @param userId   The user_id of the user to whom the email will be sent.
      * @param clientId The id of the client, if not provided the global one will be used.
@@ -161,14 +161,17 @@ public class JobsEntity extends BaseManagementEntity {
     }
 
     /**
+     * @deprecated Use {@link #exportUsers(UsersExportFilter)} instead.
+     *
      * Requests a Users Exports job. A token with scope read:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports.
-     * See https://auth0.com/docs/users/guides/bulk-user-exports.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports">POST Users Exports</a>.
+     * See <a href="https://auth0.com/docs/users/guides/bulk-user-exports">Bulk User Exports</a>.
      *
      * @param connectionId The id of the connection to export the users from.
      * @param filter       the filter to use. Can be null.
      * @return a Request to execute.
      */
+    @Deprecated
     public Request<Job> exportUsers(String connectionId, UsersExportFilter filter) {
         Asserts.assertNotNull(connectionId, "connection id");
 
@@ -190,11 +193,36 @@ public class JobsEntity extends BaseManagementEntity {
         return request;
     }
 
+    /**
+     * Requests a Users Exports job. A token with scope read:users is needed.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports">POST Users Exports</a>.
+     * See <a href="https://auth0.com/docs/users/guides/bulk-user-exports">Bulk User Exports</a>.
+     *
+     * @param filter the filter to use. Can be null.
+     * @return a Request to execute.
+     */
+    public Request<Job> exportUsers(UsersExportFilter filter) {
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/jobs/users-exports")
+            .build()
+            .toString();
+
+        Map<String, Object> requestBody = new HashMap<>();
+        if (filter != null) {
+            requestBody.putAll(filter.getAsMap());
+        }
+
+        BaseRequest<Job> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Job>() {
+        });
+        request.setBody(requestBody);
+        return request;
+    }
 
     /**
      * Requests a Users Imports job. A token with scope write:users is needed.
-     * See https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports.
-     * See https://auth0.com/docs/users/guides/bulk-user-imports.
+     * See <a href="https://auth0.com/docs/api/management/v2#!/Jobs/post_users_imports">POST User Imports</a>.
+     * See <a href="https://auth0.com/docs/users/guides/bulk-user-imports">Bulk User Imports</a>.
      *
      * @param connectionId The id of the connection to import the users to.
      * @param users        The users file. Must have an array with the users' information in JSON format.

--- a/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/JobsEntityTest.java
@@ -7,6 +7,7 @@ import com.auth0.json.mgmt.jobs.Job;
 import com.auth0.json.mgmt.jobs.JobErrorDetails;
 import com.auth0.json.mgmt.jobs.UsersExportField;
 import com.auth0.net.Request;
+import com.auth0.net.Response;
 import com.auth0.net.client.HttpMethod;
 import com.auth0.net.client.multipart.FilePart;
 import com.auth0.net.client.multipart.KeyValuePart;
@@ -100,6 +101,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldThrowOnRequestUsersExportWithNullConnectionId() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("'connection id' cannot be null!");
@@ -107,11 +109,13 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldNotThrowOnRequestUsersExportWithNullFilter() {
         api.jobs().exportUsers("con_123456789", null);
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRequestUsersExport() throws Exception {
         Request<Job> request = api.jobs().exportUsers("con_123456789", null);
         assertThat(request, is(notNullValue()));
@@ -132,6 +136,105 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
+    public void usersExportWithFilterOverridesClientId() throws Exception {
+        UsersExportFilter filter = new UsersExportFilter();
+        filter.withConnectionId("filter_con");
+
+        Request<Job> request = api.jobs().exportUsers("con_123456789", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
+        Job response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(1));
+        assertThat(body, hasEntry("connection_id", "filter_con"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldRequestUsersExportWithoutConnectionOrFilter() throws Exception {
+        Request<Job> request = api.jobs().exportUsers(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
+        Job response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(0));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldRequestUsersExportWithFilter() throws Exception {
+        UsersExportFilter filter = new UsersExportFilter();
+        filter.withConnectionId("conId");
+        filter.withFormat("json");
+        List<UsersExportField> fields = new ArrayList<>();
+        fields.add(new UsersExportField("full_name"));
+        fields.add(new UsersExportField("user_metadata.company_name", "company"));
+        filter.withFields(fields);
+
+        Request<Job> request = api.jobs().exportUsers(filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
+        Job response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(3));
+        assertThat(body, hasEntry("connection_id", "conId"));
+        assertThat(body, hasEntry("format", "json"));
+        assertThat(body, hasKey("fields"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> bodyFields = (List<Map<String, String>>) body.get("fields");
+        assertThat(bodyFields.get(0).get("name"), is("full_name"));
+        assertThat(bodyFields.get(0).get("export_as"), is(nullValue()));
+        assertThat(bodyFields.get(1).get("name"), is("user_metadata.company_name"));
+        assertThat(bodyFields.get(1).get("export_as"), is("company"));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void usersExportShouldHandleNullFilter() throws Exception {
+        Request<Job> request = api.jobs().exportUsers(null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_JOB_POST_USERS_EXPORTS, 200);
+        Job response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/jobs/users-exports"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body.size(), is(0));
+
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void shouldRequestUsersExportWithLimit() throws Exception {
         UsersExportFilter filter = new UsersExportFilter();
         filter.withLimit(82);
@@ -155,6 +258,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRequestUsersExportWithFormat() throws Exception {
         UsersExportFilter filter = new UsersExportFilter();
         filter.withFormat("csv");
@@ -178,6 +282,7 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRequestUsersExportWithFields() throws Exception {
         UsersExportFilter filter = new UsersExportFilter();
         ArrayList<UsersExportField> fields = new ArrayList<>();
@@ -437,5 +542,4 @@ public class JobsEntityTest extends BaseMgmtEntityTest {
 
         assertThat(response, is(notNullValue()));
     }
-
 }


### PR DESCRIPTION
### Changes

As discussed in #530, the export users job does not require a `connection_id`, but the `JobsEntity` currently does require it. Further, if the filter contains a `connectionId`, it will override the (required) `connection_id` parameter.

This PR:
* Deprecates the current export users method
* Adds a new export users method that accepts an (optional) filter param
* Adds tests demonstrating the behavior of the now-deprecated method, and tests for the new method

### References

#530 