### PR TITLE
Provide a custom TokenProvider to ManagementAPI.Builder instead of a static token

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -370,7 +370,19 @@ public class ManagementAPI {
     public static class Builder {
         private final String domain;
         private final String apiToken;
+        private final TokenProvider tokenProvider;
         private Auth0HttpClient httpClient = DefaultHttpClient.newBuilder().build();
+
+        /**
+         * Create a new Builder
+         * @param domain the domain of the tenant.
+         * @param tokenProvider a provider to get API tokens used to make requests to the Auth0 Management API.
+         */
+        public Builder(String domain, TokenProvider tokenProvider) {
+            this.domain = domain;
+            this.tokenProvider = tokenProvider;
+            this.apiToken = null;
+        }
 
         /**
          * Create a new Builder
@@ -380,6 +392,7 @@ public class ManagementAPI {
         public Builder(String domain, String apiToken) {
             this.domain = domain;
             this.apiToken = apiToken;
+            this.tokenProvider = null;
         }
 
         /**
@@ -398,7 +411,7 @@ public class ManagementAPI {
          * @return the configured {@code ManagementAPI} instance.
          */
         public ManagementAPI build() {
-            return new ManagementAPI(domain, SimpleTokenProvider.create(apiToken), httpClient);
+            return new ManagementAPI(domain, tokenProvider != null ? tokenProvider : SimpleTokenProvider.create(apiToken), httpClient);
         }
     }
 }


### PR DESCRIPTION
### Changes

This commit adds a new constructor to ManagementAPI.Builder, so a custom TokenProvider can be used.
This is useful to implement auto-refresh for example, like https://github.com/auth0/auth0-java/compare/master...clementdenis:auth0-java:auto_refresh_token_provider (I can create another PR if this one is accepted).

An alternative would be to make the constructor at https://github.com/auth0/auth0-java/blob/master/src/main/java/com/auth0/client/mgmt/ManagementAPI.java#L70 public to pass a TokenProvider.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
