### PR TITLE
[SDK-4654] support organization get member roles

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -184,6 +184,22 @@ public class OrganizationsEntity extends BaseManagementEntity {
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_members">https://auth0.com/docs/api/management/v2#!/Organizations/get_members</a>
      */
     public Request<MembersPage> getMembers(String orgId, PageFilter filter) {
+        return getMembers(orgId, filter, null);
+    }
+
+    /**
+     * Get the members of an organization. A token with {@code read:organization_members} scope is required.
+     * <br/>
+     * Member roles are not sent by default. Supply a {@linkplain FieldsFilter} that includes "roles" (and {@code includeFields = true} to retrieve the roles assigned to each listed member. To include the roles in the response, you must include the {@code read:organization_member_roles} scope in the token.
+     *
+     * @param orgId the ID of the organization
+     * @param pageFilter an optional pagination filter
+     * @param fieldsFilter an optional fields filter. If null, all fields (except roles) are returned.
+     * @return a Request to execute
+     *
+     * @see <a href="https://auth0.com/docs/api/management/v2#!/Organizations/get_members">https://auth0.com/docs/api/management/v2#!/Organizations/get_members</a>
+     */
+    public Request<MembersPage> getMembers(String orgId, PageFilter pageFilter, FieldsFilter fieldsFilter) {
         Asserts.assertNotNull(orgId, "organization ID");
 
         HttpUrl.Builder builder = baseUrl
@@ -192,7 +208,8 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .addPathSegment(orgId)
             .addPathSegment("members");
 
-        applyFilter(filter, builder);
+        applyFilter(pageFilter, builder);
+        applyFilter(fieldsFilter, builder);
 
         String url = builder.build().toString();
         return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<MembersPage>() {

--- a/src/main/java/com/auth0/json/mgmt/organizations/Member.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Member.java
@@ -1,8 +1,11 @@
 package com.auth0.json.mgmt.organizations;
 
+import com.auth0.json.mgmt.roles.Role;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 
 /**
  * Represents the member of an organization.
@@ -20,6 +23,8 @@ public class Member {
     private String picture;
     @JsonProperty("name")
     private String name;
+    @JsonProperty("roles")
+    private List<Role> roles;
 
     /**
      * @return the user ID of this Member.
@@ -74,5 +79,9 @@ public class Member {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -298,6 +298,27 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldListOrgMembersWithFieldsFilter() throws Exception {
+        FieldsFilter fieldsFilter = new FieldsFilter().withFields("name,email,user_id,roles", true);
+
+        Request<MembersPage> request = api.organizations().getMembers("org_abc", null, fieldsFilter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_LIST, 200);
+        MembersPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("fields", "name,email,user_id,roles"));
+        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(3));
+    }
+
+    @Test
     public void shouldListOrgMembersWithPage() throws Exception {
         PageFilter filter = new PageFilter().withPage(0, 20);
         Request<MembersPage> request = api.organizations().getMembers("org_abc", filter);
@@ -310,6 +331,30 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/organizations/org_abc/members"));
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("page", "0"));
+        assertThat(recordedRequest, hasQueryParameter("per_page", "20"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getItems(), hasSize(3));
+    }
+
+    @Test
+    public void shouldListOrgMembersWithFieldsFilterAndPageFilter() throws Exception {
+        PageFilter pageFilter = new PageFilter().withPage(0, 20);
+        FieldsFilter fieldsFilter = new FieldsFilter().withFields("name,email,user_id,roles", true);
+
+        Request<MembersPage> request = api.organizations().getMembers("org_abc", pageFilter, fieldsFilter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MockServer.ORGANIZATION_MEMBERS_LIST, 200);
+        MembersPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/organizations/org_abc/members"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("fields", "name,email,user_id,roles"));
+        assertThat(recordedRequest, hasQueryParameter("include_fields", "true"));
         assertThat(recordedRequest, hasQueryParameter("page", "0"));
         assertThat(recordedRequest, hasQueryParameter("per_page", "20"));
 

--- a/src/test/java/com/auth0/json/mgmt/organizations/MembersTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/MembersTest.java
@@ -30,7 +30,13 @@ public class MembersTest extends JsonTest<Member> {
             "   \"user_id\": \"user_123\",\n" +
             "   \"email\": \"fred@domain.com\",\n" +
             "   \"picture\": \"https://profilepic.com/mypic.png\",\n" +
-            "   \"name\": \"fred\"\n" +
+            "   \"name\": \"fred\",\n" +
+            "   \"roles\": [\n" +
+            "      {\n" +
+            "        \"id\": \"rol_abc\",\n" +
+            "        \"name\": \"test role\"\n" +
+            "      }\n" +
+            "   ]" +
             "}";
 
         Member member = fromJSON(memberJson, Member.class);
@@ -39,6 +45,8 @@ public class MembersTest extends JsonTest<Member> {
         assertThat(member.getEmail(), is("fred@domain.com"));
         assertThat(member.getPicture(), is("https://profilepic.com/mypic.png"));
         assertThat(member.getName(), is("fred"));
-
+        assertThat(member.getRoles().size(), is(1));
+        assertThat(member.getRoles().get(0).getName(), is("test role"));
+        assertThat(member.getRoles().get(0).getId(), is("rol_abc"));
     }
 }


### PR DESCRIPTION
### Changes

This change adds support for sending the `fields` and `include_fields` parameters to the `GET /api/v2/organizations/{orgId/members` endpoint.

#### Usage
```java
// return fields roles, email, name, user_id
FieldsFilter fieldsFilter = new FieldsFilter().withFields("roles,email,name,user_id", true);

List<Member> membersList = managementAPI.organizations().getMembers("orgId", pageFilter, fieldsFilter)
    .execute()
    .getBody()
    .getItems();

Role firstMemberRole = membersList.get(0).getRoles();
```

Fixes #573 