### PR TITLE
[SDK-4769] - add show_as_button to Organization Enabled Connections

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/organizations/EnabledConnection.java
+++ b/src/main/java/com/auth0/json/mgmt/organizations/EnabledConnection.java
@@ -18,6 +18,8 @@ public class EnabledConnection {
     private boolean assignMembershipOnLogin;
     @JsonProperty("connection_id")
     private String connectionId;
+    @JsonProperty("show_as_button")
+    private Boolean showAsButton;
 
     public EnabledConnection() {}
 
@@ -76,5 +78,21 @@ public class EnabledConnection {
      */
     public void setConnectionId(String connectionId) {
         this.connectionId = connectionId;
+    }
+
+    /**
+     * @return the value of the {@code show_as_button} field.
+     */
+    public Boolean getShowAsButton() {
+        return showAsButton;
+    }
+
+    /**
+     * Sets the {@code show_as_button} value.
+     *
+     * @param showAsButton the value for {@code show_as_button}.
+     */
+    public void setShowAsButton(Boolean showAsButton) {
+        this.showAsButton = showAsButton;
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/OrganizationEntityTest.java
@@ -584,6 +584,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         EnabledConnection connection = new EnabledConnection();
         connection.setAssignMembershipOnLogin(false);
         connection.setConnectionId("con_123");
+        connection.setShowAsButton(true);
 
         Request<EnabledConnection> request = api.organizations().addConnection("org_abc", connection);
         assertThat(request, is(notNullValue()));
@@ -597,9 +598,10 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body, aMapWithSize(2));
+        assertThat(body, aMapWithSize(3));
         assertThat(body, hasEntry("connection_id", "con_123"));
         assertThat(body, hasEntry("assign_membership_on_login", false));
+        assertThat(body, hasEntry("show_as_button", true));
     }
 
     @Test
@@ -656,6 +658,7 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
     public void shouldUpdateOrgConnection() throws Exception {
         EnabledConnection connection = new EnabledConnection();
         connection.setAssignMembershipOnLogin(true);
+        connection.setShowAsButton(false);
 
         Request<EnabledConnection> request = api.organizations().updateConnection("org_abc", "con_123", connection);
         assertThat(request, is(notNullValue()));
@@ -669,8 +672,9 @@ public class OrganizationEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body, aMapWithSize(1));
+        assertThat(body, aMapWithSize(2));
         assertThat(body, hasEntry("assign_membership_on_login", true));
+        assertThat(body, hasEntry("show_as_button", false));
     }
 
     // Organization roles

--- a/src/test/resources/mgmt/organization_connection.json
+++ b/src/test/resources/mgmt/organization_connection.json
@@ -1,4 +1,5 @@
 {
   "connection_id": "con_At4BWXhV3lKv82jd",
-  "assign_membership_on_login": false
+  "assign_membership_on_login": false,
+  "show_as_button": true
 }

--- a/src/test/resources/mgmt/organization_connections_list.json
+++ b/src/test/resources/mgmt/organization_connections_list.json
@@ -2,6 +2,7 @@
   {
     "connection_id": "con_At4BWXhV3lKv82jd",
     "assign_membership_on_login": false,
+    "show_as_button": true,
     "connection": {
       "name": "google-oauth2",
       "strategy": "google-oauth2"
@@ -10,6 +11,7 @@
   {
     "connection_id": "con_kai93HmEDCs8ai3d",
     "assign_membership_on_login": true,
+    "show_as_button": true,
     "connection": {
       "name": "Username-Password-Authentication",
       "strategy": "auth0"

--- a/src/test/resources/mgmt/organization_connections_paged_list.json
+++ b/src/test/resources/mgmt/organization_connections_paged_list.json
@@ -3,6 +3,7 @@
     {
       "connection_id": "con_At4BWXhV3lKv82jd",
       "assign_membership_on_login": false,
+      "show_as_button": true,
       "connection": {
         "name": "google-oauth2",
         "strategy": "google-oauth2"
@@ -11,6 +12,7 @@
     {
       "connection_id": "con_kai93HmEDCs8ai3d",
       "assign_membership_on_login": true,
+      "show_as_button": true,
       "connection": {
         "name": "Username-Password-Authentication",
         "strategy": "auth0"


### PR DESCRIPTION
### Changes

Adds the `show_as_button` field to organization enabled connections.

### References

https://auth0.com/docs/api/management/v2/organizations/get-enabled-connections
https://auth0.com/docs/api/management/v2/organizations/post-enabled-connections
https://auth0.com/docs/api/management/v2/organizations/get-enabled-connections-by-connection-id
https://auth0.com/docs/api/management/v2/organizations/patch-enabled-connections-by-connection-id
