### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 
-## [Unreleased]
+## [2.6.0](https://github.com/auth0/auth0-java/tree/2.6.0) (2023-09-07)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/2.5.0...2.6.0)
 
 **Security**
-- Updated OkHttp to 4.11.0
+- Update OkHttp to 4.11.0 [\#558](https://github.com/auth0/auth0-java/pull/558) ([evansims](https://github.com/evansims))
+
+**Fixed**
+- Align json property 'cross_origin_authentication' with api docs [\#555](https://github.com/auth0/auth0-java/pull/555) ([Jojo134](https://github.com/Jojo134))
 
 ## [2.5.0](https://github.com/auth0/auth0-java/tree/2.5.0) (2023-07-18)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/2.4.0...2.5.0)

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>2.5.0</version>
+  <version>2.6.0</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:2.5.0'
+implementation 'com.auth0:auth0:2.6.0'
 ```
 
 ### Configure the SDK


### PR DESCRIPTION
**Security**
- Update OkHttp to 4.11.0 [\#558](https://github.com/auth0/auth0-java/pull/558) ([evansims](https://github.com/evansims))

**Fixed**
- Align json property 'cross_origin_authentication' with api docs [\#555](https://github.com/auth0/auth0-java/pull/555) ([Jojo134](https://github.com/Jojo134))