### PR TITLE
Organizations API no longer returns enabled_connections

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,14 +5,14 @@ ignore:
   SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
     - '*':
       reason: 'unaffected, only affects createTempFile and createTempDir kotlin function, which are not used'
-      expires: 2023-12-31T00:00:00.000Z
+      expires: 2024-12-31T00:00:00.000Z
   SNYK-JAVA-ORGBOUNCYCASTLE-5771339:
     - '*':
       reason: 'test-only dependency, no update available'
-      expires: 2023-12-31T00:00:00.000Z
+      expires: 2024-12-31T00:00:00.000Z
   SNYK-JAVA-ORGBOUNCYCASTLE-6084022:
     - '*':
           reason: 'test-only dependency, no update available'
-          expires: 2023-12-31T00:00:00.000Z
+          expires: 2024-12-31T00:00:00.000Z
 
 patch: {}

--- a/src/main/java/com/auth0/json/mgmt/organizations/Organization.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/Organization.java
@@ -1,5 +1,6 @@
 package com.auth0.json.mgmt.organizations;
 
+import com.auth0.client.mgmt.filter.PageFilter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -114,7 +115,11 @@ public class Organization {
 
     /**
      * @return the enabled connections of this Organization.
+     * @deprecated the {@code enabled_connections} property was removed from the API response body, so this will always
+     * return {@code null}. Use {@link com.auth0.client.mgmt.OrganizationsEntity#getConnections(String, PageFilter)}
+     * instead.
      */
+    @Deprecated
     public List<EnabledConnection> getEnabledConnections() {
         return enabledConnections;
     }

--- a/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsTest.java
+++ b/src/test/java/com/auth0/json/mgmt/organizations/OrganizationsTest.java
@@ -30,13 +30,7 @@ public class OrganizationsTest extends JsonTest<Organization> {
             "        },\n" +
             "        \"metadata\": {\n" +
             "            \"key1\": \"val1\"\n" +
-            "        },\n" +
-            "        \"enabled_connections\": [\n" +
-            "            {\n" +
-            "               \"connection_id\": \"con-1\",\n" +
-            "               \"assign_membership_on_login\": \"false\"\n" +
-            "            }\n" +
-            "        ]\n" +
+            "        }\n" +
             "    }";
 
         Organization org = fromJSON(orgJson, Organization.class);
@@ -51,8 +45,6 @@ public class OrganizationsTest extends JsonTest<Organization> {
         assertThat(org.getBranding().getColors().getPageBackground(), is("#FF0000"));
         assertThat(org.getMetadata(), is(notNullValue()));
         assertThat(org.getMetadata().get("key1"), is("val1"));
-        assertThat(org.getEnabledConnections().get(0).getConnectionId(), is("con-1"));
-        assertThat(org.getEnabledConnections().get(0).isAssignMembershipOnLogin(), is(false));
     }
 
     @Test


### PR DESCRIPTION
The Organizations API no longer returns the `enabled_connections` property.

* [https://auth0.com/docs/api/management/v2/organizations/get-organizations-by-id](https://auth0.com/docs/api/management/v2/organizations/get-organizations-by-id)
* [https://auth0.com/docs/api/management/v2/organizations/get-organizations-by-id](https://auth0.com/docs/api/management/v2/organizations/get-name-by-name)

This PR deprecates `getEnabledConnections()` in favor of `OrganizationsEntity#getConnections`.