### PR TITLE
Support delete all authentication methods endpoint

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -736,6 +736,28 @@ public class UsersEntity extends BaseManagementEntity {
     }
 
     /**
+     * Deletes all authentication methods for the given user.
+     * A token with scope {@code delete:authentication_methods} is needed.
+     * @see <a href="https://auth0.com/docs/api/management/v2/users/delete-authentication-methods">https://auth0.com/docs/api/management/v2/users/delete-authentication-methods</a>
+     *
+     * @param userId the user to delete the authentication method for
+     * @return a Request to execute.
+     */
+    public Request<Void> deleteAllAuthenticationMethods(String userId) {
+        Asserts.assertNotNull(userId, "user ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegment("authentication-methods")
+            .build()
+            .toString();
+
+        return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
+    }
+
+    /**
      * Updates an authentication method.
      * A token with scope {@code update:authentication_methods} is needed.
      * @see <a href="https://auth0.com/docs/api/management/v2#!/Users/patch_authentication_methods_by_authentication_method_id">https://auth0.com/docs/api/management/v2#!/Users/patch_authentication_methods_by_authentication_method_id</a>

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -1310,6 +1310,26 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
     }
 
     @Test
+    public void shouldNotDeleteAllAuthenticationMethodsWithNullUserId() {
+        verifyThrows(IllegalArgumentException.class,
+            () -> api.users().deleteAllAuthenticationMethods(null),
+            "'user ID' cannot be null!");
+    }
+
+    @Test
+    public void shouldDeleteAllAuthenticationMethods() throws Exception {
+        Request<Void> request = api.users().deleteAllAuthenticationMethods("1");
+        assertThat(request, is(notNullValue()));
+
+        server.noContentResponse();
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.DELETE, "/api/v2/users/1/authentication-methods"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    @Test
     public void invalidateRememberedBrowsersThrowsWhenUserIdIsNull() {
         verifyThrows(IllegalArgumentException.class,
             () -> api.users().invalidateRememberedBrowsers(null),


### PR DESCRIPTION
### Changes

Adds new method `deleteAllAuthenticationMethods(String userId)` to the `UsersEntity` to delete all authenticators for the given user.

### References

Calls the [delete all authenticators endpoint](https://auth0.com/docs/api/management/v2/users/delete-authentication-methods)

### Testing

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
