### PR TITLE
Release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.6.1](https://github.com/auth0/auth0-java/tree/2.6.1) (2023-09-22)
+[Full Changelog](https://github.com/auth0/auth0-java/compare/2.6.0...2.6.1)
+
+**Security**
+- Update Okio to resolve CVE-2023-3635 [\#560](https://github.com/auth0/auth0-java/pull/560) ([evansims](https://github.com/evansims))
+
 ## [2.6.0](https://github.com/auth0/auth0-java/tree/2.6.0) (2023-09-07)
 [Full Changelog](https://github.com/auth0/auth0-java/compare/2.5.0...2.6.0)
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>auth0</artifactId>
-  <version>2.6.0</version>
+  <version>2.6.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:auth0:2.6.0'
+implementation 'com.auth0:auth0:2.6.1'
 ```
 
 ### Configure the SDK


### PR DESCRIPTION
Release 2.6.1

**Security**
- Update Okio to resolve CVE-2023-3635 [\#560](https://github.com/auth0/auth0-java/pull/560) ([evansims](https://github.com/evansims))