### PR TITLE
Support invalidate remembered browsers endpoint

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -386,6 +386,29 @@ public class UsersEntity extends BaseManagementEntity {
     }
 
     /**
+     * Invalidate all remembered browsers across all authentication factors for a user.
+     * A token with scope {@code update:users} is required.
+     *
+     * @param userId the ID of the user to invalidate all remembered browsers and authentication factors for.
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser">Invalidate all remembered browsers.</a>
+     */
+    public Request<Void> invalidateRememberedBrowsers(String userId) {
+        Asserts.assertNotNull(userId, "user ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegments("multifactor/actions/invalidate-remember-browser")
+            .build()
+            .toString();
+
+        VoidRequest request = new VoidRequest(client, tokenProvider, url, HttpMethod.POST);
+        request.setBody("");
+        return request;
+    }
+
+    /**
      * Get the permissions associated to the user.
      * A token with read:users is needed.
      * See https://auth0.com/docs/api/management/v2#!/Users/get_permissions

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -1326,6 +1326,5 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
 
         assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/users/userId/multifactor/actions/invalidate-remember-browser"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
-        System.out.println(recordedRequest.getBody());
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -1307,4 +1307,25 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
     }
+
+    @Test
+    public void invalidateRememberedBrowsersThrowsWhenUserIdIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("user ID");
+        api.users().invalidateRememberedBrowsers(null);
+    }
+
+    @Test
+    public void shouldInvalidateRememberedBrowsers() throws Exception {
+        Request<Void> request = api.users().invalidateRememberedBrowsers("userId");
+        assertThat(request, is(notNullValue()));
+
+        server.noContentResponse();
+        Void response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/users/userId/multifactor/actions/invalidate-remember-browser"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        System.out.println(recordedRequest.getBody());
+    }
 }


### PR DESCRIPTION
Adds support for the [invalidate browsers endpoint](https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser).

Fixes #540