### PR TITLE
Fix deleteAuthenticationMethodById

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -732,8 +732,7 @@ public class UsersEntity extends BaseManagementEntity {
             .build()
             .toString();
 
-        return new BaseRequest<>(this.client, tokenProvider, url, HttpMethod.DELETE, new TypeReference<Void>() {
-        });
+        return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     /**

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -1300,8 +1300,8 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         Request<Void> request = api.users().deleteAuthenticationMethodById("1", "1");
         assertThat(request, is(notNullValue()));
 
-        server.jsonResponse(AUTHENTICATOR_METHOD_UPDATE_BY_ID, 200);
-        Void response = request.execute().getBody();
+        server.noContentResponse();
+        request.execute().getBody();
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath(HttpMethod.DELETE, "/api/v2/users/1/authentication-methods/1"));


### PR DESCRIPTION
`UsersEntity#deleteAuthentiationMethodById()` fails when parsing the response body, since the response is a no-content 204 ([API docs](https://auth0.com/docs/api/management/v2#!/Users/delete_authentication_methods_by_authentication_method_id)). This happens because the implementation was incorrectly using a `BaseRequest` instead of a `VoidRequest`. This PR fixes this by using `VoidRequest` and updates the test. Tested with unit tests and manually.