### PR TITLE
[SDK-4388] Use GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,27 @@
+name: auth0/auth0-java/build-and-test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: ["master", "main", "v1"]
+
+jobs:
+  gradle:
+    runs-on:  ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+      - uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c
+        with:
+          arguments: assemble apiDiff check jacocoTestReport --continue --console=plain
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+        with:
+          flags: unittests
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Reports
+          path: build/reports

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ oss {
     repository 'auth0-java'
     organization 'auth0'
     description 'Java client library for the Auth0 platform.'
-    baselineCompareVersion '1.27.0'
+    baselineCompareVersion '2.0.0'
     testInJavaVersions = [8, 11, 17]
 
     developers {


### PR DESCRIPTION
### Changes

Updates to use GitHub Actions for build and test, replacing CircleCI (change to remove CircleCI will follow)