### PR TITLE
Release 1.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.45.1](https://github.com/auth0/auth0-java/tree/1.45.1) (2023-09-22)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/1.45.0...1.45.1)
+
+**Security**
+- Update Okio to resolve CVE-2023-3635 [\#562](https://github.com/auth0/auth0-java/pull/562) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [1.45.0](https://github.com/auth0/auth0-java/tree/1.45.0) (2023-04-28)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/1.44.2...1.45.0)
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>1.45.0</version>
+  <version>1.45.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:1.45.0'
+implementation 'com.auth0:auth0:1.45.1'
 ```
 
 ### Configure the SDK


### PR DESCRIPTION
Release 1.45.1

**Security**
- Update Okio to resolve CVE-2023-3635 [\#562](https://github.com/auth0/auth0-java/pull/562) ([jimmyjames](https://github.com/jimmyjames))