### PR TITLE
Added support for HRI phase 2 changes

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/client/Client.java
+++ b/src/main/java/com/auth0/json/mgmt/client/Client.java
@@ -100,6 +100,8 @@ public class Client {
     private SignedRequest signedRequest;
     @JsonProperty("compliance_level")
     private String complianceLevel;
+    @JsonProperty("require_proof_of_possession")
+    private Boolean requireProofOfPossession;
 
     /**
      * Getter for the name of the tenant this client belongs to.
@@ -871,6 +873,21 @@ public class Client {
      */
     public void setComplianceLevel(String complianceLevel) {
         this.complianceLevel = complianceLevel;
+    }
+
+    /**
+     * @return the value of the {@code require_proof_of_possession} field
+     */
+    public Boolean getRequireProofOfPossession() {
+        return requireProofOfPossession;
+    }
+
+    /**
+     * Sets the value of the {@code require_proof_of_possession} field
+     * @param requireProofOfPossession the value of the {@code require_proof_of_possession} field
+     */
+    public void setRequireProofOfPossession(Boolean requireProofOfPossession) {
+        this.requireProofOfPossession = requireProofOfPossession;
     }
 }
 

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/ProofOfPossession.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/ProofOfPossession.java
@@ -1,0 +1,54 @@
+package com.auth0.json.mgmt.resourceserver;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProofOfPossession {
+
+    @JsonProperty("mechanism")
+    private String mechanism;
+    @JsonProperty("required")
+    private Boolean required;
+
+    @JsonCreator
+    public ProofOfPossession(@JsonProperty("mechanism") String mechanism, @JsonProperty("required") Boolean required) {
+        this.mechanism = mechanism;
+        this.required = required;
+    }
+
+    /**
+     * Getter for the mechanism of the Proof of Possession.
+     * @return the mechanism of the Proof of Possession.
+     */
+    public String getMechanism() {
+        return mechanism;
+    }
+
+    /**
+     * Setter for the mechanism of the Proof of Possession.
+     * @param mechanism the mechanism of the Proof of Possession.
+     */
+    public void setMechanism(String mechanism) {
+        this.mechanism = mechanism;
+    }
+
+    /**
+     * Getter for the required flag of the Proof of Possession.
+     * @return the required flag of the Proof of Possession.
+     */
+    public Boolean getRequired() {
+        return required;
+    }
+
+    /**
+     * Setter for the required flag of the Proof of Possession.
+     * @param required the required flag of the Proof of Possession.
+     */
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+}

--- a/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/resourceserver/ResourceServer.java
@@ -45,6 +45,8 @@ public class ResourceServer {
     private List<AuthorizationDetails> authorizationDetails;
     @JsonProperty("token_encryption")
     private TokenEncryption tokenEncryption;
+    @JsonProperty("proof_of_possession")
+    private ProofOfPossession proofOfPossession;
 
     @JsonCreator
     public ResourceServer(@JsonProperty("identifier") String identifier) {
@@ -227,5 +229,20 @@ public class ResourceServer {
      */
     public void setTokenEncryption(TokenEncryption tokenEncryption) {
         this.tokenEncryption = tokenEncryption;
+    }
+
+    /**
+     * @return the value of the {@code proof_of_possession} field.
+     */
+    public ProofOfPossession getProofOfPossession() {
+        return proofOfPossession;
+    }
+
+    /**
+     * Sets the value of the {@code proof_of_possession} field.
+     * @param proofOfPossession the value of the {@code proof_of_possession} field.
+     */
+    public void setProofOfPossession(ProofOfPossession proofOfPossession) {
+        this.proofOfPossession = proofOfPossession;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
+++ b/src/test/java/com/auth0/json/mgmt/ResourceServerTest.java
@@ -1,5 +1,6 @@
 package com.auth0.json.mgmt;
 
+import com.auth0.json.JsonMatcher;
 import com.auth0.json.JsonTest;
 import com.auth0.json.mgmt.resourceserver.*;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import java.util.stream.Collectors;
 import static com.auth0.json.JsonMatcher.hasEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
 
 public class ResourceServerTest extends JsonTest<ResourceServer> {
     private final static String RESOURCE_SERVER_JSON = "src/test/resources/mgmt/resource_server.json";
@@ -42,6 +44,8 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(deserialized.getTokenEncryption().getEncryptionKey().getKid(), is("my kid"));
         assertThat(deserialized.getTokenEncryption().getEncryptionKey().getName(), is("my JWE public key"));
         assertThat(deserialized.getTokenEncryption().getEncryptionKey().getThumbprintSha256(), is("thumbprint"));
+        assertThat(deserialized.getProofOfPossession().getMechanism(), is("mtls"));
+        assertThat(deserialized.getProofOfPossession().getRequired(), is(true));
     }
 
     @Test
@@ -77,6 +81,8 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         encryptionKey.setPem("pem");
         TokenEncryption tokenEncryption = new TokenEncryption("format", encryptionKey);
         entity.setTokenEncryption(tokenEncryption);
+        ProofOfPossession proofOfPossession = new ProofOfPossession("mtls", true);
+        entity.setProofOfPossession(proofOfPossession);
 
         String json = toJSON(entity);
 
@@ -96,5 +102,6 @@ public class ResourceServerTest extends JsonTest<ResourceServer> {
         assertThat(json, hasEntry("consent_policy", "transactional-authorization-with-mfa"));
         assertThat(json, hasEntry("authorization_details", notNullValue()));
         assertThat(json, hasEntry("token_encryption", containsString("{\"format\":\"format\",\"encryption_key\":{\"name\":\"name\",\"alg\":\"alg\",\"pem\":\"pem\",\"kid\":\"kid\"}}")));
+        assertThat(json, hasEntry("proof_of_possession", containsString("{\"mechanism\":\"mtls\",\"required\":true}")));
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
+++ b/src/test/java/com/auth0/json/mgmt/client/ClientTest.java
@@ -135,6 +135,7 @@ public class ClientTest extends JsonTest<Client> {
         "     }\n" +
         "   ]\n" +
         "  },\n" +
+        "  \"require_proof_of_possession\": true,\n" +
         "  \"compliance_level\": \"fapi1_adv_pkj_par\"\n" +
         "}";
 
@@ -179,6 +180,7 @@ public class ClientTest extends JsonTest<Client> {
         client.setRefreshToken(refreshToken);
         client.setOrganizationUsage("require");
         client.setOrganizationRequireBehavior("pre_login_prompt");
+        client.setRequireProofOfPossession(true);
 
         Credential credential = new Credential("public_key", "PEM");
         PrivateKeyJwt privateKeyJwt = new PrivateKeyJwt(Collections.singletonList(credential));
@@ -251,6 +253,7 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(serialized, JsonMatcher.hasEntry("oidc_backchannel_logout", containsString("{\"backchannel_logout_urls\":[\"http://acme.eu.auth0.com/events\"]}")));
         assertThat(serialized, JsonMatcher.hasEntry("signed_request_object", containsString("{\"required\":true,\"credentials\":[{\"credential_type\":\"public_key\",\"name\":\"cred name\",\"pem\":\"pem\"}]}")));
         assertThat(serialized, JsonMatcher.hasEntry("compliance_level", "fapi1_adv_pkj_par"));
+        assertThat(serialized, JsonMatcher.hasEntry("require_proof_of_possession", true));
     }
 
     @Test
@@ -326,6 +329,8 @@ public class ClientTest extends JsonTest<Client> {
         assertThat(client.getSignedRequest().getCredentials().get(0).getName(), is("My JAR credential"));
         assertThat(client.getSignedRequest().getCredentials().get(0).getCreatedAt(), is(Date.from(Instant.parse("2024-03-14T11:34:28.893Z"))));
         assertThat(client.getSignedRequest().getCredentials().get(0).getUpdatedAt(), is(Date.from(Instant.parse("2024-03-14T11:34:28.893Z"))));
+
+        assertThat(client.getRequireProofOfPossession(), is(true));
     }
 
     @Test

--- a/src/test/resources/mgmt/client.json
+++ b/src/test/resources/mgmt/client.json
@@ -90,5 +90,6 @@
       }
     ]
   },
-  "compliance_level": "fapi1_adv_pkj_par"
+  "compliance_level": "fapi1_adv_pkj_par",
+  "require_proof_of_possession": true
 }

--- a/src/test/resources/mgmt/resource_server.json
+++ b/src/test/resources/mgmt/resource_server.json
@@ -36,5 +36,9 @@
       "alg": "RSA-OAEP-256",
       "thumbprint_sha256": "thumbprint"
     }
+  },
+  "proof_of_possession": {
+    "mechanism": "mtls",
+    "required": true
   }
 }


### PR DESCRIPTION
### Changes

Changes
Adds support for new and modified management endpoints related to [Highly Regulated Identity](https://auth0.com/docs/secure/highly-regulated-identity) (HRI).

Endpoints changed:

new field proof_of_possession on Resource Server
new field require_proof_of_possession on Client

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
