### PR TITLE
Add sessions and refresh tokens to Users Management API

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/UsersEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/UsersEntity.java
@@ -13,6 +13,8 @@ import com.auth0.json.mgmt.users.Identity;
 import com.auth0.json.mgmt.users.RecoveryCode;
 import com.auth0.json.mgmt.users.User;
 import com.auth0.json.mgmt.users.UsersPage;
+import com.auth0.json.mgmt.users.refreshtokens.RefreshTokensPage;
+import com.auth0.json.mgmt.users.sessions.SessionsPage;
 import com.auth0.net.EmptyBodyRequest;
 import com.auth0.net.BaseRequest;
 import com.auth0.net.Request;
@@ -785,6 +787,103 @@ public class UsersEntity extends BaseManagementEntity {
         });
         request.setBody(authenticationMethod);
         return request;
+    }
+
+    /**
+     * Get refresh tokens for a user
+     * A token with {@code read:refresh_tokens} is needed.
+     * See <a href="https://auth0.com/docs/api/management/v2/users/get-refresh-tokens-for-user">https://auth0.com/docs/api/management/v2/users/get-refresh-tokens-for-user</a>
+     *
+     * @param userId the role id
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<RefreshTokensPage> listRefreshTokens(String userId, CheckpointPaginationFilter filter) {
+        Asserts.assertNotNull(userId, "user id");
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegment("refresh-tokens");
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+        String url = builder.build().toString();
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<RefreshTokensPage>() {
+        });
+    }
+
+    /**
+     * Delete all refresh tokens for a user.
+     * A token with scope {@code delete:refresh_tokens} is needed.
+     * See <a href="https://auth0.com/docs/api/management/v2/users/delete-refresh-tokens-for-user">https://auth0.com/docs/api/management/v2/users/delete-refresh-tokens-for-user</a>
+     *
+     * @param userId the user to delete the refresh tokens for
+     * @return a Request to execute.
+     */
+    public Request<Void> deleteRefreshTokens(String userId) {
+        Asserts.assertNotNull(userId, "user ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegment("refresh-tokens")
+            .build()
+            .toString();
+
+        return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
+    }
+
+
+    /**
+     * Get sessions for user
+     * A token with {@code read:sessions} is needed.
+     * See <a href="https://auth0.com/docs/api/management/v2/users/get-sessions-for-user">https://auth0.com/docs/api/management/v2/users/get-sessions-for-user</a>
+     *
+     * @param userId the role id
+     * @param filter an optional pagination filter
+     * @return a Request to execute
+     */
+    public Request<SessionsPage> listSessions(String userId, CheckpointPaginationFilter filter) {
+        Asserts.assertNotNull(userId, "user id");
+        HttpUrl.Builder builder = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegment("sessions");
+        if (filter != null) {
+            for (Map.Entry<String, Object> e : filter.getAsMap().entrySet()) {
+                builder.addQueryParameter(e.getKey(), String.valueOf(e.getValue()));
+            }
+        }
+        String url = builder.build().toString();
+        return new BaseRequest<>(client, tokenProvider, url, HttpMethod.GET, new TypeReference<SessionsPage>() {
+        });
+    }
+
+    /**
+     * Delete sessions for user
+     * A token with scope {@code delete:sessions} is needed.
+     * See <a href="https://auth0.com/docs/api/management/v2/users/delete-sessions-for-user">https://auth0.com/docs/api/management/v2/users/delete-sessions-for-user</a>
+     *
+     * @param userId the user to delete the sessions for
+     * @return a Request to execute.
+     */
+    public Request<Void> deleteSessions(String userId) {
+        Asserts.assertNotNull(userId, "user ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/users")
+            .addPathSegment(userId)
+            .addPathSegment("sessions")
+            .build()
+            .toString();
+
+        return new VoidRequest(this.client, tokenProvider, url, HttpMethod.DELETE);
     }
 
     private static void encodeAndAddQueryParam(HttpUrl.Builder builder, BaseFilter filter) {

--- a/src/main/java/com/auth0/client/mgmt/filter/CheckpointPaginationFilter.java
+++ b/src/main/java/com/auth0/client/mgmt/filter/CheckpointPaginationFilter.java
@@ -1,0 +1,38 @@
+package com.auth0.client.mgmt.filter;
+
+public class CheckpointPaginationFilter extends BaseFilter {
+
+    /**
+     * Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
+     *
+     * @param includeTotals whether to include or not total result count.
+     * @return this filter instance
+     */
+    public CheckpointPaginationFilter withTotals(boolean includeTotals) {
+        parameters.put("include_totals", includeTotals);
+        return this;
+    }
+
+    /**
+     * Optional ID from which to start selection (exclusive).
+     *
+     * @param from the ID from which to start selection. This can be obtained from the {@code next} field returned from
+     *             a checkpoint-paginated result.
+     * @return this filter instance.
+     */
+    public CheckpointPaginationFilter withFrom(String from) {
+        parameters.put("from", from);
+        return this;
+    }
+
+    /**
+     * Number of results per page. Defaults to 50.
+     *
+     * @param take the amount of entries to retrieve per page.
+     * @return this filter instance.
+     */
+    public CheckpointPaginationFilter withTake(int take) {
+        parameters.put("take", take);
+        return this;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/refreshtokens/RefreshToken.java
+++ b/src/main/java/com/auth0/json/mgmt/users/refreshtokens/RefreshToken.java
@@ -1,0 +1,97 @@
+package com.auth0.json.mgmt.users.refreshtokens;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RefreshToken {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("created_at")
+    private Date createdAt;
+    @JsonProperty("idle_expires_at")
+    private Date idleExpiresAt;
+    @JsonProperty("expires_at")
+    private Date expiresAt;
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("session_id")
+    private String sessionId;
+    @JsonProperty("rotating")
+    private Boolean rotating;
+    @JsonProperty("resource_servers")
+    private List<ResourceServer> resourceServers;
+
+    /**
+     * @return The ID of the refresh token
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return ID of the user which can be used when interacting with other APIs.
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     * @return The date and time when the refresh token was created
+     */
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     *
+     * @return The date and time when the refresh token will expire if idle
+     */
+    public Date getIdleExpiresAt() {
+        return idleExpiresAt;
+    }
+
+    /**
+     *
+     * @return The date and time when the refresh token will expire
+     */
+    public Date getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
+     * @return ID of the client application granted with this refresh token
+     */
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     *
+     * @return ID of the authenticated session used to obtain this refresh-token
+     */
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    /**
+     * @return True if the token is a rotating refresh token
+     */
+    public Boolean isRotating() {
+        return rotating;
+    }
+
+    /**
+     * @return A list of the resource server IDs associated to this refresh-token and their granted scopes
+     */
+    public List<ResourceServer> getResourceServers() {
+        return resourceServers;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/refreshtokens/RefreshTokensPage.java
+++ b/src/main/java/com/auth0/json/mgmt/users/refreshtokens/RefreshTokensPage.java
@@ -1,0 +1,44 @@
+package com.auth0.json.mgmt.users.refreshtokens;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * This does not extend com.auth0.json.mgmt.Page<RefreshToken> because the URL only supports "next" and "take" pagination.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RefreshTokensPage {
+    @JsonProperty("total")
+    private Integer total;
+
+    @JsonProperty("next")
+    private String next;
+
+    @JsonProperty("tokens")
+    private List<RefreshToken> tokens;
+
+    /**
+     * @return the total number of refresh tokens. This is only present when `include_totals` is passed as a query parameter.
+     */
+    public Integer getTotal() {
+        return total;
+    }
+
+    /**
+     * @return the token ID from which to start selection for a new page
+     */
+    public String getNext() {
+        return next;
+    }
+
+    /**
+     * @return the list of Tokens
+     */
+    public List<RefreshToken> getTokens() {
+        return tokens;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/refreshtokens/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/users/refreshtokens/ResourceServer.java
@@ -1,0 +1,30 @@
+package com.auth0.json.mgmt.users.refreshtokens;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResourceServer {
+    @JsonProperty("audience")
+    private String audience;
+    @JsonProperty("scopes")
+    private List<String> scopes;
+
+    /**
+     * @return Resource server ID
+     */
+    public String getAudience() {
+        return audience;
+    }
+
+    /**
+     * @return List of scopes for the refresh token
+     */
+    public List<String> getScopes() {
+        return scopes;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/sessions/Authentication.java
+++ b/src/main/java/com/auth0/json/mgmt/users/sessions/Authentication.java
@@ -1,0 +1,21 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Authentication {
+    @JsonProperty("methods")
+    private List<AuthenticationMethod> methods;
+
+    /**
+     * @return Contains the authentication methods a user has completed during their session
+     */
+    public List<AuthenticationMethod> getMethods() {
+        return methods;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/sessions/AuthenticationMethod.java
+++ b/src/main/java/com/auth0/json/mgmt/users/sessions/AuthenticationMethod.java
@@ -1,0 +1,39 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuthenticationMethod {
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("timestamp")
+    private Date timestamp;
+    @JsonProperty("type")
+    private String type;
+
+    /**
+     * @return One of: "federated", "passkey", "pwd", "sms", "email", "mfa", "mock" or a custom method denoted by a URL
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return Timestamp of when the signal was received
+     */
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * @return A specific MFA factor. Only present when "name" is set to "mfa"
+     */
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/sessions/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/users/sessions/Client.java
@@ -1,0 +1,19 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Client {
+    @JsonProperty("client_id")
+    private String clientId;
+
+    /**
+     * @return ID of client for the session
+     */
+    public String getClientId() {
+        return clientId;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/sessions/Device.java
+++ b/src/main/java/com/auth0/json/mgmt/users/sessions/Device.java
@@ -1,0 +1,55 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Device {
+    @JsonProperty("initial_ip")
+    private String initialIP;
+    @JsonProperty("initial_asn")
+    private String initialASN;
+    @JsonProperty("last_user_agent")
+    private String lastUserAgent;
+    @JsonProperty("last_ip")
+    private String lastIP;
+    @JsonProperty("last_asn")
+    private String lastASN;
+
+    /**
+     * @return First IP address associated with this session
+     */
+    public String getInitialIP() {
+        return initialIP;
+    }
+
+    /**
+     * @return First autonomous system number associated with this session
+     */
+    public String getInitialASN() {
+        return initialASN;
+    }
+
+    /**
+     * @return Last user agent of the device from which this user logged in
+     */
+    public String getLastUserAgent() {
+        return lastUserAgent;
+    }
+
+    /**
+     * @return Last IP address from which this user logged in
+     */
+    public String getLastIP() {
+        return lastIP;
+    }
+
+    /**
+     * @return Last autonomous system number from which this user logged in
+     */
+    public String getLastASN() {
+        return lastASN;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/sessions/Session.java
+++ b/src/main/java/com/auth0/json/mgmt/users/sessions/Session.java
@@ -1,0 +1,104 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Session {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("created_at")
+    private Date createdAt;
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+    @JsonProperty("authenticated_at")
+    private Date authenticatedAt;
+    @JsonProperty("idle_expires_at")
+    private Date idleExpiresAt;
+    @JsonProperty("expires_at")
+    private Date expiresAt;
+    @JsonProperty("device")
+    private Device device;
+    @JsonProperty("clients")
+    private List<Client> clients;
+    @JsonProperty("authentication")
+    private Authentication authentication;
+
+    /**
+     * @return The ID of the session
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return ID of the user which can be used when interacting with other APIs.
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     *
+     * @return The date and time when the session was created
+     */
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * @return The date and time when the session was last updated
+     */
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /**
+     * @return The date and time when the session was last authenticated
+     */
+    public Date getAuthenticatedAt() {
+        return authenticatedAt;
+    }
+
+    /**
+     * @return The date and time when the session will expire if idle
+     */
+    public Date getIdleExpiresAt() {
+        return idleExpiresAt;
+    }
+
+    /**
+     * @return The date and time when the session will expire
+     */
+    public Date getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
+     * @return Metadata related to the device used in the session
+     */
+    public Device getDevice() {
+        return device;
+    }
+
+    /**
+     * @return List of client details for the session
+     */
+    public List<Client> getClients() {
+        return clients;
+    }
+
+    /**
+     * @return Details about authentication signals obtained during the login flow
+     */
+    public Authentication getAuthentication() {
+        return authentication;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/users/sessions/SessionsPage.java
+++ b/src/main/java/com/auth0/json/mgmt/users/sessions/SessionsPage.java
@@ -1,0 +1,44 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * This does not extend com.auth0.json.mgmt.Page<RefreshToken> because the URL only supports "next" and "take" pagination.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SessionsPage {
+    @JsonProperty("total")
+    private Integer total;
+
+    @JsonProperty("next")
+    private String next;
+
+    @JsonProperty("sessions")
+    private List<Session> sessions;
+
+    /**
+     * @return the total number of refresh tokens. This is only present when `include_totals` is passed as a query parameter.
+     */
+    public Integer getTotal() {
+        return total;
+    }
+
+    /**
+     * @return the token ID from which to start selection for a new page
+     */
+    public String getNext() {
+        return next;
+    }
+
+    /**
+     * @return the list of Sessions
+     */
+    public List<Session> getSessions() {
+        return sessions;
+    }
+}

--- a/src/test/java/com/auth0/client/MockServer.java
+++ b/src/test/java/com/auth0/client/MockServer.java
@@ -78,6 +78,8 @@ public class MockServer {
     public static final String MGMT_USERS_PAGED_LIST = "src/test/resources/mgmt/users_paged_list.json";
     public static final String MGMT_USER_PERMISSIONS_PAGED_LIST = "src/test/resources/mgmt/user_permissions_paged_list.json";
     public static final String MGMT_USER_ROLES_PAGED_LIST = "src/test/resources/mgmt/user_roles_paged_list.json";
+    public static final String MGMT_USER_REFRESH_TOKENS = "src/test/resources/mgmt/user_refresh_tokens.json";
+    public static final String MGMT_USER_SESSIONS = "src/test/resources/mgmt/user_sessions.json";
     public static final String MGMT_USER = "src/test/resources/mgmt/user.json";
     public static final String MGMT_RECOVERY_CODE = "src/test/resources/mgmt/recovery_code.json";
     public static final String MGMT_IDENTITIES_LIST = "src/test/resources/mgmt/identities_list.json";

--- a/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/UsersEntityTest.java
@@ -4,6 +4,7 @@ import com.auth0.client.mgmt.filter.FieldsFilter;
 import com.auth0.client.mgmt.filter.LogEventFilter;
 import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.client.mgmt.filter.UserFilter;
+import com.auth0.client.mgmt.filter.CheckpointPaginationFilter;
 import com.auth0.json.mgmt.guardian.Enrollment;
 import com.auth0.json.mgmt.logevents.LogEvent;
 import com.auth0.json.mgmt.logevents.LogEventsPage;
@@ -17,6 +18,8 @@ import com.auth0.json.mgmt.users.User;
 import com.auth0.json.mgmt.users.UsersPage;
 import com.auth0.json.mgmt.users.authenticationmethods.AuthenticationMethod;
 import com.auth0.json.mgmt.users.authenticationmethods.AuthenticationMethodsPage;
+import com.auth0.json.mgmt.users.refreshtokens.RefreshTokensPage;
+import com.auth0.json.mgmt.users.sessions.SessionsPage;
 import com.auth0.net.Request;
 import com.auth0.net.client.HttpMethod;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -1346,6 +1349,160 @@ public class UsersEntityTest extends BaseMgmtEntityTest {
         RecordedRequest recordedRequest = server.takeRequest();
 
         assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/users/userId/multifactor/actions/invalidate-remember-browser"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    @Test
+    public void shouldListRefreshTokensWithoutFilter() throws Exception {
+        Request<RefreshTokensPage> request = api.users().listRefreshTokens("1", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_USER_REFRESH_TOKENS, 200);
+        RefreshTokensPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/users/1/refresh-tokens"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getTokens(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListRefreshTokensWithPage() throws Exception {
+        CheckpointPaginationFilter filter = new CheckpointPaginationFilter().withFrom("tokenId2").withTake(5);
+        Request<RefreshTokensPage> request = api.users().listRefreshTokens("1", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_USER_REFRESH_TOKENS, 200);
+        RefreshTokensPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/users/1/refresh-tokens"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("from", "tokenId2"));
+        assertThat(recordedRequest, hasQueryParameter("take", "5"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getTokens(), hasSize(2));
+    }
+
+    @Test
+    public void shouldListRefreshTokensWithTotal() throws Exception {
+        CheckpointPaginationFilter filter = new CheckpointPaginationFilter().withTotals(true);
+        Request<RefreshTokensPage> request = api.users().listRefreshTokens("1", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_USER_REFRESH_TOKENS, 200);
+        RefreshTokensPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/users/1/refresh-tokens"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getTokens(), hasSize(2));
+        assertThat(response.getTotal(), is(11));
+    }
+
+    @Test
+    public void shouldNotDeleteRefreshTokensWithNullUserId() {
+        verifyThrows(IllegalArgumentException.class,
+            () -> api.users().deleteRefreshTokens(null),
+            "'user ID' cannot be null!");
+    }
+
+    @Test
+    public void shouldDeleteRefreshTokens() throws Exception {
+        Request<Void> request = api.users().deleteRefreshTokens("1");
+        assertThat(request, is(notNullValue()));
+
+        server.noContentResponse();
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.DELETE, "/api/v2/users/1/refresh-tokens"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
+    @Test
+    public void shouldListSessionsWithoutFilter() throws Exception {
+        Request<SessionsPage> request = api.users().listSessions("1", null);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_USER_SESSIONS, 200);
+        SessionsPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/users/1/sessions"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getSessions(), hasSize(1));
+    }
+
+    @Test
+    public void shouldListSessionsWithPage() throws Exception {
+        CheckpointPaginationFilter filter = new CheckpointPaginationFilter().withFrom("sessionId3").withTake(9);
+        Request<SessionsPage> request = api.users().listSessions("1", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_USER_SESSIONS, 200);
+        SessionsPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/users/1/sessions"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("from", "sessionId3"));
+        assertThat(recordedRequest, hasQueryParameter("take", "9"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getSessions(), hasSize(1));
+    }
+
+    @Test
+    public void shouldListSessionsWithTotal() throws Exception {
+        CheckpointPaginationFilter filter = new CheckpointPaginationFilter().withTotals(true);
+        Request<SessionsPage> request = api.users().listSessions("1", filter);
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(MGMT_USER_SESSIONS, 200);
+        SessionsPage response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.GET, "/api/v2/users/1/sessions"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+        assertThat(recordedRequest, hasQueryParameter("include_totals", "true"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getSessions(), hasSize(1));
+        assertThat(response.getTotal(), is(9));
+    }
+
+    @Test
+    public void shouldNotDeleteSessionsWithNullUserId() {
+        verifyThrows(IllegalArgumentException.class,
+            () -> api.users().deleteRefreshTokens(null),
+            "'user ID' cannot be null!");
+    }
+
+    @Test
+    public void shouldDeleteSessions() throws Exception {
+        Request<Void> request = api.users().deleteSessions("1");
+        assertThat(request, is(notNullValue()));
+
+        server.noContentResponse();
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.DELETE, "/api/v2/users/1/sessions"));
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/filter/CheckpointPaginationFilterTest.java
+++ b/src/test/java/com/auth0/client/mgmt/filter/CheckpointPaginationFilterTest.java
@@ -1,0 +1,37 @@
+package com.auth0.client.mgmt.filter;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CheckpointPaginationFilterTest {
+
+    private CheckpointPaginationFilter filter;
+
+    @BeforeEach
+    public void setUp() {
+        filter = new CheckpointPaginationFilter();
+    }
+
+    @Test
+    public void shouldIncludeTotals() {
+        CheckpointPaginationFilter instance = filter.withTotals(true);
+
+        assertThat(filter, is(instance));
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("include_totals", true));
+    }
+
+    @Test
+    public void shouldIncludeCheckpointParams() {
+        CheckpointPaginationFilter instance = filter.withFrom("abc123").withTake(2);
+
+        assertThat(filter.getAsMap(), is(notNullValue()));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("from", "abc123"));
+        assertThat(filter.getAsMap(), Matchers.hasEntry("take", 2));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/users/refreshtokens/RefreshTokensPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/refreshtokens/RefreshTokensPageTest.java
@@ -1,0 +1,44 @@
+package com.auth0.json.mgmt.users.refreshtokens;
+
+import com.auth0.json.JsonTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class RefreshTokensPageTest extends JsonTest<RefreshTokensPage> {
+    private static final String json = "{\n\"tokens\": [\n{\n\"id\": \"tokenId1\",\n\"user_id\": \"userId1\",\n\"created_at\": \"2024-06-26T09:10:26.643Z\",\n\"updated_at\": \"2024-06-26T09:10:27.131Z\",\n\"expires_at\": \"2024-07-03T09:10:26.643Z\",\n\"client_id\": \"clientId1\",\n\"session_id\": \"sessionId1\",\n\"rotating\": false,\n\"resource_servers\": [\n{\n\"audience\": \"https://api.example.com\",\n\"scopes\": [\n\"read:examples\",\n\"write:examples\"\n]\n}\n]\n},\n{\n\"id\": \"tokenId2\",\n\"user_id\": \"userId1\",\n\"created_at\": \"2024-06-26T09:10:26.643Z\",\n\"updated_at\": \"2024-06-26T09:10:27.131Z\",\n\"expires_at\": \"2024-07-03T09:10:26.643Z\",\n\"client_id\": \"clientId2\",\n\"session_id\": \"sessionId2\",\n\"rotating\": true,\n\"resource_servers\": [\n{\n\"audience\": \"https://api.example.com\",\n\"scopes\": [\n\"read:examples\",\n\"write:examples\"\n]\n}\n]\n}\n],\n\"next\": \"token1\"\n}\n";
+    private static final String jsonWithTotal = "{\n\"tokens\": [\n{\n\"id\": \"tokenId1\",\n\"user_id\": \"userId1\",\n\"created_at\": \"2024-06-26T09:10:26.643Z\",\n\"updated_at\": \"2024-06-26T09:10:27.131Z\",\n\"expires_at\": \"2024-07-03T09:10:26.643Z\",\n\"client_id\": \"clientId1\",\n\"session_id\": \"sessionId1\",\n\"rotating\": false,\n\"resource_servers\": [\n{\n\"audience\": \"https://api.example.com\",\n\"scopes\": [\n\"read:examples\",\n\"write:examples\"\n]\n}\n]\n},\n{\n\"id\": \"tokenId2\",\n\"user_id\": \"userId1\",\n\"created_at\": \"2024-06-26T09:10:26.643Z\",\n\"updated_at\": \"2024-06-26T09:10:27.131Z\",\n\"expires_at\": \"2024-07-03T09:10:26.643Z\",\n\"client_id\": \"clientId2\",\n\"session_id\": \"sessionId2\",\n\"rotating\": true,\n\"resource_servers\": [\n{\n\"audience\": \"https://api.example.com\",\n\"scopes\": [\n\"read:examples\",\n\"write:examples\"\n]\n}\n]\n}\n],\n\"next\": \"token1\",\n\"total\": 11\n}\n";
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        RefreshTokensPage page = fromJSON(json, RefreshTokensPage.class);
+
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getNext(), is("token1"));
+
+        assertThat(page.getTokens().size(), is(2));
+        assertThat(page.getTokens().get(0).getId(), is("tokenId1"));
+        assertThat(page.getTokens().get(0).getUserId(), is("userId1"));
+        assertThat(page.getTokens().get(0).getCreatedAt(), is(parseJSONDate("2024-06-26T09:10:26.643Z")));
+        assertThat(page.getTokens().get(0).getIdleExpiresAt(), is(nullValue()));
+        assertThat(page.getTokens().get(0).getExpiresAt(), is(parseJSONDate("2024-07-03T09:10:26.643Z")));
+        assertThat(page.getTokens().get(0).getClientId(), is("clientId1"));
+        assertThat(page.getTokens().get(0).getSessionId(), is("sessionId1"));
+        assertThat(page.getTokens().get(0).isRotating(), is(false));
+
+        assertThat(page.getTokens().get(0).getResourceServers().size(), is(1));
+        assertThat(page.getTokens().get(0).getResourceServers().get(0).getAudience(), is("https://api.example.com"));
+        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes().size(), is(2));
+        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes().get(0), is("read:examples"));
+        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes().get(1), is("write:examples"));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotal() throws Exception {
+        RefreshTokensPage page = fromJSON(jsonWithTotal, RefreshTokensPage.class);
+
+        assertThat(page.getTotal(), is(11));
+    }
+}

--- a/src/test/java/com/auth0/json/mgmt/users/sessions/SessionsPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/users/sessions/SessionsPageTest.java
@@ -1,0 +1,50 @@
+package com.auth0.json.mgmt.users.sessions;
+
+import com.auth0.json.JsonTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SessionsPageTest extends JsonTest<SessionsPage> {
+    private static final String json = "{\"sessions\":[{\"id\":\"sessionId1\",\n\"user_id\":\"userId1\",\n\"created_at\":\"2024-06-26T09:10:26.643Z\",\n\"updated_at\":\"2024-06-26T09:10:27.131Z\",\n\"authenticated_at\":\"2024-06-26T09:10:26.643Z\",\n\"authentication\":{\n\"methods\":[\n{\n\"name\":\"pwd\",\n\"timestamp\":\"2024-06-26T09:10:26.643Z\"\n}\n]\n},\n\"idle_expires_at\":\"2024-06-26T09:40:27.131Z\",\n\"expires_at\":\"2024-07-03T09:10:26.643Z\",\n\"device\":{\n\"initial_asn\":\"1234\",\n\"initial_ip\":\"203.0.113.1\",\n\"last_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36\",\n\"last_ip\":\"203.0.113.1\",\n\"last_asn\":\"1234\"\n},\n\"clients\":[\n{\n\"client_id\":\"clientId1\"\n}\n]\n}\n],\n\"next\":\"sessionId1\"\n}\n";
+    private static final String jsonWithTotals = "{\"sessions\":[{\"id\":\"sessionId1\",\n\"user_id\":\"userId1\",\n\"created_at\":\"2024-06-26T09:10:26.643Z\",\n\"updated_at\":\"2024-06-26T09:10:27.131Z\",\n\"authenticated_at\":\"2024-06-26T09:10:26.643Z\",\n\"authentication\":{\n\"methods\":[\n{\n\"name\":\"pwd\",\n\"timestamp\":\"2024-06-26T09:10:26.643Z\"\n}\n]\n},\n\"idle_expires_at\":\"2024-06-26T09:40:27.131Z\",\n\"expires_at\":\"2024-07-03T09:10:26.643Z\",\n\"device\":{\n\"initial_asn\":\"1234\",\n\"initial_ip\":\"203.0.113.1\",\n\"last_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36\",\n\"last_ip\":\"203.0.113.1\",\n\"last_asn\":\"1234\"\n},\n\"clients\":[\n{\n\"client_id\":\"clientId1\"\n}\n]\n}\n],\n\"next\":\"sessionId1\",\n\"total\":11\n}\n";
+
+    @Test
+    public void shouldDeserialize() throws Exception {
+        SessionsPage page = fromJSON(json, SessionsPage.class);
+
+        assertThat(page.getTotal(), is(nullValue()));
+        assertThat(page.getNext(), is("sessionId1"));
+        assertThat(page.getSessions().size(), is(1));
+        assertThat(page.getSessions().get(0).getId(), is("sessionId1"));
+        assertThat(page.getSessions().get(0).getUserId(), is("userId1"));
+        assertThat(page.getSessions().get(0).getCreatedAt(), is(parseJSONDate("2024-06-26T09:10:26.643Z")));
+        assertThat(page.getSessions().get(0).getUpdatedAt(), is(parseJSONDate("2024-06-26T09:10:27.131Z")));
+        assertThat(page.getSessions().get(0).getAuthenticatedAt(), is(parseJSONDate("2024-06-26T09:10:26.643Z")));
+        assertThat(page.getSessions().get(0).getIdleExpiresAt(), is(parseJSONDate("2024-06-26T09:40:27.131Z")));
+        assertThat(page.getSessions().get(0).getExpiresAt(), is(parseJSONDate("2024-07-03T09:10:26.643Z")));
+
+        assertThat(page.getSessions().get(0).getDevice().getInitialASN(), is("1234"));
+        assertThat(page.getSessions().get(0).getDevice().getInitialIP(), is("203.0.113.1"));
+        assertThat(page.getSessions().get(0).getDevice().getLastUserAgent(), is("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"));
+        assertThat(page.getSessions().get(0).getDevice().getLastIP(), is("203.0.113.1"));
+        assertThat(page.getSessions().get(0).getDevice().getLastASN(), is("1234"));
+
+        assertThat(page.getSessions().get(0).getClients().size(), is(1));
+        assertThat(page.getSessions().get(0).getClients().get(0).getClientId(), is("clientId1"));
+
+        assertThat(page.getSessions().get(0).getAuthentication().getMethods().size(), is(1));
+        assertThat(page.getSessions().get(0).getAuthentication().getMethods().get(0).getName(), is("pwd"));
+        assertThat(page.getSessions().get(0).getAuthentication().getMethods().get(0).getTimestamp(), is(parseJSONDate("2024-06-26T09:10:26.643Z")));
+        assertThat(page.getSessions().get(0).getAuthentication().getMethods().get(0).getType(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldDeserializeWithTotals() throws Exception {
+        SessionsPage page = fromJSON(jsonWithTotals, SessionsPage.class);
+
+        assertThat(page.getTotal(), is(11));
+    }
+}

--- a/src/test/resources/mgmt/user_refresh_tokens.json
+++ b/src/test/resources/mgmt/user_refresh_tokens.json
@@ -1,0 +1,44 @@
+{
+  "tokens": [
+    {
+      "id": "tokenId1",
+      "user_id": "userId1",
+      "created_at": "2024-06-26T09:10:26.643Z",
+      "updated_at": "2024-06-26T09:10:27.131Z",
+      "expires_at": "2024-07-03T09:10:26.643Z",
+      "client_id": "clientId1",
+      "session_id": "sessionId1",
+      "rotating": false,
+      "resource_servers": [
+        {
+          "audience": "https://api.example.com",
+          "scopes": [
+            "read:examples",
+            "write:examples"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "tokenId2",
+      "user_id": "userId1",
+      "created_at": "2024-06-26T09:10:26.643Z",
+      "updated_at": "2024-06-26T09:10:27.131Z",
+      "expires_at": "2024-07-03T09:10:26.643Z",
+      "client_id": "clientId2",
+      "session_id": "sessionId2",
+      "rotating": true,
+      "resource_servers": [
+        {
+          "audience": "https://api.example.com",
+          "scopes": [
+            "read:examples",
+            "write:examples"
+          ]
+        }
+      ]
+    }
+  ],
+  "next": "token1",
+  "total": 11
+}

--- a/src/test/resources/mgmt/user_sessions.json
+++ b/src/test/resources/mgmt/user_sessions.json
@@ -1,0 +1,35 @@
+{
+  "sessions": [
+    {
+      "id": "sessionId1",
+      "user_id": "userId1",
+      "created_at": "2024-06-26T09:10:26.643Z",
+      "updated_at": "2024-06-26T09:10:27.131Z",
+      "authenticated_at": "2024-06-26T09:10:26.643Z",
+      "authentication": {
+        "methods": [
+          {
+            "name": "pwd",
+            "timestamp": "2024-06-26T09:10:26.643Z"
+          }
+        ]
+      },
+      "idle_expires_at": "2024-06-26T09:40:27.131Z",
+      "expires_at": "2024-07-03T09:10:26.643Z",
+      "device": {
+        "initial_asn": "1234",
+        "initial_ip": "203.0.113.1",
+        "last_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+        "last_ip": "203.0.113.1",
+        "last_asn": "1234"
+      },
+      "clients": [
+        {
+          "client_id": "clientId1"
+        }
+      ]
+    }
+  ],
+  "next": "sessionId1",
+  "total": 9
+}


### PR DESCRIPTION
### Changes

Adds support for the following APIs:

- https://auth0.com/docs/api/management/v2/users/get-refresh-tokens-for-user
- https://auth0.com/docs/api/management/v2/users/delete-refresh-tokens-for-user
- https://auth0.com/docs/api/management/v2/users/get-sessions-for-user
- https://auth0.com/docs/api/management/v2/users/delete-sessions-for-user

These APIs only support the checkpoint pagination so I've added a different filter for them.


### References

Fixes #653

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
