### PR TITLE
propagate error message on rate limit exception

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1359,7 +1359,7 @@ public class AuthAPI {
          */
         public AuthAPI build() {
             return new AuthAPI(domain, clientId, clientSecret, clientAssertionSigner,
-                Objects.nonNull(httpClient) ? httpClient : DefaultHttpClient.newBuilder().build());
+                Objects.nonNull(httpClient) ? httpClient : DefaultHttpClient.newBuilder().withMaxRetries(0).build());
         }
     }
 }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1359,7 +1359,7 @@ public class AuthAPI {
          */
         public AuthAPI build() {
             return new AuthAPI(domain, clientId, clientSecret, clientAssertionSigner,
-                Objects.nonNull(httpClient) ? httpClient : DefaultHttpClient.newBuilder().withMaxRetries(0).build());
+                Objects.nonNull(httpClient) ? httpClient : DefaultHttpClient.newBuilder().build());
         }
     }
 }

--- a/src/main/java/com/auth0/exception/RateLimitException.java
+++ b/src/main/java/com/auth0/exception/RateLimitException.java
@@ -1,5 +1,7 @@
 package com.auth0.exception;
 
+import java.util.Map;
+
 /**
  * Represents a server error when a rate limit has been exceeded.
  * <p>
@@ -15,6 +17,13 @@ public class RateLimitException extends APIException {
     private final long reset;
 
     private static final int STATUS_CODE_TOO_MANY_REQUEST = 429;
+
+    public RateLimitException(long limit, long remaining, long reset, Map<String, Object> values) {
+        super(values, STATUS_CODE_TOO_MANY_REQUEST);
+        this.limit = limit;
+        this.remaining = remaining;
+        this.reset = reset;
+    }
 
     public RateLimitException(long limit, long remaining, long reset) {
         super("Rate limit reached", STATUS_CODE_TOO_MANY_REQUEST, null);

--- a/src/main/java/com/auth0/net/BaseRequest.java
+++ b/src/main/java/com/auth0/net/BaseRequest.java
@@ -218,7 +218,15 @@ public class BaseRequest<T> implements Request<T> {
         long limit = Long.parseLong(response.getHeader("x-ratelimit-limit", "-1"));
         long remaining = Long.parseLong(response.getHeader("x-ratelimit-remaining", "-1"));
         long reset = Long.parseLong(response.getHeader("x-ratelimit-reset", "-1"));
-        return new RateLimitException(limit, remaining, reset);
+
+        String payload = response.getBody();
+        MapType mapType = mapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
+        try {
+            Map<String, Object> values = mapper.readValue(payload, mapType);
+            return new RateLimitException(limit, remaining, reset, values);
+        } catch (IOException e) {
+            return new RateLimitException(limit, remaining, reset);
+        }
     }
 
     /**

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -138,9 +138,7 @@ public class DefaultHttpClient implements Auth0HttpClient {
         ResponseBody responseBody = okResponse.body();
         String content = null;
 
-        // The RateLimitInterceptor needs to close the response; we don't need the body in that case and trying to
-        // get the body will result in an exception because the responsebody has been closed
-        if (Objects.nonNull(responseBody) && okResponse.code() != 429) {
+        if (Objects.nonNull(responseBody)) {
             content = responseBody.string();
         }
         return Auth0HttpResponse.newBuilder()

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -100,6 +100,8 @@ public class DefaultHttpClient implements Auth0HttpClient {
                     future.complete(buildResponse(response));
                 } catch (IOException e) {
                     future.completeExceptionally(e);
+                } finally {
+                    response.close();
                 }
             }
         });

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -144,6 +144,7 @@ public class MockServer {
     public static final String KEY_LIST = "src/test/resources/mgmt/key_list.json";
     public static final String KEY_REVOKE = "src/test/resources/mgmt/key_revoke.json";
     public static final String KEY_ROTATE = "src/test/resources/mgmt/key_rotate.json";
+    public static final String RATE_LIMIT_ERROR = "src/test/resources/mgmt/rate_limit_error.json";
 
     private final MockWebServer server;
 
@@ -184,7 +185,11 @@ public class MockServer {
         server.enqueue(response);
     }
 
-    public void rateLimitReachedResponse(long limit, long remaining, long reset) {
+    public void rateLimitReachedResponse(long limit, long remaining, long reset) throws IOException {
+        rateLimitReachedResponse(limit, remaining, reset, null);
+    }
+
+    public void rateLimitReachedResponse(long limit, long remaining, long reset, String path) throws IOException {
         MockResponse response = new MockResponse().setResponseCode(429);
         if (limit != -1) {
             response.addHeader("x-ratelimit-limit", String.valueOf(limit));
@@ -194,6 +199,11 @@ public class MockServer {
         }
         if (reset != -1) {
             response.addHeader("x-ratelimit-reset", String.valueOf(reset));
+        }
+        if (path != null) {
+                response
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(readTextFile(path));
         }
         server.enqueue(response);
     }

--- a/src/test/java/com/auth0/net/BaseRequestTest.java
+++ b/src/test/java/com/auth0/net/BaseRequestTest.java
@@ -401,9 +401,9 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void shouldParseRateLimitsHeaders() {
+    public void shouldParseRateLimitException() throws Exception {
         BaseRequest<List> request = new BaseRequest<>(client, tokenProvider, server.getBaseUrl(),  HttpMethod.GET, listType);
-        server.rateLimitReachedResponse(100, 10, 5);
+        server.rateLimitReachedResponse(100, 10, 5, RATE_LIMIT_ERROR);
         Exception exception = null;
         try {
             request.execute().getBody();
@@ -414,10 +414,10 @@ public class BaseRequestTest {
         assertThat(exception, Matchers.is(notNullValue()));
         assertThat(exception, Matchers.is(Matchers.instanceOf(RateLimitException.class)));
         assertThat(exception.getCause(), Matchers.is(nullValue()));
-        assertThat(exception.getMessage(), Matchers.is("Request failed with status code 429: Rate limit reached"));
+        assertThat(exception.getMessage(), Matchers.is("Request failed with status code 429: Global limit has been reached"));
         RateLimitException rateLimitException = (RateLimitException) exception;
-        assertThat(rateLimitException.getDescription(), Matchers.is("Rate limit reached"));
-        assertThat(rateLimitException.getError(), Matchers.is(nullValue()));
+        assertThat(rateLimitException.getDescription(), Matchers.is("Global limit has been reached"));
+        assertThat(rateLimitException.getError(), Matchers.is("too_many_requests"));
         assertThat(rateLimitException.getValue("non_existing_key"), Matchers.is(nullValue()));
         assertThat(rateLimitException.getStatusCode(), Matchers.is(429));
         assertThat(rateLimitException.getLimit(), Matchers.is(100L));
@@ -426,7 +426,7 @@ public class BaseRequestTest {
     }
 
     @Test
-    public void shouldDefaultRateLimitsHeadersWhenMissing() {
+    public void shouldDefaultRateLimitsHeadersWhenMissing() throws Exception {
         BaseRequest<List> request = new BaseRequest<>(client, tokenProvider, server.getBaseUrl(),  HttpMethod.GET, listType);
         server.rateLimitReachedResponse(-1, -1, -1);
         Exception exception = null;

--- a/src/test/java/com/auth0/net/MultipartRequestTest.java
+++ b/src/test/java/com/auth0/net/MultipartRequestTest.java
@@ -335,7 +335,7 @@ public class MultipartRequestTest {
     }
 
     @Test
-    public void shouldParseRateLimitsHeaders() {
+    public void shouldParseRateLimitsHeaders() throws Exception {
         MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.rateLimitReachedResponse(100, 10, 5);
@@ -361,7 +361,7 @@ public class MultipartRequestTest {
     }
 
     @Test
-    public void shouldDefaultRateLimitsHeadersWhenMissing() {
+    public void shouldDefaultRateLimitsHeadersWhenMissing() throws Exception {
         MultipartRequest<List> request = new MultipartRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, listType);
         request.addPart("non_empty", "body");
         server.rateLimitReachedResponse(-1, -1, -1);

--- a/src/test/java/com/auth0/net/RateLimitInterceptorTest.java
+++ b/src/test/java/com/auth0/net/RateLimitInterceptorTest.java
@@ -108,9 +108,7 @@ public class RateLimitInterceptorTest {
 
         int index = 0;
         for (int i = 0; i < maxRetries + 1; i++) {
-            System.out.println("about to take request " + i);
             index = server.takeRequest().getSequenceNumber();
-            System.out.println("took request " + i);
         }
 
         assertThat(response.code(), is(429));

--- a/src/test/resources/mgmt/rate_limit_error.json
+++ b/src/test/resources/mgmt/rate_limit_error.json
@@ -1,0 +1,6 @@
+{
+  "statusCode":429,
+  "error":"Too Many Requests",
+  "message":"Global limit has been reached",
+  "errorCode":"too_many_requests"
+}


### PR DESCRIPTION
### Changes

Prior to this change, any error messages returned from Auth0 APIs caused by a 429 (rate limit exceeded) were not propagated to the exception. This change updates the `RateLimitException` class to accept message parameters, populates those values from the response, and updates the `RateLimitInterceptor` to not eagerly close responses on retry, which was causing the inability to retrieve the response body (it was already closed).