### PR TITLE
[SDK-4736] support backchannel logout property on Client

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -94,6 +94,8 @@ public class Client {
     private ClientAuthenticationMethods clientAuthenticationMethods;
     @JsonProperty("require_pushed_authorization_requests")
     private Boolean requiresPushedAuthorizationRequests;
+    @JsonProperty("oidc_backchannel_logout")
+    private OIDCBackchannelLogout oidcBackchannelLogout;
 
     /**
      * Getter for the name of the tenant this client belongs to.
@@ -819,6 +821,21 @@ public class Client {
      */
     public void setRequiresPushedAuthorizationRequests(Boolean requiresPushedAuthorizationRequests) {
         this.requiresPushedAuthorizationRequests = requiresPushedAuthorizationRequests;
+    }
+
+    /**
+     * @return the value of the {@code oidc_backchannel_logout} property.
+     */
+    public OIDCBackchannelLogout getOidcBackchannelLogout() {
+        return oidcBackchannelLogout;
+    }
+
+    /**
+     * Sets the {@code oidc_backchannel_logout} property.
+     * @param oidcBackchannelLogout the value to set the {@code oidc_backchannel_logout} property to.
+     */
+    public void setOidcBackchannelLogout(OIDCBackchannelLogout oidcBackchannelLogout) {
+        this.oidcBackchannelLogout = oidcBackchannelLogout;
     }
 }
 

--- a/src/main/java/com/auth0/json/mgmt/client/OIDCBackchannelLogout.java
+++ b/src/main/java/com/auth0/json/mgmt/client/OIDCBackchannelLogout.java
@@ -1,0 +1,36 @@
+package com.auth0.json.mgmt.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents the value of the {@code oidc_backchannel_logout} property on an Auth0 application.\
+ * @see Client
+ * @see com.auth0.client.mgmt.ClientsEntity
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OIDCBackchannelLogout {
+
+    @JsonProperty("backchannel_logout_urls")
+    private List<String> backchannelLogoutUrls;
+
+    /**
+     * Create a new instance with the given list of Logout URIs that will receive a {@code logout_token} when selected Back-Channel Logout Initiators occur.
+     * @param backchannelLogoutUrls the list of allowed backchannel logout URLs.
+     */
+    public OIDCBackchannelLogout(@JsonProperty("backchannel_logout_urls") List<String> backchannelLogoutUrls) {
+        this.backchannelLogoutUrls = backchannelLogoutUrls;
+    }
+
+    /**
+     * @return the list of Logout URIs that will receive a {@code logout_token} when selected Back-Channel Logout Initiators occur.
+     */
+    public List<String> getBackchannelLogoutUrls() {
+        return this.backchannelLogoutUrls;
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -99,7 +99,10 @@ public class ClientTest extends JsonTest<Client> {
         "      ]\n" +
         "    }\n" +
         "  },\n" +
-        "  \"require_pushed_authorization_requests\": true\n" +
+        "  \"require_pushed_authorization_requests\": true,\n" +
+        "  \"oidc_backchannel_logout\": {\n" +
+        "     \"backchannel_logout_urls\": [\"http://acme.eu.auth0.com/events\"]\n" +
+        "  }\n" +
         "}";
 
     @Test
@@ -148,6 +151,7 @@ public class ClientTest extends JsonTest<Client> {
         ClientAuthenticationMethods cam = new ClientAuthenticationMethods(privateKeyJwt);
         client.setClientAuthenticationMethods(cam);
         client.setRequiresPushedAuthorizationRequests(true);
+        client.setOidcBackchannelLogout(new OIDCBackchannelLogout(Collections.singletonList("http://acme.eu.auth0.com/events")));
 
         String serialized = toJSON(client);
         assertThat(serialized, is(notNullValue()));
@@ -184,6 +188,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("client_authentication_methods", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("client_authentication_methods", containsString("{\"private_key_jwt\":{\"credentials\":[{\"credential_type\":\"public_key\",\"pem\":\"PEM\"}]}}")));
         assertThat(serialized, JsonMatcher.hasEntry("require_pushed_authorization_requests", true));
+        assertThat(serialized, JsonMatcher.hasEntry("oidc_backchannel_logout", containsString("{\"backchannel_logout_urls\":[\"http://acme.eu.auth0.com/events\"]}")));
     }
 
     @Test
@@ -235,6 +240,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getClientAuthenticationMethods().getPrivateKeyJwt().getCredentials().get(0).getId(), is("cred_abc"));
         assertThat(client.getClientAuthenticationMethods().getPrivateKeyJwt().getCredentials().get(1).getId(), is("cred_123"));
         assertThat(client.getRequiresPushedAuthorizationRequests(), is(true));
+        assertThat(client.getOidcBackchannelLogout().getBackchannelLogoutUrls().size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
### Changes

Adds support for the `oidc_backchannel_logout` property on a `Client`.