### PR TITLE
[SDK-4763] - Add support for HRI Management API changes 

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -96,7 +96,8 @@ public class Client {
     private Boolean requiresPushedAuthorizationRequests;
     @JsonProperty("oidc_backchannel_logout")
     private OIDCBackchannelLogout oidcBackchannelLogout;
-
+    @JsonProperty("signed_request_object")
+    private SignedRequest signedRequest;
     /**
      * Getter for the name of the tenant this client belongs to.
      * @return the tenant name
@@ -836,6 +837,22 @@ public class Client {
      */
     public void setOidcBackchannelLogout(OIDCBackchannelLogout oidcBackchannelLogout) {
         this.oidcBackchannelLogout = oidcBackchannelLogout;
+    }
+
+    /**
+     * @return the value of the {@code signed_request_object} field.
+     */
+    public SignedRequest getSignedRequest() {
+        return signedRequest;
+    }
+
+    /**
+     * Sets the value of the  {@code SignedRequest} field.
+     *
+     * @param signedRequest the value to set the {@code signed_request_field} field to.
+     */
+    public void setSignedRequest(SignedRequest signedRequest) {
+        this.signedRequest = signedRequest;
     }
 }
 

--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -98,6 +98,9 @@ public class Client {
     private OIDCBackchannelLogout oidcBackchannelLogout;
     @JsonProperty("signed_request_object")
     private SignedRequest signedRequest;
+    @JsonProperty("compliance_level")
+    private String complianceLevel;
+
     /**
      * Getter for the name of the tenant this client belongs to.
      * @return the tenant name
@@ -853,6 +856,21 @@ public class Client {
      */
     public void setSignedRequest(SignedRequest signedRequest) {
         this.signedRequest = signedRequest;
+    }
+
+    /**
+     * @return the value of the {@code compliance_level} field
+     */
+    public String getComplianceLevel() {
+        return complianceLevel;
+    }
+
+    /**
+     * Sets the value of the {@code compliance_level} field
+     * @param complianceLevel the value of the {@code compliance_level} field
+     */
+    public void setComplianceLevel(String complianceLevel) {
+        this.complianceLevel = complianceLevel;
     }
 }
 

--- a/src/main/java/com/auth0/json/mgmt/client/ClientAuthenticationMethods.java
+++ b/src/main/java/com/auth0/json/mgmt/client/ClientAuthenticationMethods.java
@@ -15,22 +15,40 @@ public class ClientAuthenticationMethods {
     private PrivateKeyJwt privateKeyJwt;
     @JsonProperty("self_signed_tls_client_auth")
     private SelfSignedTLSClientAuth selfSignedTLSClientAuth;
+    @JsonProperty("tls_client_auth")
+    private TLSClientAuth tlsClientAuth;
 
     public ClientAuthenticationMethods() {
 
     }
 
+    /**
+     * Create a new instance.
+     * @param privateKeyJwt the value of the {@code private_key_jwt} field.
+     */
     public ClientAuthenticationMethods(PrivateKeyJwt privateKeyJwt) {
-        this(privateKeyJwt, null);
+        this(privateKeyJwt, null, null);
     }
 
     /**
      * Create a new instance.
+     * @param privateKeyJwt the value of the {@code private_key_jwt} field.
      * @param selfSignedTLSClientAuth the value of the {@code self_signed_tls_client_auth} field.
      */
     public ClientAuthenticationMethods(PrivateKeyJwt privateKeyJwt, SelfSignedTLSClientAuth selfSignedTLSClientAuth) {
+        this(privateKeyJwt, selfSignedTLSClientAuth, null);
+    }
+
+    /**
+     * Create a new instance.
+     * @param privateKeyJwt the value of the {@code private_key_jwt} field.
+     * @param selfSignedTLSClientAuth the value of the {@code self_signed_tls_client_auth} field.
+     * @param tlsClientAuth the value of the {@code tls_client_auth} field.
+     */
+    public ClientAuthenticationMethods(PrivateKeyJwt privateKeyJwt, SelfSignedTLSClientAuth selfSignedTLSClientAuth, TLSClientAuth tlsClientAuth) {
         this.privateKeyJwt = privateKeyJwt;
         this.selfSignedTLSClientAuth = selfSignedTLSClientAuth;
+        this.tlsClientAuth = tlsClientAuth;
     }
 
     public PrivateKeyJwt getPrivateKeyJwt() {
@@ -42,5 +60,12 @@ public class ClientAuthenticationMethods {
      */
     public SelfSignedTLSClientAuth getSelfSignedTLSClientAuth() {
         return selfSignedTLSClientAuth;
+    }
+
+    /**
+     * @return the value of the {@code tls_client_auth} field
+     */
+    public TLSClientAuth getTlsClientAuth() {
+        return tlsClientAuth;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/client/ClientAuthenticationMethods.java
+++ b/src/main/java/com/auth0/json/mgmt/client/ClientAuthenticationMethods.java
@@ -13,16 +13,34 @@ public class ClientAuthenticationMethods {
 
     @JsonProperty("private_key_jwt")
     private PrivateKeyJwt privateKeyJwt;
+    @JsonProperty("self_signed_tls_client_auth")
+    private SelfSignedTLSClientAuth selfSignedTLSClientAuth;
 
     public ClientAuthenticationMethods() {
 
     }
 
     public ClientAuthenticationMethods(PrivateKeyJwt privateKeyJwt) {
+        this(privateKeyJwt, null);
+    }
+
+    /**
+     * Create a new instance.
+     * @param selfSignedTLSClientAuth the value of the {@code self_signed_tls_client_auth} field.
+     */
+    public ClientAuthenticationMethods(PrivateKeyJwt privateKeyJwt, SelfSignedTLSClientAuth selfSignedTLSClientAuth) {
         this.privateKeyJwt = privateKeyJwt;
+        this.selfSignedTLSClientAuth = selfSignedTLSClientAuth;
     }
 
     public PrivateKeyJwt getPrivateKeyJwt() {
         return privateKeyJwt;
+    }
+
+    /**
+     * @return the value of the {@code self_signed_tls_client_auth} field
+     */
+    public SelfSignedTLSClientAuth getSelfSignedTLSClientAuth() {
+        return selfSignedTLSClientAuth;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/client/Credential.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Credential.java
@@ -31,6 +31,8 @@ public class Credential {
     private String alg;
     @JsonProperty("parse_expiry_from_cert")
     private Boolean parseExpiryFromCert;
+    @JsonProperty("subject_dn")
+    private String subjectDn;
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("created_at")
     private Date createdAt;
@@ -187,5 +189,20 @@ public class Credential {
      */
     public void setParseExpiryFromCert(Boolean parseExpiryFromCert) {
         this.parseExpiryFromCert = parseExpiryFromCert;
+    }
+
+    /**
+     * @return the value of the {@code subject_dn} field
+     */
+    public String getSubjectDn() {
+        return subjectDn;
+    }
+
+    /**
+     * Sets the value of the {@code subject_dn} field
+     * @param subjectDn the value of the {@code subject_dn} field
+     */
+    public void setSubjectDn(String subjectDn) {
+        this.subjectDn = subjectDn;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/client/SelfSignedTLSClientAuth.java
+++ b/src/main/java/com/auth0/json/mgmt/client/SelfSignedTLSClientAuth.java
@@ -19,14 +19,9 @@ public class SelfSignedTLSClientAuth {
 
     /**
      * Create a new instance
-     */
-    public SelfSignedTLSClientAuth() {}
-
-    /**
-     * Create a new instance
      * @param credentials the credentials to use
      */
-    public SelfSignedTLSClientAuth(List<Credential> credentials) {
+    public SelfSignedTLSClientAuth(@JsonProperty("credentials") List<Credential> credentials) {
         this.credentials = credentials;
     }
 

--- a/src/main/java/com/auth0/json/mgmt/client/SelfSignedTLSClientAuth.java
+++ b/src/main/java/com/auth0/json/mgmt/client/SelfSignedTLSClientAuth.java
@@ -1,0 +1,39 @@
+package com.auth0.json.mgmt.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Class that represents an Auth0 Application self-signed TLS client authentication method. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SelfSignedTLSClientAuth {
+
+    @JsonProperty("credentials")
+    private List<Credential> credentials;
+
+    /**
+     * Create a new instance
+     */
+    public SelfSignedTLSClientAuth() {}
+
+    /**
+     * Create a new instance
+     * @param credentials the credentials to use
+     */
+    public SelfSignedTLSClientAuth(List<Credential> credentials) {
+        this.credentials = credentials;
+    }
+
+    /**
+     * @return the credentials
+     */
+    public List<Credential> getCredentials() {
+        return credentials;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/client/SignedRequest.java
+++ b/src/main/java/com/auth0/json/mgmt/client/SignedRequest.java
@@ -1,0 +1,44 @@
+package com.auth0.json.mgmt.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Class that represents an Auth0 Application signed request object. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SignedRequest {
+
+    @JsonProperty("required")
+    private Boolean required;
+    @JsonProperty("credentials")
+    private List<Credential> credentials;
+
+    /**
+     * @return the value of the {@code credentials} field
+     */
+    public List<Credential> getCredentials() {
+        return credentials;
+    }
+
+    /**
+     * Sets the value of the {@code credentials} field
+     *
+     * @param credentials the value of the {@code credentials} field
+     */
+    public void setCredentials(List<Credential> credentials) {
+        this.credentials = credentials;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/client/TLSClientAuth.java
+++ b/src/main/java/com/auth0/json/mgmt/client/TLSClientAuth.java
@@ -17,14 +17,9 @@ public class TLSClientAuth  {
 
     /**
      * Create a new instance
-     */
-    public TLSClientAuth() {}
-
-    /**
-     * Create a new instance
      * @param credentials the credentials to use
      */
-    public TLSClientAuth(List<Credential> credentials) {
+    public TLSClientAuth(@JsonProperty("credentials") List<Credential> credentials) {
         this.credentials = credentials;
     }
 

--- a/src/main/java/com/auth0/json/mgmt/client/TLSClientAuth.java
+++ b/src/main/java/com/auth0/json/mgmt/client/TLSClientAuth.java
@@ -1,0 +1,37 @@
+package com.auth0.json.mgmt.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Class that represents an Auth0 Application TLS client authentication method. Related to the {@link com.auth0.client.mgmt.ClientsEntity} entity.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TLSClientAuth  {
+    @JsonProperty("credentials")
+    private List<Credential> credentials;
+
+    /**
+     * Create a new instance
+     */
+    public TLSClientAuth() {}
+
+    /**
+     * Create a new instance
+     * @param credentials the credentials to use
+     */
+    public TLSClientAuth(List<Credential> credentials) {
+        this.credentials = credentials;
+    }
+
+    /**
+     * @return the credentials
+     */
+    public List<Credential> getCredentials() {
+        return credentials;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/AuthorizationDetails.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/AuthorizationDetails.java
@@ -1,0 +1,37 @@
+package com.auth0.json.mgmt.resourceserver;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents the authorization details associated with a {@link ResourceServer}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuthorizationDetails {
+
+    @JsonProperty("type")
+    private String type;
+
+    public AuthorizationDetails() {}
+
+    public AuthorizationDetails(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the value of the {@code type} field
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the value of the {@code type} field
+     * @param type the value of the {@code type} field
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/AuthorizationDetails.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/AuthorizationDetails.java
@@ -1,5 +1,6 @@
 package com.auth0.json.mgmt.resourceserver;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,9 +15,12 @@ public class AuthorizationDetails {
     @JsonProperty("type")
     private String type;
 
-    public AuthorizationDetails() {}
-
-    public AuthorizationDetails(String type) {
+    /**
+     * Create a new instance.
+     * @param type the value of the {@code type} field.
+     */
+    @JsonCreator
+    public AuthorizationDetails(@JsonProperty("type") String type) {
         this.type = type;
     }
 

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/AuthorizationDetails.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/AuthorizationDetails.java
@@ -26,12 +26,4 @@ public class AuthorizationDetails {
     public String getType() {
         return type;
     }
-
-    /**
-     * Sets the value of the {@code type} field
-     * @param type the value of the {@code type} field
-     */
-    public void setType(String type) {
-        this.type = type;
-    }
 }

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/EncryptionKey.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/EncryptionKey.java
@@ -1,0 +1,99 @@
+package com.auth0.json.mgmt.resourceserver;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents the encryption key associated with a {@link TokenEncryption}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EncryptionKey {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("alg")
+    private String alg;
+    @JsonProperty("pem")
+    private String pem;
+    @JsonProperty("kid")
+    private String kid;
+    @JsonProperty("thumbprint_sha256")
+    private String thumbprintSha256;
+
+    /**
+     * @return the value of the {@code name} field.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the value of the {@code name} field.
+     * @param name the value of the {@code name} field.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the value of the {@code alg} field.
+     */
+    public String getAlg() {
+        return alg;
+    }
+
+    /**
+     * Sets the value of the {@code alg} field.
+     * @param alg the value of the {@code alg} field.
+     */
+    public void setAlg(String alg) {
+        this.alg = alg;
+    }
+
+    /**
+     * @return the value of the {@code pem} field.
+     */
+    public String getPem() {
+        return pem;
+    }
+
+    /**
+     * Sets the value of the {@code pem} field.
+     * @param pem the value of the {@code pem} field.
+     */
+    public void setPem(String pem) {
+        this.pem = pem;
+    }
+
+    /**
+     * @return the value of the {@code kid} field.
+     */
+    public String getKid() {
+        return kid;
+    }
+
+    /**
+     * Sets the value of the {@code kid} field.
+     * @param kid the value of the {@code kid} field.
+     */
+    public void setKid(String kid) {
+        this.kid = kid;
+    }
+
+    /**
+     * @return the value of the {@code thumbprint_sha256} field.
+     */
+    public String getThumbprintSha256() {
+        return thumbprintSha256;
+    }
+
+    /**
+     * Sets the value of the {@code thumbprint_sha256} field.
+     * @param thumbprintSha256 the value of the {@code thumbprint_sha256} field.
+     */
+    public void setThumbprintSha256(String thumbprintSha256) {
+        this.thumbprintSha256 = thumbprintSha256;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
@@ -41,9 +41,10 @@ public class ResourceServer {
     private Boolean enforcePolicies;
     @JsonProperty("consent_policy")
     private String consentPolicy;
-
     @JsonProperty("authorization_details")
     private List<AuthorizationDetails> authorizationDetails;
+    @JsonProperty("token_encryption")
+    private TokenEncryption tokenEncryption;
 
     @JsonCreator
     public ResourceServer(@JsonProperty("identifier") String identifier) {
@@ -211,5 +212,20 @@ public class ResourceServer {
      */
     public void setAuthorizationDetails(List<AuthorizationDetails> authorizationDetails) {
         this.authorizationDetails = authorizationDetails;
+    }
+
+    /**
+     * @return the value of the {@code token_encryption} field.
+     */
+    public TokenEncryption getTokenEncryption() {
+        return tokenEncryption;
+    }
+
+    /**
+     * Sets the value of the {@code token_encryption} field.
+     * @param tokenEncryption the value of the {@code token_encryption} field.
+     */
+    public void setTokenEncryption(TokenEncryption tokenEncryption) {
+        this.tokenEncryption = tokenEncryption;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
@@ -42,6 +42,9 @@ public class ResourceServer {
     @JsonProperty("consent_policy")
     private String consentPolicy;
 
+    @JsonProperty("authorization_details")
+    private List<AuthorizationDetails> authorizationDetails;
+
     @JsonCreator
     public ResourceServer(@JsonProperty("identifier") String identifier) {
         this.identifier = identifier;
@@ -193,5 +196,20 @@ public class ResourceServer {
      */
     public void setConsentPolicy(String consentPolicy) {
         this.consentPolicy = consentPolicy;
+    }
+
+    /**
+     * @return the value of the {@code authorization_details} field.
+     */
+    public List<AuthorizationDetails> getAuthorizationDetails() {
+        return authorizationDetails;
+    }
+
+    /**
+     * Sets the value of the {@code authorization_details} field.
+     * @param authorizationDetails the value of the {@code authorization_details} field.
+     */
+    public void setAuthorizationDetails(List<AuthorizationDetails> authorizationDetails) {
+        this.authorizationDetails = authorizationDetails;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
@@ -39,6 +39,8 @@ public class ResourceServer {
     private Boolean isSystem;
     @JsonProperty("enforce_policies")
     private Boolean enforcePolicies;
+    @JsonProperty("consent_policy")
+    private String consentPolicy;
 
     @JsonCreator
     public ResourceServer(@JsonProperty("identifier") String identifier) {
@@ -178,4 +180,18 @@ public class ResourceServer {
         this.tokenLifetimeForWeb = tokenLifetimeForWeb;
     }
 
+    /**
+     * @return the value of the {@code consent_policy} field.
+     */
+    public String getConsentPolicy() {
+        return consentPolicy;
+    }
+
+    /**
+     * Sets the value of the {@code consent_policy} field
+     * @param consentPolicy the value of the {@code consent_policy} field
+     */
+    public void setConsentPolicy(String consentPolicy) {
+        this.consentPolicy = consentPolicy;
+    }
 }

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/TokenEncryption.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/TokenEncryption.java
@@ -17,6 +17,11 @@ public class TokenEncryption {
     @JsonProperty("encryption_key")
     private EncryptionKey encryptionKey;
 
+    /**
+     * Create a new instance.
+     * @param format the value of the {@code format} field.
+     * @param encryptionKey the value of the {@code encryption_key} field.
+     */
     @JsonCreator
     public TokenEncryption(@JsonProperty("format") String format, @JsonProperty("encryption_key") EncryptionKey encryptionKey) {
         this.format = format;

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/TokenEncryption.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/TokenEncryption.java
@@ -1,0 +1,38 @@
+package com.auth0.json.mgmt.resourceserver;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that represents the token encryption associated with a {@link ResourceServer}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TokenEncryption {
+
+    @JsonProperty("format")
+    private String format;
+    @JsonProperty("encryption_key")
+    private EncryptionKey encryptionKey;
+
+    @JsonCreator
+    public TokenEncryption(@JsonProperty("format") String format, @JsonProperty("encryption_key") EncryptionKey encryptionKey) {
+        this.format = format;
+        this.encryptionKey = encryptionKey;
+    }
+    /**
+     * @return the value of the {@code format} field.
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * @return the value of the {@code encryption_key} field.
+     */
+    public EncryptionKey getEncryptionKey() {
+        return encryptionKey;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/tenants/Mtls.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Mtls.java
@@ -1,0 +1,34 @@
+package com.auth0.json.mgmt.tenants;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the value of the {@code enable_endpoint_aliases} field of the {@link Tenant}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Mtls {
+
+    @JsonProperty("enable_endpoint_aliases")
+    private Boolean enableEndpointAliases;
+
+    /**
+     * @return the value of the {@code enable_endpoint_aliases} field
+     */
+    public Boolean getEnableEndpointAliases() {
+        return enableEndpointAliases;
+    }
+
+    /**
+     * Sets the value of the {@code enable_endpoint_aliases} field
+     *
+     * @param enableEndpointAliases the value of the {@code enable_endpoint_aliases} field
+     */
+    public void setEnableEndpointAliases(Boolean enableEndpointAliases) {
+        this.enableEndpointAliases = enableEndpointAliases;
+    }
+
+}

--- a/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
@@ -52,6 +52,9 @@ public class Tenant {
     @JsonProperty("pushed_authorization_requests_supported")
     private Boolean pushedAuthorizationRequestsSupported;
 
+    @JsonProperty("remove_alg_from_jwks")
+    private Boolean removeAlgFromJwks;
+
 
     /**
      * Getter for the change password page customization.
@@ -358,5 +361,21 @@ public class Tenant {
      */
     public void setPushedAuthorizationRequestsSupported(Boolean pushedAuthorizationRequestsSupported) {
         this.pushedAuthorizationRequestsSupported = pushedAuthorizationRequestsSupported;
+    }
+
+    /**
+     * @return the value of the {@code remove_alg_from_jwks} field
+     */
+    public Boolean getRemoveAlgFromJwks() {
+        return removeAlgFromJwks;
+    }
+
+    /**
+     * Sets the value of the {@code remove_alg_from_jwks} field
+     *
+     * @param removeAlgFromJwks the value of the {@code remove_alg_from_jwks} field
+     */
+    public void setRemoveAlgFromJwks(Boolean removeAlgFromJwks) {
+        this.removeAlgFromJwks = removeAlgFromJwks;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
@@ -46,6 +46,10 @@ public class Tenant {
     @JsonProperty("idle_session_lifetime")
     private Integer idleSessionLifetime;
 
+    @JsonProperty("acr_values_supported")
+    private List<String> acrValuesSupported;
+
+
     /**
      * Getter for the change password page customization.
      *
@@ -319,5 +323,21 @@ public class Tenant {
     @JsonProperty("idle_session_lifetime")
     public void setIdleSessionLifetime(Integer idleSessionLifetime) {
         this.idleSessionLifetime = idleSessionLifetime;
+    }
+
+    /**
+     * @return the value of the {@code acr_values_supported} field
+     */
+    public List<String> getAcrValuesSupported() {
+        return acrValuesSupported;
+    }
+
+    /**
+     * Sets the value of the {@code acr_values_supported} field
+     *
+     * @param acrValuesSupported the value of the {@code acr_values_supported_field}
+     */
+    public void setAcrValuesSupported(List<String> acrValuesSupported) {
+        this.acrValuesSupported = acrValuesSupported;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
@@ -49,6 +49,9 @@ public class Tenant {
     @JsonProperty("acr_values_supported")
     private List<String> acrValuesSupported;
 
+    @JsonProperty("pushed_authorization_requests_supported")
+    private Boolean pushedAuthorizationRequestsSupported;
+
 
     /**
      * Getter for the change password page customization.
@@ -339,5 +342,21 @@ public class Tenant {
      */
     public void setAcrValuesSupported(List<String> acrValuesSupported) {
         this.acrValuesSupported = acrValuesSupported;
+    }
+
+    /**
+     * @return the value of the {@code pushed_authorization_requests_supported} field.
+     */
+    public Boolean getPushedAuthorizationRequestsSupported() {
+        return pushedAuthorizationRequestsSupported;
+    }
+
+    /**
+     * Sets the value of the {@code pushed_authorization_requests_supported} field
+     *
+     * @param pushedAuthorizationRequestsSupported the value of the {@code pushed_authorization_requests_supported} field
+     */
+    public void setPushedAuthorizationRequestsSupported(Boolean pushedAuthorizationRequestsSupported) {
+        this.pushedAuthorizationRequestsSupported = pushedAuthorizationRequestsSupported;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
+++ b/src/main/java/com/auth0/json/mgmt/tenants/Tenant.java
@@ -55,6 +55,9 @@ public class Tenant {
     @JsonProperty("remove_alg_from_jwks")
     private Boolean removeAlgFromJwks;
 
+    @JsonProperty("mtls")
+    private Mtls mtls;
+
 
     /**
      * Getter for the change password page customization.
@@ -377,5 +380,21 @@ public class Tenant {
      */
     public void setRemoveAlgFromJwks(Boolean removeAlgFromJwks) {
         this.removeAlgFromJwks = removeAlgFromJwks;
+    }
+
+    /**
+     * @return the value of the {@code mtls} field
+     */
+    public Mtls getMtls() {
+        return mtls;
+    }
+
+    /**
+     * Sets the value of the {@code mtls} field
+     *
+     * @param mtls the value of the {@code mtls} field
+     */
+    public void setMtls(Mtls mtls) {
+        this.mtls = mtls;
     }
 }

--- a/src/test/java/com/auth0/json/JsonMatcher.java
+++ b/src/test/java/com/auth0/json/JsonMatcher.java
@@ -38,7 +38,7 @@ public class JsonMatcher extends TypeSafeDiagnosingMatcher<String> {
                 return false;
             }
             if (!item.contains(getStringKey(key))) {
-                mismatchDescription.appendText("JSON didn't contained the key ").appendValue(key);
+                mismatchDescription.appendText("JSON does not contain the key ").appendValue(key);
                 return false;
             }
         }

--- a/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
@@ -1,9 +1,7 @@
 package com.auth0.json.mgmt;
 
 import com.auth0.json.JsonTest;
-import com.auth0.json.mgmt.resourceserver.AuthorizationDetails;
-import com.auth0.json.mgmt.resourceserver.ResourceServer;
-import com.auth0.json.mgmt.resourceserver.Scope;
+import com.auth0.json.mgmt.resourceserver.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -38,6 +36,12 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(deserialized.getAuthorizationDetails(), is(notNullValue()));
         assertThat(deserialized.getAuthorizationDetails().size(), is(2));
         assertThat(deserialized.getAuthorizationDetails().stream().map(AuthorizationDetails::getType).collect(Collectors.toList()), containsInAnyOrder("payment", "my custom type"));
+        assertThat(deserialized.getTokenEncryption(), notNullValue());
+        assertThat(deserialized.getTokenEncryption().getFormat(), is("compact-nested-jwe"));
+        assertThat(deserialized.getTokenEncryption().getEncryptionKey().getAlg(), is("RSA-OAEP-256"));
+        assertThat(deserialized.getTokenEncryption().getEncryptionKey().getKid(), is("my kid"));
+        assertThat(deserialized.getTokenEncryption().getEncryptionKey().getName(), is("my JWE public key"));
+        assertThat(deserialized.getTokenEncryption().getEncryptionKey().getThumbprintSha256(), is("thumbprint"));
     }
 
     @Test
@@ -66,8 +70,17 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         AuthorizationDetails authorizationDetails1 = new AuthorizationDetails("type1");
         AuthorizationDetails authorizationDetails2 = new AuthorizationDetails("type2");
         entity.setAuthorizationDetails(Arrays.asList(authorizationDetails1, authorizationDetails2));
+        EncryptionKey encryptionKey = new EncryptionKey();
+        encryptionKey.setName("name");
+        encryptionKey.setAlg("alg");
+        encryptionKey.setKid("kid");
+        encryptionKey.setPem("pem");
+        TokenEncryption tokenEncryption = new TokenEncryption("format", encryptionKey);
+        entity.setTokenEncryption(tokenEncryption);
 
         String json = toJSON(entity);
+
+        System.out.println(json);
 
         assertThat(json, hasEntry("id", "23445566abab"));
         assertThat(json, hasEntry("name", "Some API"));
@@ -82,5 +95,6 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(json, hasEntry("verification_location", "verification_location"));
         assertThat(json, hasEntry("consent_policy", "transactional-authorization-with-mfa"));
         assertThat(json, hasEntry("authorization_details", notNullValue()));
+        assertThat(json, hasEntry("token_encryption", containsString("{\"format\":\"format\",\"encryption_key\":{\"name\":\"name\",\"alg\":\"alg\",\"pem\":\"pem\",\"kid\":\"kid\"}}")));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
@@ -32,6 +32,7 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(deserialized.getTokenDialect(), is("access_token"));
         assertThat(deserialized.getTokenLifetime(), is(86400));
         assertThat(deserialized.getVerificationLocation(), is("verification_location"));
+        assertThat(deserialized.getConsentPolicy(), is("transactional-authorization-with-mfa"));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         entity.setTokenLifetime(86400);
         entity.setTokenDialect("access_token_authz");
         entity.setVerificationLocation("verification_location");
+        entity.setConsentPolicy("transactional-authorization-with-mfa");
 
         String json = toJSON(entity);
 
@@ -70,5 +72,6 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(json, hasEntry("token_lifetime", 86400));
         assertThat(json, hasEntry("token_dialect", "access_token_authz"));
         assertThat(json, hasEntry("verification_location", "verification_location"));
+        assertThat(json, hasEntry("consent_policy", "transactional-authorization-with-mfa"));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
@@ -1,17 +1,19 @@
 package com.auth0.json.mgmt;
 
 import com.auth0.json.JsonTest;
+import com.auth0.json.mgmt.resourceserver.AuthorizationDetails;
 import com.auth0.json.mgmt.resourceserver.ResourceServer;
 import com.auth0.json.mgmt.resourceserver.Scope;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.auth0.json.JsonMatcher.hasEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class ResourceServerTest extends JsonTest<ResourceServer> {
     private final static String RESOURCE_SERVER_JSON = "src/test/resources/mgmt/resource_server.json";
@@ -33,6 +35,9 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(deserialized.getTokenLifetime(), is(86400));
         assertThat(deserialized.getVerificationLocation(), is("verification_location"));
         assertThat(deserialized.getConsentPolicy(), is("transactional-authorization-with-mfa"));
+        assertThat(deserialized.getAuthorizationDetails(), is(notNullValue()));
+        assertThat(deserialized.getAuthorizationDetails().size(), is(2));
+        assertThat(deserialized.getAuthorizationDetails().stream().map(AuthorizationDetails::getType).collect(Collectors.toList()), containsInAnyOrder("payment", "my custom type"));
     }
 
     @Test
@@ -58,6 +63,9 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         entity.setTokenDialect("access_token_authz");
         entity.setVerificationLocation("verification_location");
         entity.setConsentPolicy("transactional-authorization-with-mfa");
+        AuthorizationDetails authorizationDetails1 = new AuthorizationDetails("type1");
+        AuthorizationDetails authorizationDetails2 = new AuthorizationDetails("type2");
+        entity.setAuthorizationDetails(Arrays.asList(authorizationDetails1, authorizationDetails2));
 
         String json = toJSON(entity);
 
@@ -73,5 +81,6 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(json, hasEntry("token_dialect", "access_token_authz"));
         assertThat(json, hasEntry("verification_location", "verification_location"));
         assertThat(json, hasEntry("consent_policy", "transactional-authorization-with-mfa"));
+        assertThat(json, hasEntry("authorization_details", notNullValue()));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -117,7 +117,8 @@ public class ClientTest extends JsonTest<Client> {
         "       \"updated_at\": \"2024-03-14T11:34:28.893Z\"\n" +
         "     }\n" +
         "   ]\n" +
-        "  }" +
+        "  },\n" +
+        "  \"compliance_level\": \"fapi1_adv_pkj_par\"\n" +
         "}";
 
     @Test
@@ -168,7 +169,7 @@ public class ClientTest extends JsonTest<Client> {
         client.setRequiresPushedAuthorizationRequests(true);
         client.setOidcBackchannelLogout(new OIDCBackchannelLogout(Collections.singletonList("http://acme.eu.auth0.com/events")));
 
-        // JAR configuration
+        // HRI configuration
         Credential signedRequestCredential = new Credential();
         signedRequestCredential.setName("cred name");
         signedRequestCredential.setCredentialType("public_key");
@@ -177,6 +178,7 @@ public class ClientTest extends JsonTest<Client> {
         signedRequest.setRequired(true);
         signedRequest.setCredentials(Collections.singletonList(signedRequestCredential));
         client.setSignedRequest(signedRequest);
+        client.setComplianceLevel("fapi1_adv_pkj_par");
 
         String serialized = toJSON(client);
         assertThat(serialized, is(notNullValue()));
@@ -215,6 +217,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("require_pushed_authorization_requests", true));
         assertThat(serialized, JsonMatcher.hasEntry("oidc_backchannel_logout", containsString("{\"backchannel_logout_urls\":[\"http://acme.eu.auth0.com/events\"]}")));
         assertThat(serialized, JsonMatcher.hasEntry("signed_request_object", containsString("{\"required\":true,\"credentials\":[{\"credential_type\":\"public_key\",\"name\":\"cred name\",\"pem\":\"pem\"}]}")));
+        assertThat(serialized, JsonMatcher.hasEntry("compliance_level", "fapi1_adv_pkj_par"));
     }
 
     @Test
@@ -268,6 +271,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getRequiresPushedAuthorizationRequests(), is(true));
         assertThat(client.getOidcBackchannelLogout().getBackchannelLogoutUrls().size(), is(1));
 
+        assertThat(client.getComplianceLevel(), is("fapi1_adv_pkj_par"));
         assertThat(client.getSignedRequest(), is(notNullValue()));
         assertThat(client.getSignedRequest().getCredentials(), is(notNullValue()));
         assertThat(client.getSignedRequest().getCredentials().size(), is(1));

--- a/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class TenantTest extends JsonTest<Tenant> {
 
-    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"], \"pushed_authorization_requests_supported\": true, \"remove_alg_from_jwks\": true}";
+    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"], \"pushed_authorization_requests_supported\": true, \"remove_alg_from_jwks\": true, \"mtls\": {\"enable_endpoint_aliases\": true}}";
 
 
     @Test
@@ -35,6 +35,9 @@ public class TenantTest extends JsonTest<Tenant> {
         tenant.setAcrValuesSupported(Collections.singletonList("supported acr value"));
         tenant.setPushedAuthorizationRequestsSupported(true);
         tenant.setRemoveAlgFromJwks(true);
+        Mtls mtls = new Mtls();
+        mtls.setEnableEndpointAliases(true);
+        tenant.setMtls(mtls);
 
         String serialized = toJSON(tenant);
         assertThat(serialized, is(notNullValue()));
@@ -56,6 +59,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(serialized, JsonMatcher.hasEntry("acr_values_supported", Collections.singletonList("supported acr value")));
         assertThat(serialized, JsonMatcher.hasEntry("pushed_authorization_requests_supported", true));
         assertThat(serialized, JsonMatcher.hasEntry("remove_alg_from_jwks", true));
+        assertThat(serialized, JsonMatcher.hasEntry("enable_endpoint_aliases", notNullValue()));
     }
 
     @Test
@@ -81,6 +85,8 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(tenant.getAcrValuesSupported(), contains("string1", "string2"));
         assertThat(tenant.getPushedAuthorizationRequestsSupported(), is(true));
         assertThat(tenant.getRemoveAlgFromJwks(), is(true));
+        assertThat(tenant.getMtls(), is(notNullValue()));
+        assertThat(tenant.getMtls().getEnableEndpointAliases(), is(true));
     }
 
 }

--- a/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class TenantTest extends JsonTest<Tenant> {
 
-    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"], \"pushed_authorization_requests_supported\": true}";
+    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"], \"pushed_authorization_requests_supported\": true, \"remove_alg_from_jwks\": true}";
 
 
     @Test
@@ -34,6 +34,7 @@ public class TenantTest extends JsonTest<Tenant> {
         tenant.setSessionCookie(new SessionCookie("persistent"));
         tenant.setAcrValuesSupported(Collections.singletonList("supported acr value"));
         tenant.setPushedAuthorizationRequestsSupported(true);
+        tenant.setRemoveAlgFromJwks(true);
 
         String serialized = toJSON(tenant);
         assertThat(serialized, is(notNullValue()));
@@ -54,6 +55,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(serialized, JsonMatcher.hasEntry("session_cookie", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("acr_values_supported", Collections.singletonList("supported acr value")));
         assertThat(serialized, JsonMatcher.hasEntry("pushed_authorization_requests_supported", true));
+        assertThat(serialized, JsonMatcher.hasEntry("remove_alg_from_jwks", true));
     }
 
     @Test
@@ -78,6 +80,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(tenant.getSessionCookie().getMode(), is("persistent"));
         assertThat(tenant.getAcrValuesSupported(), contains("string1", "string2"));
         assertThat(tenant.getPushedAuthorizationRequestsSupported(), is(true));
+        assertThat(tenant.getRemoveAlgFromJwks(), is(true));
     }
 
 }

--- a/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class TenantTest extends JsonTest<Tenant> {
 
-    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"]}";
+    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"], \"pushed_authorization_requests_supported\": true}";
 
 
     @Test
@@ -33,6 +33,7 @@ public class TenantTest extends JsonTest<Tenant> {
         tenant.setIdleSessionLifetime(0);
         tenant.setSessionCookie(new SessionCookie("persistent"));
         tenant.setAcrValuesSupported(Collections.singletonList("supported acr value"));
+        tenant.setPushedAuthorizationRequestsSupported(true);
 
         String serialized = toJSON(tenant);
         assertThat(serialized, is(notNullValue()));
@@ -52,6 +53,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(serialized, JsonMatcher.hasEntry("idle_session_lifetime", 0));
         assertThat(serialized, JsonMatcher.hasEntry("session_cookie", notNullValue()));
         assertThat(serialized, JsonMatcher.hasEntry("acr_values_supported", Collections.singletonList("supported acr value")));
+        assertThat(serialized, JsonMatcher.hasEntry("pushed_authorization_requests_supported", true));
     }
 
     @Test
@@ -74,7 +76,8 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(tenant.getIdleSessionLifetime(), is(0));
         assertThat(tenant.getSessionCookie(), is(notNullValue()));
         assertThat(tenant.getSessionCookie().getMode(), is("persistent"));
-        assertThat(tenant.getAcrValuesSupported(),contains("string1", "string2") );
+        assertThat(tenant.getAcrValuesSupported(), contains("string1", "string2"));
+        assertThat(tenant.getPushedAuthorizationRequestsSupported(), is(true));
     }
 
 }

--- a/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
+++ b/src/test/java/com/auth0/json/mgmt/tenants/TenantTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 
 public class TenantTest extends JsonTest<Tenant> {
 
-    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}}";
+    private static final String json = "{\"change_password\":{},\"guardian_mfa_page\":{},\"default_audience\":\"https://domain.auth0.com/myapi\",\"default_directory\":\"Username-Password-Authentication\",\"error_page\":{},\"flags\":{},\"friendly_name\":\"My-Tenant\",\"picture_url\":\"https://pic.to/123\",\"support_email\":\"support@auth0.com\",\"support_url\":\"https://support.auth0.com\",\"allowed_logout_urls\":[\"https://domain.auth0.com/logout\"], \"session_lifetime\":24, \"idle_session_lifetime\":0.5, \"session_cookie\":{\"mode\": \"persistent\"}, \"acr_values_supported\":[\"string1\",\"string2\"]}";
 
 
     @Test
@@ -32,6 +32,7 @@ public class TenantTest extends JsonTest<Tenant> {
         tenant.setSessionLifetime(48);
         tenant.setIdleSessionLifetime(0);
         tenant.setSessionCookie(new SessionCookie("persistent"));
+        tenant.setAcrValuesSupported(Collections.singletonList("supported acr value"));
 
         String serialized = toJSON(tenant);
         assertThat(serialized, is(notNullValue()));
@@ -50,6 +51,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(serialized, JsonMatcher.hasEntry("session_lifetime", 48));
         assertThat(serialized, JsonMatcher.hasEntry("idle_session_lifetime", 0));
         assertThat(serialized, JsonMatcher.hasEntry("session_cookie", notNullValue()));
+        assertThat(serialized, JsonMatcher.hasEntry("acr_values_supported", Collections.singletonList("supported acr value")));
     }
 
     @Test
@@ -72,6 +74,7 @@ public class TenantTest extends JsonTest<Tenant> {
         assertThat(tenant.getIdleSessionLifetime(), is(0));
         assertThat(tenant.getSessionCookie(), is(notNullValue()));
         assertThat(tenant.getSessionCookie().getMode(), is("persistent"));
+        assertThat(tenant.getAcrValuesSupported(),contains("string1", "string2") );
     }
 
 }

--- a/src/test/resources/mgmt/client.json
+++ b/src/test/resources/mgmt/client.json
@@ -79,5 +79,6 @@
         "updated_at": "2024-03-14T11:34:28.893Z"
       }
     ]
-  }
+  },
+  "compliance_level": "fapi1_adv_pkj_par"
 }

--- a/src/test/resources/mgmt/client.json
+++ b/src/test/resources/mgmt/client.json
@@ -66,5 +66,18 @@
         "id": "cred_abc"
       }]
     }
+  },
+  "signed_request_object": {
+    "credentials": [
+      {
+        "id": "cred_id",
+        "credential_type": "public_key",
+        "kid": "cred_kid",
+        "alg": "RS256",
+        "name": "My JAR credential",
+        "created_at": "2024-03-14T11:34:28.893Z",
+        "updated_at": "2024-03-14T11:34:28.893Z"
+      }
+    ]
   }
 }

--- a/src/test/resources/mgmt/client.json
+++ b/src/test/resources/mgmt/client.json
@@ -65,6 +65,16 @@
       "credentials": [ {
         "id": "cred_abc"
       }]
+    },
+    "self_signed_tls_client_auth": {
+      "credentials": [ {
+        "id": "cred_123"
+      }]
+    },
+    "tls_client_auth": {
+      "credentials": [ {
+        "id": "cred_789"
+      }]
     }
   },
   "signed_request_object": {

--- a/src/test/resources/mgmt/resource_server.json
+++ b/src/test/resources/mgmt/resource_server.json
@@ -21,5 +21,6 @@
     }
   ],
   "is_system": true,
-  "enforce_policies": false
+  "enforce_policies": false,
+  "consent_policy": "transactional-authorization-with-mfa"
 }

--- a/src/test/resources/mgmt/resource_server.json
+++ b/src/test/resources/mgmt/resource_server.json
@@ -27,5 +27,14 @@
     "type": "payment"
   }, {
     "type": "my custom type"
-  }]
+  }],
+  "token_encryption": {
+    "format": "compact-nested-jwe",
+    "encryption_key": {
+      "name": "my JWE public key",
+      "kid": "my kid",
+      "alg": "RSA-OAEP-256",
+      "thumbprint_sha256": "thumbprint"
+    }
+  }
 }

--- a/src/test/resources/mgmt/resource_server.json
+++ b/src/test/resources/mgmt/resource_server.json
@@ -22,5 +22,10 @@
   ],
   "is_system": true,
   "enforce_policies": false,
-  "consent_policy": "transactional-authorization-with-mfa"
+  "consent_policy": "transactional-authorization-with-mfa",
+  "authorization_details": [{
+    "type": "payment"
+  }, {
+    "type": "my custom type"
+  }]
 }

--- a/src/test/resources/mgmt/tenant.json
+++ b/src/test/resources/mgmt/tenant.json
@@ -33,5 +33,6 @@
   "session_cookie": {
     "mode": "persistent"
   },
-  "acr_values_supported": ["string1", "string2"]
+  "acr_values_supported": ["string1", "string2"],
+  "pushed_authorization_requests_supported": true
 }

--- a/src/test/resources/mgmt/tenant.json
+++ b/src/test/resources/mgmt/tenant.json
@@ -34,5 +34,6 @@
     "mode": "persistent"
   },
   "acr_values_supported": ["string1", "string2"],
-  "pushed_authorization_requests_supported": true
+  "pushed_authorization_requests_supported": true,
+  "remove_alg_from_jwks": true
 }

--- a/src/test/resources/mgmt/tenant.json
+++ b/src/test/resources/mgmt/tenant.json
@@ -35,5 +35,8 @@
   },
   "acr_values_supported": ["string1", "string2"],
   "pushed_authorization_requests_supported": true,
-  "remove_alg_from_jwks": true
+  "remove_alg_from_jwks": true,
+  "mtls": {
+    "enable_endpoint_aliases": true
+  }
 }

--- a/src/test/resources/mgmt/tenant.json
+++ b/src/test/resources/mgmt/tenant.json
@@ -32,5 +32,6 @@
   ],
   "session_cookie": {
     "mode": "persistent"
-  }
+  },
+  "acr_values_supported": ["string1", "string2"]
 }


### PR DESCRIPTION
### Changes

Adds support for new and modified management endpoints related to [Highly Regulated Identity](https://auth0.com/docs/secure/highly-regulated-identity) (HRI).

Endpoints changed:
- new field `acr_values_supported` on Tenant
- new field `pushed_authorization_requests_supported` on Tenant
- new field `remove_alg_from_jwks` on Tenant
- new field `mtls` on Tenant
- new field `require_pushed_authorization_requests` on Client
- new field `signed_request_object` on Client
- new field `compliance_level` on Client
- new field `tls_client_auth` on `client_authentication_methods` field of Client
- new field `self_signed_tls_client_auth` on `client_authentication_methods` field of Client
- new field `require_proof_of_possession` on Client
- new field `consent_policy` on Resource Server
- new field `authorization_details` on Resource Server
- new field `token_encryption` on Resource Server
- new field `proof_of_possession` on Resource Server