### PR TITLE
Ignore test-only dependency snyk issue

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,5 +14,9 @@ ignore:
     - '*':
           reason: 'test-only dependency, no update available'
           expires: 2024-12-31T00:00:00.000Z
+  SNYK-JAVA-ORGBOUNCYCASTLE-6277380:
+    - '*':
+          reason: 'test-only dependency, no update available'
+          expires: 2024-12-31T00:00:00.000Z
 
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -18,5 +18,8 @@ ignore:
     - '*':
           reason: 'test-only dependency, no update available'
           expires: 2024-12-31T00:00:00.000Z
-
+  SNYK-JAVA-ORGBOUNCYCASTLE-6613080:
+    - '*':
+          reason: 'test-only dependency, no update available'
+          expires: 2024-12-31T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
### Changes

Adds snyk rule to ignore test-only dependency of bouncy castle:

- https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277380
- https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6613080