### PR TITLE
Update Okio to resolve CVE-2023-3635

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ ext {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
+    // TODO remove direct dependency when OkHttp 4.12.0 is released
+    implementation "com.squareup.okio:okio:3.4.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.14.2"
     implementation "com.auth0:java-jwt:4.4.0"
     implementation "net.jodah:failsafe:2.4.4"

--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,13 @@ ext {
 }
 
 dependencies {
-    implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
-    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     // TODO remove direct dependency when OkHttp 4.12.0 is released
-    implementation "com.squareup.okio:okio:3.4.0"
+    implementation ("com.squareup.okhttp3:okhttp:${okhttpVersion}") {
+      exclude group: 'com.squareup.okhttp3', module: 'okio'
+    }
+    implementation "com.squareup.okio:okio:3.5.0"
+
+    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.14.2"
     implementation "com.auth0:java-jwt:4.4.0"
     implementation "net.jodah:failsafe:2.4.4"


### PR DESCRIPTION
Excludes transient dependency okio from OkHttp and include 3.5.0 which resolves CVE-2023-3635. Once OkHttp 4.12.0 is released we can remove the manual okio dependency and exclude rule.