### PR TITLE
[SDK-4400] Support Organization Name on Authorize URL

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthorizeUrlBuilder.java
+++ b/src/main/java/com/auth0/client/auth/AuthorizeUrlBuilder.java
@@ -109,7 +109,7 @@ public class AuthorizeUrlBuilder {
     /**
      * Sets the organization query string parameter value used to login to an organization.
      *
-     * @param organization The ID of the organization to log the user in to.
+     * @param organization The ID or name of the organization to log the user in to.
      * @return the builder instance.
      */
     public AuthorizeUrlBuilder withOrganization(String organization) {

--- a/src/main/java/com/auth0/utils/tokens/IdTokenVerifier.java
+++ b/src/main/java/com/auth0/utils/tokens/IdTokenVerifier.java
@@ -138,14 +138,26 @@ public final class IdTokenVerifier {
 
         // Org verification
         if (this.organization != null) {
-            String orgClaim = decoded.getClaim("org_id").asString();
-            if (isEmpty(orgClaim)) {
-                throw new IdTokenValidationException("Organization Id (org_id) claim must be a string present in the ID token");
+            String org = this.organization.trim();
+            if (org.startsWith("org_")) {
+                // org ID
+                String orgClaim = decoded.getClaim("org_id").asString();
+                if (isEmpty(orgClaim)) {
+                    throw new IdTokenValidationException("Organization Id (org_id) claim must be a string present in the ID token");
+                }
+                if (!this.organization.equals(orgClaim)) {
+                    throw new IdTokenValidationException(String.format("Organization (org_id) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", this.organization, orgClaim));
+                }
+            } else {
+                // org name
+                String orgNameClaim = decoded.getClaim("org_name").asString();
+                if (isEmpty(orgNameClaim)) {
+                    throw new IdTokenValidationException("Organization name (org_name) claim must be a string present in the ID token");
+                }
+                if (!org.equalsIgnoreCase(orgNameClaim)) {
+                    throw new IdTokenValidationException(String.format("Organization (org_name) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", this.organization, orgNameClaim));
+                }
             }
-            if (!this.organization.equals(orgClaim)) {
-                throw new IdTokenValidationException(String.format("Organization (org_id) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", this.organization, orgClaim));
-            }
-
         }
 
         final Calendar cal = Calendar.getInstance();

--- a/src/main/java/com/auth0/utils/tokens/IdTokenVerifier.java
+++ b/src/main/java/com/auth0/utils/tokens/IdTokenVerifier.java
@@ -154,7 +154,7 @@ public final class IdTokenVerifier {
                 if (isEmpty(orgNameClaim)) {
                     throw new IdTokenValidationException("Organization name (org_name) claim must be a string present in the ID token");
                 }
-                if (!org.equalsIgnoreCase(orgNameClaim)) {
+                if (!org.toLowerCase().equals(orgNameClaim)) {
                     throw new IdTokenValidationException(String.format("Organization (org_name) claim mismatch in the ID token; expected \"%s\" but found \"%s\"", this.organization, orgNameClaim));
                 }
             }


### PR DESCRIPTION
Adds support for using the `org_name` authorize parameter, as well as support for verifying the `org_name` claim.