### PR TITLE
Added support for revoke session endpoint

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/SessionsEntity.java
+++ b/src/main/java/com/auth0/client/mgmt/SessionsEntity.java
@@ -2,6 +2,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.json.mgmt.sessions.Session;
 import com.auth0.net.BaseRequest;
+import com.auth0.net.EmptyBodyVoidRequest;
 import com.auth0.net.Request;
 import com.auth0.net.VoidRequest;
 import com.auth0.net.client.Auth0HttpClient;
@@ -63,5 +64,26 @@ public class SessionsEntity extends BaseManagementEntity{
             .toString();
 
         return new VoidRequest(client, tokenProvider, url, HttpMethod.DELETE);
+    }
+
+    /**
+     * Revoke the session for a given session ID.
+     * A token with scope {@code delete:sessions}, {@code delete:refresh_tokens} is needed.
+     * See <a href="https://auth0.com/docs/api/management/v2/sessions/revoke-session">https://auth0.com/docs/api/management/v2/sessions/revoke-session</a>
+     * @param sessionId the session ID.
+     * @return a Request to execute.
+     */
+    public Request<Void> revoke(String sessionId){
+        Asserts.assertNotNull(sessionId, "session ID");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegments("api/v2/sessions")
+            .addPathSegment(sessionId)
+            .addPathSegment("revoke")
+            .build()
+            .toString();
+
+        return new EmptyBodyVoidRequest<>(client, tokenProvider, url, HttpMethod.POST, new TypeReference<Void>() {});
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/SessionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/SessionsEntityTest.java
@@ -58,4 +58,24 @@ public class SessionsEntityTest extends BaseMgmtEntityTest{
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
     }
 
+    @Test
+    public void revokeShouldThrowOnNullSessionId() {
+        verifyThrows(IllegalArgumentException.class,
+            () -> api.sessions().revoke(null),
+            "'session ID' cannot be null!");
+    }
+
+    @Test
+    public void shouldRevoke() throws Exception {
+        Request<Void> request = api.sessions().revoke("session_ID");
+        assertThat(request, is(notNullValue()));
+
+        server.noContentResponse();
+        request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/api/v2/sessions/session_ID/revoke"));
+        assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
+    }
+
 }


### PR DESCRIPTION
### Changes

- Added revoke-session endpoint

### References

https://auth0.com/docs/api/management/v2/sessions/revoke-session

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
