### PR TITLE
SDKs support for Control Your Own Key

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/KeysEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/KeysEntity.java
@@ -108,7 +108,7 @@ public class KeysEntity extends BaseManagementEntity {
      * See https://auth0.com/docs/api/management/v2#!/Keys/post-encryption-rekey
      * @return a Request to execute.
      */
-    public Request<Void> rekey(){
+    public Request<Void> postEncryptionRekey(){
         String url = baseUrl
             .newBuilder()
             .addPathSegments("api/v2/keys/encryption/rekey")

--- a/src/main/java/com/auth0/client/mgmt/KeysEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/KeysEntity.java
@@ -3,6 +3,7 @@ package com.auth0.client.mgmt;
 import com.auth0.json.mgmt.keys.Key;
 import com.auth0.net.EmptyBodyRequest;
 import com.auth0.net.BaseRequest;
+import com.auth0.net.EmptyBodyVoidRequest;
 import com.auth0.net.Request;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.HttpMethod;
@@ -99,5 +100,21 @@ public class KeysEntity extends BaseManagementEntity {
             .toString();
         return new EmptyBodyRequest<>(this.client, tokenProvider, url, HttpMethod.PUT, new TypeReference<Key>() {
         });
+    }
+
+    /**
+     * Perform rekeying operation on the key hierarchy.
+     * A token with scope create:encryption_keys and update:encryption_keys is needed
+     * See https://auth0.com/docs/api/management/v2#!/Keys/post-encryption-rekey
+     * @return a Request to execute.
+     */
+    public Request<Void> rekey(){
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/keys/encryption/rekey")
+            .build()
+            .toString();
+
+        return new EmptyBodyVoidRequest<>(this.client, tokenProvider, url, HttpMethod.POST, new TypeReference<Void>() {});
     }
 }

--- a/src/main/java/com/auth0/net/EmptyBodyVoidRequest.java
+++ b/src/main/java/com/auth0/net/EmptyBodyVoidRequest.java
@@ -1,0 +1,42 @@
+package com.auth0.net;
+
+import com.auth0.client.mgmt.TokenProvider;
+import com.auth0.exception.Auth0Exception;
+import com.auth0.net.client.Auth0HttpClient;
+import com.auth0.net.client.Auth0HttpResponse;
+import com.auth0.net.client.HttpMethod;
+import com.auth0.net.client.HttpRequestBody;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+/**
+ * Request class that does not accept parameters to be sent as part of its body and request doesn't return any value on its success.
+ * The content type of this request is "application/json".
+ *
+ * @param <T> The type expected to be received as part of the response.
+ * @see BaseRequest
+ */
+public class EmptyBodyVoidRequest<T> extends BaseRequest<T>  {
+    public EmptyBodyVoidRequest(Auth0HttpClient client, TokenProvider tokenProvider, String url, HttpMethod method, TypeReference<T> tType) {
+        super(client, tokenProvider, url, method, tType);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected HttpRequestBody createRequestBody() {
+        return HttpRequestBody.create("application/json", new byte[0]);
+    }
+
+    @Override
+    public EmptyBodyVoidRequest<T> addParameter(String name, Object value) {
+        //do nothing
+        return this;
+    }
+    @Override
+    protected T parseResponseBody(Auth0HttpResponse response) throws Auth0Exception {
+        if (!response.isSuccessful()) {
+            throw super.createResponseException(response);
+        }
+        return null;
+    }
+
+}

--- a/src/test/java/com/auth0/client/mgmt/KeysEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/KeysEntityTest.java
@@ -98,7 +98,7 @@ public class KeysEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldRekey() throws Exception {
-        Request<Void> request = api.keys().rekey();
+        Request<Void> request = api.keys().postEncryptionRekey();
         assertThat(request, is(notNullValue()));
 
         server.emptyResponse(204);

--- a/src/test/java/com/auth0/client/mgmt/KeysEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/KeysEntityTest.java
@@ -95,4 +95,18 @@ public class KeysEntityTest extends BaseMgmtEntityTest {
 
         assertThat(response, is(notNullValue()));
     }
+
+    @Test
+    public void shouldRekey() throws Exception {
+        Request<Void> request = api.keys().rekey();
+        assertThat(request, is(notNullValue()));
+
+        server.emptyResponse(204);
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/keys/encryption/rekey"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
 }

--- a/src/test/java/com/auth0/net/EmptyBodyVoidRequestTest.java
+++ b/src/test/java/com/auth0/net/EmptyBodyVoidRequestTest.java
@@ -1,0 +1,53 @@
+package com.auth0.net;
+
+import com.auth0.client.MockServer;
+import com.auth0.client.mgmt.TokenProvider;
+import com.auth0.net.client.Auth0HttpClient;
+import com.auth0.net.client.DefaultHttpClient;
+import com.auth0.net.client.HttpMethod;
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.auth0.client.MockServer.AUTH_TOKENS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EmptyBodyVoidRequestTest {
+
+    private Auth0HttpClient client;
+    private TokenProvider tokenProvider;
+    private MockServer server;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        client = new DefaultHttpClient.Builder().build();
+        server = new MockServer();
+        tokenProvider = new TokenProvider() {
+            @Override
+            public String getToken() {
+                return "Bearer abc";
+            }
+
+            @Override
+            public CompletableFuture<String> getTokenAsync() {
+                return CompletableFuture.completedFuture("Bearer abc");
+            }
+        };
+    }
+
+    @Test
+    public void shouldCreatePOSTRequest() throws Exception {
+        EmptyBodyVoidRequest<Void> request = new EmptyBodyVoidRequest<>(client, tokenProvider, server.getBaseUrl(), HttpMethod.POST, new TypeReference<Void>() {});
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        Void execute = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod(), is(HttpMethod.POST.toString()));
+        assertThat(execute, is(nullValue()));
+    }
+}


### PR DESCRIPTION
### Changes

- added rekey endpoint in KeyEntity
- created custom request class called EmptyBodyVoidRequest

### References

https://github.com/auth0/node-auth0/pull/1041

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
