### PR TITLE
(v1) Update Okio to resolve CVE-2023-3635

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,13 +63,15 @@ test {
 }
 
 ext {
-    okhttpVersion = '4.10.0'
+    okhttpVersion = '4.11.0'
     hamcrestVersion = '2.2'
 }
 
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
+    // TODO remove direct dependency when OkHttp 4.12.0 is released
+    implementation "com.squareup.okio:okio:3.4.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     implementation "com.auth0:java-jwt:3.19.4"
     implementation "net.jodah:failsafe:2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,13 @@ ext {
 }
 
 dependencies {
-    implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
-    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     // TODO remove direct dependency when OkHttp 4.12.0 is released
-    implementation "com.squareup.okio:okio:3.4.0"
+    implementation ("com.squareup.okhttp3:okhttp:${okhttpVersion}") {
+      exclude group: 'com.squareup.okhttp3', module: 'okio'
+    }
+    implementation "com.squareup.okio:okio:3.5.0"
+
+    implementation "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     implementation "com.auth0:java-jwt:3.19.4"
     implementation "net.jodah:failsafe:2.4.1"


### PR DESCRIPTION
Excludes transient dependency okio from OkHttp and include 3.5.0 which resolves CVE-2023-3635. Once OkHttp 4.12.0 is released we can remove the manual okio dependency and exclude rule.