### PR TITLE
(v1) Update Okio to resolve CVE-2023-3635

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.44.2](https://github.com/auth0/auth0-java/tree/1.44.2) (2023-01-11)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.1...1.44.2)
+
+This patch release does not contain any functional changes, but is being released using an updated signing key for verification as part of our commitment to best security practices.
+Please review [the README note for additional details.](https://github.com/auth0/auth0-java/blob/master/README.md)
+
+**Security**
+- Bump java-jwt dependency to 3.19.4 [\#498](https://github.com/auth0/auth0-java/pull/498) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [1.44.1](https://github.com/auth0/auth0-java/tree/1.44.1) (2022-10-25)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.0...1.44.1)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **Note**
+> As part of our ongoing commitment to best security practices, we have rotated the signing keys used to sign previous releases of this SDK. As a result, new patch builds have been released using the new signing key. Please upgrade at your earliest convenience.
+>
+> While this change won't affect most developers, if you have implemented a dependency signature validation step in your build process, you may notice a warning that past releases can't be verified. This is expected, and a result of the key rotation process. Updating to the latest version will resolve this for you.
+
 ![A Java client library for the Auth0 Authentication and Management APIs.](https://cdn.auth0.com/website/sdks/banners/auth0-java-banner.png)
 
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/auth0-java.svg?style=flat-square)](https://circleci.com/gh/auth0/auth0-java/tree/master)
@@ -28,14 +33,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>1.44.1</version>
+  <version>1.44.2</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:1.44.1'
+implementation 'com.auth0:auth0:1.44.2'
 ```
 
 ### Configure the SDK

--- a/build.gradle
+++ b/build.gradle
@@ -63,13 +63,15 @@ test {
 }
 
 ext {
-    okhttpVersion = '4.10.0'
+    okhttpVersion = '4.11.0'
     hamcrestVersion = '2.2'
 }
 
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
+    // TODO remove direct dependency when OkHttp 4.12.0 is released
+    implementation "com.squareup.okio:okio:3.4.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     implementation "com.auth0:java-jwt:3.19.4"
     implementation "net.jodah:failsafe:2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,13 @@ ext {
 }
 
 dependencies {
-    implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
-    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     // TODO remove direct dependency when OkHttp 4.12.0 is released
-    implementation "com.squareup.okio:okio:3.4.0"
+    implementation ("com.squareup.okhttp3:okhttp:${okhttpVersion}") {
+      exclude group: 'com.squareup.okhttp3', module: 'okio'
+    }
+    implementation "com.squareup.okio:okio:3.5.0"
+
+    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     implementation "com.auth0:java-jwt:3.19.4"
     implementation "net.jodah:failsafe:2.4.1"

--- a/src/main/java/com/auth0/json/auth/PushedAuthorizationResponse.java
+++ b/src/main/java/com/auth0/json/auth/PushedAuthorizationResponse.java
@@ -1,0 +1,30 @@
+package com.auth0.json.auth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PushedAuthorizationResponse {
+
+    @JsonProperty("request_uri")
+    private String requestURI;
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonCreator
+    public PushedAuthorizationResponse(@JsonProperty("request_uri") String requestURI, @JsonProperty("expires_in") Integer expiresIn) {
+        this.requestURI = requestURI;
+        this.expiresIn = expiresIn;
+    }
+
+    public String getRequestURI() {
+        return requestURI;
+    }
+
+    public Integer getExpiresIn() {
+        return expiresIn;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -90,6 +90,8 @@ public class Client {
     private Boolean crossOriginAuth;
     @JsonProperty("cross_origin_loc")
     private String crossOriginLoc;
+    @JsonProperty("require_pushed_authorization_requests")
+    private Boolean requiresPushedAuthorizationRequests;
 
     /**
      * Getter for the name of the tenant this client belongs to.
@@ -792,6 +794,21 @@ public class Client {
     @JsonProperty("cross_origin_loc")
     public String getCrossOriginLoc() {
         return crossOriginLoc;
+    }
+
+    /**
+     * @return whether this client requires pushed authorization requests or not.
+     */
+    public Boolean getRequiresPushedAuthorizationRequests() {
+        return requiresPushedAuthorizationRequests;
+    }
+
+    /**
+     * Sets whether the client requires pushed authorization requests or not.
+     * @param requiresPushedAuthorizationRequests true if the client should require pushed authorization requests, false if not.
+     */
+    public void setRequiresPushedAuthorizationRequests(Boolean requiresPushedAuthorizationRequests) {
+        this.requiresPushedAuthorizationRequests = requiresPushedAuthorizationRequests;
     }
 }
 

--- a/src/main/java/com/auth0/net/FormBodyRequest.java
+++ b/src/main/java/com/auth0/net/FormBodyRequest.java
@@ -1,0 +1,63 @@
+package com.auth0.net;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import static com.auth0.utils.Asserts.assertNotNull;
+
+/**
+ * Request class that represents a application/x-www-form-urlencoded request
+ *
+ * @param <T> The type expected to be received as part of the response.
+ * @see ExtendedBaseRequest
+ */
+public class FormBodyRequest<T> extends ExtendedBaseRequest<T> {
+
+    private static final String CONTENT_TYPE_FORM_DATA = "application/x-www-form-urlencoded";
+
+    private final TypeReference<T> tType;
+    private final ObjectMapper mapper;
+    private final FormBody.Builder bodyBuilder;
+
+    FormBodyRequest(OkHttpClient client, String url, String method, ObjectMapper mapper, TypeReference<T> tType, FormBody.Builder bodyBuilder) {
+        super(client, url, method, mapper);
+        if ("GET".equalsIgnoreCase(method)) {
+            throw new IllegalArgumentException("application/x-www-form-urlencoded requests do not support the GET method.");
+        }
+        this.mapper = mapper;
+        this.tType = tType;
+        this.bodyBuilder = bodyBuilder;
+    }
+
+    public FormBodyRequest(OkHttpClient client, String url, String method, TypeReference<T> tType) {
+        this(client, url, method, new ObjectMapper(), tType, new FormBody.Builder());
+    }
+
+    @Override
+    protected String getContentType() {
+        return CONTENT_TYPE_FORM_DATA;
+    }
+
+    @Override
+    protected RequestBody createRequestBody() throws IOException {
+        return bodyBuilder.build();
+    }
+
+    @Override
+    protected T readResponseBody(ResponseBody body) throws IOException {
+        String payload = body.string();
+        return mapper.readValue(payload, tType);
+    }
+
+    public FormBodyRequest<T> addData(String name, String value) {
+        assertNotNull(name, "name");
+        assertNotNull(value, "value");
+        bodyBuilder.add(name, value);
+        return this;
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -102,6 +102,7 @@ public class MockServer {
     public static final String MULTIPART_SAMPLE = "src/test/resources/mgmt/multipart_sample.json";
     public static final String PASSWORDLESS_EMAIL_RESPONSE = "src/test/resources/auth/passwordless_email.json";
     public static final String PASSWORDLESS_SMS_RESPONSE = "src/test/resources/auth/passwordless_sms.json";
+    public static final String PUSHED_AUTHORIZATION_RESPONSE = "src/test/resources/auth/pushed_authorization_response.json";
     public static final String ORGANIZATION = "src/test/resources/mgmt/organization.json";
     public static final String ORGANIZATIONS_LIST = "src/test/resources/mgmt/organizations_list.json";
     public static final String ORGANIZATIONS_PAGED_LIST = "src/test/resources/mgmt/organizations_paged_list.json";

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1416,4 +1416,79 @@ public class AuthAPITest {
         assertThat(response.getTokenType(), not(emptyOrNullString()));
         assertThat(response.getExpiresIn(), is(notNullValue()));
     }
+
+    @Test
+    public void authorizeUrlWithPARShouldThrowWhenRequestUriNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'request uri' cannot be null!");
+        api.authorizeUrlWithPAR(null);
+    }
+
+    @Test
+    public void shouldBuildAuthorizeUrlWithPAR() {
+        AuthAPI api = new AuthAPI("domain.auth0.com", CLIENT_ID, CLIENT_SECRET);
+        String url = api.authorizeUrlWithPAR("urn:example:bwc4JK-ESC0w8acc191e-Y1LTC2");
+        assertThat(url, is(notNullValue()));
+        assertThat(url, isUrl("https", "domain.auth0.com", "/authorize"));
+
+        assertThat(url, hasQueryParameter("request_uri", "urn:example:bwc4JK-ESC0w8acc191e-Y1LTC2"));
+        assertThat(url, hasQueryParameter("client_id", CLIENT_ID));
+    }
+
+    @Test
+    public void pushedAuthorizationRequestShouldThrowWhenRedirectUriIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'redirect uri' must be a valid URL!");
+        api.pushedAuthorizationRequest(null, "code", Collections.emptyMap());
+    }
+
+    @Test
+    public void pushedAuthorizationRequestShouldThrowWhenResponseTypeIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("'response type' cannot be null!");
+        api.pushedAuthorizationRequest("https://domain.com/callback", null, Collections.emptyMap());
+    }
+
+    @Test
+    public void shouldCreatePushedAuthorizationRequestWithNullAdditionalParams() throws Exception {
+        Request<PushedAuthorizationResponse> request = api.pushedAuthorizationRequest("https://domain.com/callback", "code", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(PUSHED_AUTHORIZATION_RESPONSE, 200);
+        PushedAuthorizationResponse response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/par"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/x-www-form-urlencoded"));
+
+        String expected = "client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET + "&redirect_uri=https%3A%2F%2Fdomain.com%2Fcallback&response_type=code";
+        assertThat(expected, is(readFromRequest(recordedRequest)));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getRequestURI(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), notNullValue());
+    }
+
+    @Test
+    public void shouldCreatePushedAuthorizationRequestWithAdditionalParams() throws Exception {
+        Map<String, String> additionalParams = new HashMap<>();
+        additionalParams.put("audience", "aud");
+        additionalParams.put("connection", "conn");
+        Request<PushedAuthorizationResponse> request = api.pushedAuthorizationRequest("https://domain.com/callback", "code", additionalParams);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(PUSHED_AUTHORIZATION_RESPONSE, 200);
+        PushedAuthorizationResponse response = request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath("POST", "/oauth/par"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/x-www-form-urlencoded"));
+
+        String expected = "client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET + "&redirect_uri=https%3A%2F%2Fdomain.com%2Fcallback&response_type=code&audience=aud&connection=conn";
+        assertThat(expected, is(readFromRequest(recordedRequest)));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getRequestURI(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), notNullValue());
+    }
 }

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -15,7 +15,80 @@ import static org.hamcrest.Matchers.*;
 public class ClientTest extends JsonTest<Client> {
 
     private static final String readOnlyJson = "{\"client_id\":\"clientId\",\"is_heroku_app\":true,\"signing_keys\":[{\"cert\":\"ce\",\"pkcs7\":\"pk\",\"subject\":\"su\"}]}";
-    private static final String json = "{\"name\":\"name\",\"description\":\"description\",\"client_secret\":\"secret\",\"app_type\":\"type\",\"logo_uri\":\"uri\",\"oidc_conformant\":true,\"is_first_party\":true,\"initiate_login_uri\":\"https://myhome.com/login\",\"callbacks\":[\"value\"],\"allowed_origins\":[\"value\"],\"web_origins\":[\"value\"],\"grant_types\":[\"value\"],\"client_aliases\":[\"value\"],\"allowed_clients\":[\"value\"],\"allowed_logout_urls\":[\"value\"],\"organization_usage\":\"allow\",\"organization_require_behavior\":\"no_prompt\",\"jwt_configuration\":{\"lifetime_in_seconds\":100,\"scopes\":\"openid\",\"alg\":\"alg\"},\"encryption_key\":{\"pub\":\"pub\",\"cert\":\"cert\"},\"sso\":true,\"sso_disabled\":true,\"custom_login_page_on\":true,\"custom_login_page\":\"custom\",\"custom_login_page_preview\":\"preview\",\"form_template\":\"template\",\"addons\":{\"rms\":{},\"mscrm\":{},\"slack\":{},\"layer\":{}},\"token_endpoint_auth_method\":\"method\",\"client_metadata\":{\"key\":\"value\"},\"mobile\":{\"android\":{\"app_package_name\":\"pkg\",\"sha256_cert_fingerprints\":[\"256\"]},\"ios\":{\"team_id\":\"team\",\"app_bundle_identifier\":\"id\"}},\"refresh_token\":{\"rotation_type\":\"non-rotating\"}}";
+    private static final String json = "{\n" +
+        "  \"name\": \"name\",\n" +
+        "  \"description\": \"description\",\n" +
+        "  \"client_secret\": \"secret\",\n" +
+        "  \"app_type\": \"type\",\n" +
+        "  \"logo_uri\": \"uri\",\n" +
+        "  \"oidc_conformant\": true,\n" +
+        "  \"is_first_party\": true,\n" +
+        "  \"initiate_login_uri\": \"https://myhome.com/login\",\n" +
+        "  \"callbacks\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"allowed_origins\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"web_origins\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"grant_types\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"client_aliases\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"allowed_clients\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"allowed_logout_urls\": [\n" +
+        "    \"value\"\n" +
+        "  ],\n" +
+        "  \"organization_usage\": \"allow\",\n" +
+        "  \"organization_require_behavior\": \"no_prompt\",\n" +
+        "  \"jwt_configuration\": {\n" +
+        "    \"lifetime_in_seconds\": 100,\n" +
+        "    \"scopes\": \"openid\",\n" +
+        "    \"alg\": \"alg\"\n" +
+        "  },\n" +
+        "  \"encryption_key\": {\n" +
+        "    \"pub\": \"pub\",\n" +
+        "    \"cert\": \"cert\"\n" +
+        "  },\n" +
+        "  \"sso\": true,\n" +
+        "  \"sso_disabled\": true,\n" +
+        "  \"custom_login_page_on\": true,\n" +
+        "  \"custom_login_page\": \"custom\",\n" +
+        "  \"custom_login_page_preview\": \"preview\",\n" +
+        "  \"form_template\": \"template\",\n" +
+        "  \"addons\": {\n" +
+        "    \"rms\": {},\n" +
+        "    \"mscrm\": {},\n" +
+        "    \"slack\": {},\n" +
+        "    \"layer\": {}\n" +
+        "  },\n" +
+        "  \"token_endpoint_auth_method\": \"method\",\n" +
+        "  \"client_metadata\": {\n" +
+        "    \"key\": \"value\"\n" +
+        "  },\n" +
+        "  \"mobile\": {\n" +
+        "    \"android\": {\n" +
+        "      \"app_package_name\": \"pkg\",\n" +
+        "      \"sha256_cert_fingerprints\": [\n" +
+        "        \"256\"\n" +
+        "      ]\n" +
+        "    },\n" +
+        "    \"ios\": {\n" +
+        "      \"team_id\": \"team\",\n" +
+        "      \"app_bundle_identifier\": \"id\"\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"refresh_token\": {\n" +
+        "    \"rotation_type\": \"non-rotating\"\n" +
+        "  },\n" +
+        "  \"require_pushed_authorization_requests\": true\n" +
+        "}";
 
     @Test
     public void shouldSerialize() throws Exception {
@@ -58,6 +131,7 @@ public class ClientTest extends JsonTest<Client> {
         client.setRefreshToken(refreshToken);
         client.setOrganizationUsage("require");
         client.setOrganizationRequireBehavior("pre_login_prompt");
+        client.setRequiresPushedAuthorizationRequests(true);
 
         String serialized = toJSON(client);
         assertThat(serialized, is(notNullValue()));
@@ -91,6 +165,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("refresh_token", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("organization_usage", "require"));
         assertThat(serialized, JsonMatcher.hasEntry("organization_require_behavior", "pre_login_prompt"));
+        assertThat(serialized, JsonMatcher.hasEntry("require_pushed_authorization_requests", true));
     }
 
     @Test
@@ -134,6 +209,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getRefreshToken(), is(notNullValue()));
         assertThat(client.getOrganizationUsage(), is("allow"));
         assertThat(client.getOrganizationRequireBehavior(), is("no_prompt"));
+        assertThat(client.getRequiresPushedAuthorizationRequests(), is(true));
     }
 
     @Test

--- a/src/test/java/com/auth0/net/FormBodyRequestTest.java
+++ b/src/test/java/com/auth0/net/FormBodyRequestTest.java
@@ -1,0 +1,43 @@
+package com.auth0.net;
+
+import com.auth0.client.MockServer;
+import com.auth0.json.auth.PushedAuthorizationResponse;
+import com.auth0.json.auth.TokenHolder;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.OkHttpClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class FormBodyRequestTest {
+
+    private MockServer server;
+    private OkHttpClient client;
+
+    private TypeReference<TokenHolder> tokenHolderType;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockServer();
+        client = new OkHttpClient();
+        tokenHolderType = new TypeReference<TokenHolder>() {
+        };
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void shouldNotSupportGETMethod() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            new FormBodyRequest<>(client, server.getBaseUrl(), "GET", new TypeReference<PushedAuthorizationResponse>() {});
+        });
+        assertThat(exception.getMessage(), is("application/x-www-form-urlencoded requests do not support the GET method."));
+    }
+}

--- a/src/test/resources/auth/pushed_authorization_response.json
+++ b/src/test/resources/auth/pushed_authorization_response.json
@@ -1,0 +1,4 @@
+{
+  "request_uri": "urn:example:bwc4JK-ESC0w8acc191e-Y1LTC2",
+  "expires_in": 90
+}


### PR DESCRIPTION
Excludes transient dependency okio from OkHttp and include 3.5.0 which resolves CVE-2023-3635. Once OkHttp 4.12.0 is released we can remove the manual okio dependency and exclude rule.