### PR TITLE
Align json property 'cross_origin_authentication' with api docs

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -86,7 +86,7 @@ public class Client {
     private String tenant;
     @JsonProperty("global")
     private Boolean global;
-    @JsonProperty("cross_origin_auth")
+    @JsonProperty("cross_origin_authentication")
     private Boolean crossOriginAuth;
     @JsonProperty("cross_origin_loc")
     private String crossOriginLoc;
@@ -766,7 +766,7 @@ public class Client {
      * Setter whether this client can be used to make cross-origin authentication requests (true) or it is not allowed to make such requests (false).
      * @param crossOriginAuth whether an application can make cross-origin authentication requests or not
      */
-    @JsonProperty("cross_origin_auth")
+    @JsonProperty("cross_origin_authentication")
     public void setCrossOriginAuth(Boolean crossOriginAuth) {
         this.crossOriginAuth = crossOriginAuth;
     }
@@ -775,7 +775,7 @@ public class Client {
      * Whether this client can be used to make cross-origin authentication requests (true) or it is not allowed to make such requests (false).
      * @return true if application can make cross-origin authentication requests, false otherwise
      */
-    @JsonProperty("cross_origin_auth")
+    @JsonProperty("cross_origin_authentication")
     public Boolean getCrossOriginAuth() {
         return crossOriginAuth;
     }

--- a/src/test/resources/mgmt/clients_list.json
+++ b/src/test/resources/mgmt/clients_list.json
@@ -41,7 +41,7 @@
     "is_heroku_app": false,
     "tenant": "auth0",
     "global": false,
-    "cross_origin_auth": false,
+    "cross_origin_authentication": false,
     "cross_origin_loc": "https://auth0.com/auth/callback-cross-auth",
     "addons": {
       "rms": {},


### PR DESCRIPTION
### Changes

- fixes https://github.com/auth0/auth0-java/issues/554
- align attribute with the response documentation https://auth0.com/docs/api/management/v2/clients/get-clients

### References

- go implementation https://github.com/auth0/go-auth0/blob/main/management/client.go#L68C2-L68C2
- Management API docs https://auth0.com/docs/api/management/v2/clients/get-clients

### Testing

This just change from which attribute of the json the value is extracted

- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
