### PR TITLE
[SDK-4542] Support organization in client credentials

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -63,6 +63,7 @@ public class AuthAPI {
     private static final String PATH_REVOKE = "revoke";
     private static final String PATH_PASSWORDLESS = "passwordless";
     private static final String PATH_START = "start";
+    private static final String KEY_ORGANIZATION = "organization";
 
     private final Auth0HttpClient client;
     private final String clientId;
@@ -715,12 +716,40 @@ public class AuthAPI {
      * @return a Request to configure and execute.
      */
     public TokenRequest requestToken(String audience) {
+        return requestToken(audience, null);
+    }
+
+    /**
+     * Creates a request to get a Token for the given audience using the 'Client Credentials' grant.
+     * Default used realm is defined in the "API Authorization Settings" in the account's advanced settings in the Auth0 Dashboard.
+     * <strong>This operation requires that a client secret be configured for the {@code AuthAPI} client.</strong>
+     * <pre>
+     * {@code
+     * try {
+     *      TokenHolder result = authAPI.requestToken("https://myapi.me.auth0.com/users", "org_123")
+     *          .execute()
+     *          .getBody();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @see <a href="https://auth0.com/docs/api/authentication#client-credentials-flow">Client Credentials Flow API docs</a>
+     * @param audience the audience of the API to request access to.
+     * @param org the organization name or ID to be included in the request.
+     * @return a Request to configure and execute.
+     */
+    public TokenRequest requestToken(String audience, String org) {
         Asserts.assertNotNull(audience, "audience");
 
         TokenRequest request = new TokenRequest(client, getTokenUrl());
         request.addParameter(KEY_CLIENT_ID, clientId);
         request.addParameter(KEY_GRANT_TYPE, "client_credentials");
         request.addParameter(KEY_AUDIENCE, audience);
+        if (org != null && !org.trim().isEmpty()) {
+            request.addParameter(KEY_ORGANIZATION, org);
+        }
         addClientAuthentication(request, true);
         return request;
     }

--- a/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/ClientGrantsEntity.java
@@ -1,8 +1,10 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.filter.ClientGrantsFilter;
+import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.json.mgmt.clientgrants.ClientGrant;
 import com.auth0.json.mgmt.clientgrants.ClientGrantsPage;
+import com.auth0.json.mgmt.organizations.OrganizationsPage;
 import com.auth0.net.BaseRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
@@ -61,23 +63,43 @@ public class ClientGrantsEntity extends BaseManagementEntity {
      * @return a Request to execute.
      */
     public Request<ClientGrant> create(String clientId, String audience, String[] scope) {
+        return create(clientId, audience, scope, null, null);
+    }
+
+    /**
+     * Create a Client Grant. A token with scope create:client_grants is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Client_Grants/post_client_grants
+     *
+     * @param clientId the application's client id to associate this grant with.
+     * @param audience the audience of the grant.
+     * @param scope    the scope to grant.
+     * @param orgUsage      Defines whether organizations can be used with client credentials exchanges for this grant. (defaults to deny when not defined)
+     * @param allowAnyOrg   If true, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations.
+     * @return a Request to execute.
+     */
+    public Request<ClientGrant> create(String clientId, String audience, String[] scope, String orgUsage, Boolean allowAnyOrg) {
         Asserts.assertNotNull(clientId, "client id");
         Asserts.assertNotNull(audience, "audience");
         Asserts.assertNotNull(scope, "scope");
 
         String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/client-grants")
-                .build()
-                .toString();
+            .newBuilder()
+            .addPathSegments("api/v2/client-grants")
+            .build()
+            .toString();
         BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<ClientGrant>() {
         });
         request.addParameter("client_id", clientId);
         request.addParameter("audience", audience);
         request.addParameter("scope", scope);
+        if (orgUsage != null && !orgUsage.trim().isEmpty()) {
+            request.addParameter("organization_usage", orgUsage);
+        }
+        if (allowAnyOrg != null) {
+            request.addParameter("allow_any_organization", allowAnyOrg);
+        }
         return request;
     }
-
 
     /**
      * Delete an existing Client Grant. A token with scope delete:client_grants is needed.
@@ -107,18 +129,63 @@ public class ClientGrantsEntity extends BaseManagementEntity {
      * @return a Request to execute.
      */
     public Request<ClientGrant> update(String clientGrantId, String[] scope) {
+        return update(clientGrantId, scope, null, null);
+    }
+
+    /**
+     * Update an existing Client Grant. A token with scope update:client_grants is needed.
+     * See https://auth0.com/docs/api/management/v2#!/Client_Grants/patch_client_grants_by_id
+     *
+     * @param clientGrantId the client grant id.
+     * @param scope         the scope to grant.
+     * @param orgUsage      Defines whether organizations can be used with client credentials exchanges for this grant. (defaults to deny when not defined)
+     * @param allowAnyOrg   If true, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations.
+     * @return a Request to execute.
+     */
+    public Request<ClientGrant> update(String clientGrantId, String[] scope, String orgUsage, Boolean allowAnyOrg) {
         Asserts.assertNotNull(clientGrantId, "client grant id");
         Asserts.assertNotNull(scope, "scope");
 
         String url = baseUrl
-                .newBuilder()
-                .addPathSegments("api/v2/client-grants")
-                .addPathSegment(clientGrantId)
-                .build()
-                .toString();
+            .newBuilder()
+            .addPathSegments("api/v2/client-grants")
+            .addPathSegment(clientGrantId)
+            .build()
+            .toString();
         BaseRequest<ClientGrant> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.PATCH, new TypeReference<ClientGrant>() {
         });
         request.addParameter("scope", scope);
+        if (orgUsage != null && !orgUsage.trim().isEmpty()) {
+            request.addParameter("organization_usage", orgUsage);
+        }
+        if (allowAnyOrg != null) {
+            request.addParameter("allow_any_organization", allowAnyOrg);
+        }
         return request;
+    }
+
+    /**
+     * Returns the organizations associated with this client grant. A token with scope {@code read:organization_client_grants} is required.
+     * @param clientGrantId the client grant ID.
+     * @param filter an optional filter to limit results.
+     * @return a request to execute.
+     */
+    public Request<OrganizationsPage> listOrganizations(String clientGrantId, PageFilter filter) {
+        Asserts.assertNotNull(clientGrantId, "client grant ID");
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/client-grants")
+            .addPathSegment(clientGrantId)
+            .addPathSegment("organizations");
+
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+
+        String url = builder.build().toString();
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<OrganizationsPage>() {
+        });
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/OrganizationsEntity.java
@@ -1,9 +1,6 @@
 package com.auth0.client.mgmt;
 
-import com.auth0.client.mgmt.filter.BaseFilter;
-import com.auth0.client.mgmt.filter.FieldsFilter;
-import com.auth0.client.mgmt.filter.InvitationsFilter;
-import com.auth0.client.mgmt.filter.PageFilter;
+import com.auth0.client.mgmt.filter.*;
 import com.auth0.json.mgmt.roles.RolesPage;
 import com.auth0.json.mgmt.organizations.*;
 import com.auth0.net.BaseRequest;
@@ -596,6 +593,73 @@ public class OrganizationsEntity extends BaseManagementEntity {
             .addPathSegment(orgId)
             .addPathSegment("invitations")
             .addPathSegment(invitationId)
+            .build()
+            .toString();
+
+        return new VoidRequest(client, tokenProvider,  url, HttpMethod.DELETE);
+    }
+
+    /**
+     * Get the client grants associated with this organization. A token with scope {@code read:organization_client_grants} is required.
+     * @param orgId the organization ID.
+     * @param filter an optional filter to refine results.
+     * @return a request to execute.
+     */
+    public Request<OrganizationClientGrantsPage> listClientGrants(String orgId, OrganizationClientGrantsFilter filter) {
+        Asserts.assertNotNull(orgId, "organization ID");
+
+         HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegments(orgId)
+            .addPathSegment("client-grants");
+
+         applyFilter(filter, builder);
+
+         String url = builder.build().toString();
+
+         return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<OrganizationClientGrantsPage>() {});
+    }
+
+    /**
+     * Associate a client grant with an organization. A token with scope {@code create:organization_client_grants} is required.
+     * @param orgId the organization ID.
+     * @param addOrganizationClientGrantRequestBody the body of the request containing information about the client grant to associate.
+     * @return a request to execute.
+     */
+    public Request<OrganizationClientGrant> addClientGrant(String orgId, CreateOrganizationClientGrantRequestBody addOrganizationClientGrantRequestBody) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(addOrganizationClientGrantRequestBody, "client grant");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("client-grants")
+            .build()
+            .toString();
+
+        BaseRequest<OrganizationClientGrant> request =  new BaseRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<OrganizationClientGrant>() {});
+        request.setBody(addOrganizationClientGrantRequestBody);
+        return request;
+    }
+
+    /**
+     * Remove a client grant from an organization. A token with scope {@code delete:organization_client_grants} is required.
+     * @param orgId the organization ID.
+     * @param grantId the client grant ID.
+     * @return a request to execute.
+     */
+    public Request<Void> deleteClientGrant(String orgId, String grantId) {
+        Asserts.assertNotNull(orgId, "organization ID");
+        Asserts.assertNotNull(grantId, "client grant ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments(ORGS_PATH)
+            .addPathSegment(orgId)
+            .addPathSegment("client-grants")
+            .addPathSegment(grantId)
             .build()
             .toString();
 

--- a/src/main/java/com/auth0/client/mgmt/filter/OrganizationClientGrantsFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/OrganizationClientGrantsFilter.java
@@ -1,13 +1,10 @@
 package com.auth0.client.mgmt.filter;
 
 /**
- * Class used to filter the results received when calling the Client Grants endpoint. Related to the {@link com.auth0.client.mgmt.ClientGrantsEntity} entity.
- * <p>
- * This class is not thread-safe.
- *
- * @see BaseFilter
+ * Class used to filter the results received when listing the client grants associated with an organization.
+ * Related to the {@link com.auth0.client.mgmt.OrganizationsEntity} entity.
  */
-public class ClientGrantsFilter extends BaseFilter {
+public class OrganizationClientGrantsFilter extends BaseFilter {
 
     /**
      * Filter by client id
@@ -15,7 +12,7 @@ public class ClientGrantsFilter extends BaseFilter {
      * @param clientId only retrieve items with this client id.
      * @return this filter instance
      */
-    public ClientGrantsFilter withClientId(String clientId) {
+    public OrganizationClientGrantsFilter withClientId(String clientId) {
         parameters.put("client_id", clientId);
         return this;
     }
@@ -26,18 +23,8 @@ public class ClientGrantsFilter extends BaseFilter {
      * @param audience only retrieve the item with this audience.
      * @return this filter instance
      */
-    public ClientGrantsFilter withAudience(String audience) {
+    public OrganizationClientGrantsFilter withAudience(String audience) {
         parameters.put("audience", audience);
-        return this;
-    }
-
-    /**
-     * Filter by {@code allow_any_organization}
-     * @param allowAnyOrganization only retrieve items with the {@code allow_any_organization} value specfied.
-     * @return this filter instance.
-     */
-    public ClientGrantsFilter withAllowAnyOrganization(Boolean allowAnyOrganization) {
-        parameters.put("allow_any_organization", allowAnyOrganization);
         return this;
     }
 
@@ -48,7 +35,7 @@ public class ClientGrantsFilter extends BaseFilter {
      * @param amountPerPage the amount of items per page to retrieve.
      * @return this filter instance
      */
-    public ClientGrantsFilter withPage(int pageNumber, int amountPerPage) {
+    public OrganizationClientGrantsFilter withPage(int pageNumber, int amountPerPage) {
         parameters.put("page", pageNumber);
         parameters.put("per_page", amountPerPage);
         return this;
@@ -60,9 +47,8 @@ public class ClientGrantsFilter extends BaseFilter {
      * @param includeTotals whether to include or not the query summary.
      * @return this filter instance
      */
-    public ClientGrantsFilter withTotals(boolean includeTotals) {
+    public OrganizationClientGrantsFilter withTotals(boolean includeTotals) {
         parameters.put("include_totals", includeTotals);
         return this;
     }
-
 }

--- a/src/main/java/com/auth0/json/mgmt/organizations/CreateOrganizationClientGrantRequestBody.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/CreateOrganizationClientGrantRequestBody.java
@@ -1,0 +1,28 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the body of the request to send when associating a client grant with an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity#addClientGrant(String, CreateOrganizationClientGrantRequestBody)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateOrganizationClientGrantRequestBody {
+
+    @JsonProperty("grant_id")
+    private String grantId;
+
+    /**
+     * Create a new instance.
+     * @param grantId the ID of the grant.
+     */
+    @JsonCreator
+    public CreateOrganizationClientGrantRequestBody(String grantId) {
+        this.grantId = grantId;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationClientGrant.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationClientGrant.java
@@ -1,4 +1,4 @@
-package com.auth0.json.mgmt.clientgrants;
+package com.auth0.json.mgmt.organizations;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -7,13 +7,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
- * Class that represents an Auth0 Client Grant object. Related to the {@link com.auth0.client.mgmt.ClientGrantsEntity} entity.
+ * Represents a client grant associated with an organization.
+ * @see com.auth0.client.mgmt.OrganizationsEntity
  */
-@SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ClientGrant {
-
+public class OrganizationClientGrant {
     @JsonProperty("id")
     private String id;
     @JsonProperty("client_id")
@@ -22,10 +21,6 @@ public class ClientGrant {
     private String audience;
     @JsonProperty("scope")
     private List<String> scope;
-    @JsonProperty("organization_usage")
-    private String organizationUsage;
-    @JsonProperty("allow_any_organization")
-    private Boolean allowAnyOrganization;
 
     /**
      * Getter for the id of the client grant.
@@ -97,31 +92,4 @@ public class ClientGrant {
         this.scope = scope;
     }
 
-    /**
-     * @return the organization use
-     */
-    public String getOrganizationUsage() {
-        return organizationUsage;
-    }
-
-    /**
-     * @param organizationUsage the value of {@code organization_usage} to set.
-     */
-    public void setOrganizationUsage(String organizationUsage) {
-        this.organizationUsage = organizationUsage;
-    }
-
-    /**
-     * @return the value of {@code allow_any_organization}
-     */
-    public Boolean getAllowAnyOrganization() {
-        return allowAnyOrganization;
-    }
-
-    /**
-     * @param allowAnyOrganization the value of {@code allow_any_organization} to set.
-     */
-    public void setAllowAnyOrganization(Boolean allowAnyOrganization) {
-        this.allowAnyOrganization = allowAnyOrganization;
-    }
 }

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantsPage.java
@@ -1,0 +1,27 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.Page;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+/**
+ * Represents a page of a response when getting the client grants associated with an organization.
+ * @see OrganizationClientGrant
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = OrganizationClientGrantsPageDeserializer.class)
+public class OrganizationClientGrantsPage extends Page<OrganizationClientGrant> {
+
+    public OrganizationClientGrantsPage(List<OrganizationClientGrant> items) {
+        super(items);
+    }
+
+    public OrganizationClientGrantsPage(Integer start, Integer length, Integer total, Integer limit, List<OrganizationClientGrant> items) {
+        super(start, length, total, limit, items);
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantsPageDeserializer.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantsPageDeserializer.java
@@ -1,0 +1,25 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.mgmt.PageDeserializer;
+
+import java.util.List;
+
+/**
+ * Parses a paged response into its {@linkplain OrganizationClientGrant} representation.
+ */
+public class OrganizationClientGrantsPageDeserializer extends PageDeserializer<OrganizationClientGrantsPage, OrganizationClientGrant> {
+
+    OrganizationClientGrantsPageDeserializer() {
+        super(OrganizationClientGrant.class, "client_grants");
+    }
+
+    @Override
+    protected OrganizationClientGrantsPage createPage(List<OrganizationClientGrant> items) {
+        return new OrganizationClientGrantsPage(items);
+    }
+
+    @Override
+    protected OrganizationClientGrantsPage createPage(Integer start, Integer length, Integer total, Integer limit, List<OrganizationClientGrant> items) {
+        return new OrganizationClientGrantsPage(start, length, total, limit, items);
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -127,6 +127,9 @@ public class MockServer {
     public static final String ORGANIZATION_CONNECTION = "src/test/resources/mgmt/organization_connection.json";
     public static final String ORGANIZATION_MEMBER_ROLES_LIST = "src/test/resources/mgmt/organization_member_roles_list.json";
     public static final String ORGANIZATION_MEMBER_ROLES_PAGED_LIST = "src/test/resources/mgmt/organization_member_roles_paged_list.json";
+    public static final String ORGANIZATION_CLIENT_GRANTS = "src/test/resources/mgmt/organization_client_grants.json";
+    public static final String ORGANIZATION_CLIENT_GRANTS_PAGED_LIST = "src/test/resources/mgmt/organization_client_grants_paged_list.json";
+    public static final String ORGANIZATION_CLIENT_GRANT = "src/test/resources/mgmt/organization_client_grant.json";
     public static final String INVITATION = "src/test/resources/mgmt/invitation.json";
     public static final String INVITATIONS_LIST = "src/test/resources/mgmt/invitations_list.json";
     public static final String INVITATIONS_PAGED_LIST = "src/test/resources/mgmt/invitations_paged_list.json";

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -848,6 +848,61 @@ public class AuthAPITest {
         assertThat(body, hasEntry("client_id", CLIENT_ID));
         assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
         assertThat(body, hasEntry("audience", "https://myapi.auth0.com/users"));
+        assertThat(body, not(hasEntry("organization", any(String.class))));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateLogInWithClientCredentialsGrantRequestWithOrg() throws Exception {
+        TokenRequest request = api.requestToken("https://myapi.auth0.com/users", "org_123");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("grant_type", "client_credentials"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+        assertThat(body, hasEntry("audience", "https://myapi.auth0.com/users"));
+        assertThat(body, hasEntry("organization", "org_123"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+        assertThat(response.getIdToken(), not(emptyOrNullString()));
+        assertThat(response.getRefreshToken(), not(emptyOrNullString()));
+        assertThat(response.getTokenType(), not(emptyOrNullString()));
+        assertThat(response.getExpiresIn(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateLogInWithClientCredentialsGrantRequestWithoutOrgWhenEmpty() throws Exception {
+        TokenRequest request = api.requestToken("https://myapi.auth0.com/users", " ");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("grant_type", "client_credentials"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+        assertThat(body, hasEntry("audience", "https://myapi.auth0.com/users"));
+        assertThat(body, not(hasKey("organization")));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getAccessToken(), not(emptyOrNullString()));

--- a/src/test/java/com/auth0/json/mgmt/ClientGrantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ClientGrantTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class ClientGrantTest extends JsonTest<ClientGrant> {
 
-    private static final String json = "{\"client_id\":\"clientId\",\"audience\":\"aud\",\"scope\":[\"one\",\"two\"]}";
+    private static final String json = "{\"client_id\":\"clientId\",\"audience\":\"aud\",\"scope\":[\"one\",\"two\"],\"organization_usage\": \"allow\",\"allow_any_organization\":true}";
     private static final String readOnlyJson = "{\"id\":\"grantId\"}";
 
     @Test
@@ -21,12 +21,16 @@ public class ClientGrantTest extends JsonTest<ClientGrant> {
         grant.setAudience("aud");
         grant.setClientId("clientId");
         grant.setScope(Arrays.asList("one", "two"));
+        grant.setOrganizationUsage("require");
+        grant.setAllowAnyOrganization(true);
 
         String serialized = toJSON(grant);
         assertThat(serialized, is(notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("client_id", "clientId"));
         assertThat(serialized, JsonMatcher.hasEntry("audience", "aud"));
         assertThat(serialized, JsonMatcher.hasEntry("scope", Arrays.asList("one", "two")));
+        assertThat(serialized, JsonMatcher.hasEntry("organization_usage", "require"));
+        assertThat(serialized, JsonMatcher.hasEntry("allow_any_organization", true));
     }
 
     @Test
@@ -38,6 +42,8 @@ public class ClientGrantTest extends JsonTest<ClientGrant> {
         assertThat(grant.getAudience(), is("aud"));
         assertThat(grant.getClientId(), is("clientId"));
         assertThat(grant.getScope(), contains("one", "two"));
+        assertThat(grant.getOrganizationUsage(), is("allow"));
+        assertThat(grant.getAllowAnyOrganization(), is(true));
     }
 
     @Test

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantTest.java
@@ -1,0 +1,48 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonMatcher;
+import com.auth0.json.JsonTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class OrganizationClientGrantTest extends JsonTest<OrganizationClientGrant> {
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        OrganizationClientGrant clientGrant = new OrganizationClientGrant();
+        clientGrant.setClientId("client-id");
+        clientGrant.setAudience("https://api-identifier/");
+        clientGrant.setScope(Arrays.asList("read:messages", "write:messages"));
+
+        String serialized = toJSON(clientGrant);
+        assertThat(serialized, is(notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("client_id", "client-id"));
+        assertThat(serialized, JsonMatcher.hasEntry("audience", "https://api-identifier/"));
+        assertThat(serialized, JsonMatcher.hasEntry("scope", Arrays.asList("read:messages", "write:messages")));
+    }
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        String json = "{\n" +
+            "  \"id\": \"1\",\n" +
+            "  \"client_id\": \"clientId1\",\n" +
+            "  \"audience\": \"audience1\",\n" +
+            "  \"scope\": [\n" +
+            "    \"openid\",\n" +
+            "    \"profile\"\n" +
+            "  ]\n" +
+            "}";
+
+        OrganizationClientGrant clientGrant = fromJSON(json, OrganizationClientGrant.class);
+
+        assertThat(clientGrant, is(notNullValue()));
+
+        assertThat(clientGrant.getAudience(), is("audience1"));
+        assertThat(clientGrant.getClientId(), is("clientId1"));
+        assertThat(clientGrant.getScope(), contains("openid", "profile"));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationClientGrantsPageTest.java
@@ -1,0 +1,71 @@
+package com.auth0.json.mgmt.organizations;
+
+import com.auth0.json.JsonTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class OrganizationClientGrantsPageTest extends JsonTest<OrganizationClientGrantsPage> {
+
+    private static final String JSON_WITHOUT_TOTALS = "[\n" +
+        "  {\n" +
+        "    \"id\": \"cgr_4pI9a42haOLLWnwq\",\n" +
+        "    \"client_id\": \"client-id\",\n" +
+        "    \"audience\": \"https://api-identifier\",\n" +
+        "    \"scope\": [\n" +
+        "      \"update:items\",\n" +
+        "      \"read:messages\"\n" +
+        "    ]\n" +
+        "  },\n" +
+        "  {\n" +
+        "    \"id\": \"cgr_D018f9kmBmwbZod\",\n" +
+        "    \"client_id\": \"client-id\",\n" +
+        "    \"audience\": \"https://api-identifier\",\n" +
+        "    \"scope\": []\n" +
+        "  }\n" +
+        "]";
+
+    private static final String JSON_WITH_TOTALS = "{\n" +
+        "  \"total\": 13,\n" +
+        "  \"start\": 0,\n" +
+        "  \"limit\": 1,\n" +
+        "  \"client_grants\": [\n" +
+        "    {\n" +
+        "      \"id\": \"cgr_3aidkk3skLVOM3Ay7\",\n" +
+        "      \"client_id\": \"client-id\",\n" +
+        "      \"audience\": \"https://api-identifier/\",\n" +
+        "      \"scope\": [\n" +
+        "        \"read:messages\"\n" +
+        "      ]\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    @Test
+    public void shouldDeserializeWithoutTotals() throws Exception {
+        OrganizationClientGrantsPage page = fromJSON(JSON_WITHOUT_TOTALS, OrganizationClientGrantsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(nullValue()));
+        assertThat(page.getLength(), is(nullValue()));
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getLimit(), is(nullValue()));
+        assertThat(page.getNext(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(2));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        OrganizationClientGrantsPage page = fromJSON(JSON_WITH_TOTALS, OrganizationClientGrantsPage.class);
+
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getStart(), is(0));
+        assertThat(page.getTotal(), is(13));
+        assertThat(page.getLimit(), is(1));
+        assertThat(page.getNext(), is(nullValue()));
+        assertThat(page.getItems(), is(notNullValue()));
+        assertThat(page.getItems().size(), is(1));
+    }
+}

--- a/src/test/resources/mgmt/organization_client_grant.json
+++ b/src/test/resources/mgmt/organization_client_grant.json
@@ -1,0 +1,9 @@
+{
+  "id": "1",
+  "client_id": "clientId1",
+  "audience": "audience1",
+  "scope": [
+    "openid",
+    "profile"
+  ]
+}

--- a/src/test/resources/mgmt/organization_client_grants.json
+++ b/src/test/resources/mgmt/organization_client_grants.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "cgr_4pI9a42haOLLWnwq",
+    "client_id": "client-id",
+    "audience": "https://api-identifier",
+    "scope": [
+      "update:items",
+      "read:messages"
+    ]
+  },
+  {
+    "id": "cgr_D018f9kmBmwbZod",
+    "client_id": "client-id",
+    "audience": "https://api-identifier",
+    "scope": []
+  }
+]

--- a/src/test/resources/mgmt/organization_client_grants_paged_list.json
+++ b/src/test/resources/mgmt/organization_client_grants_paged_list.json
@@ -1,0 +1,15 @@
+{
+  "total": 13,
+  "start": 0,
+  "limit": 1,
+  "client_grants": [
+    {
+      "id": "cgr_3aidkk3skLVOM3Ay7",
+      "client_id": "client-id",
+      "audience": "https://api-identifier/",
+      "scope": [
+        "read:messages"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

### AuthAPI changes

- New method to create a `client_credentials` request to `/oauth/token` allowing the optional `organization` parameter

### Management API changes

- Updated `ClientsGrantEntity` to support getting, creating, and updating client grants with respect to organizations
- Updated `OrganizationsEntity` to support getting, associating, and removing client grants associated with an organization

