### PR TITLE
Fixed POST/PATCH connection endpoints

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/connections/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/connections/Connection.java
@@ -210,6 +210,7 @@ public class Connection {
      * Getter for the domain connection flag.
      * @return the domain connection flag.
      */
+    @JsonProperty("is_domain_connection")
     public boolean isDomainConnection() {
         return isDomainConnection;
     }
@@ -218,7 +219,8 @@ public class Connection {
      * Setter for the domain connection flag.
      * @param domainConnection the domain connection flag to set.
      */
+    @JsonProperty("is_domain_connection")
     public void setDomainConnection(boolean domainConnection) {
-        isDomainConnection = domainConnection;
+        this.isDomainConnection = domainConnection;
     }
 }

--- a/src/main/java/com/auth0/json/mgmt/connections/Connection.java
+++ b/src/main/java/com/auth0/json/mgmt/connections/Connection.java
@@ -35,9 +35,9 @@ public class Connection {
     @JsonProperty("realms")
     private List<String> realms;
     @JsonProperty("show_as_button")
-    private boolean showAsButton;
+    private Boolean showAsButton;
     @JsonProperty("is_domain_connection")
-    private boolean isDomainConnection;
+    private Boolean isDomainConnection;
 
     public Connection() {
     }
@@ -193,7 +193,8 @@ public class Connection {
      *
      * @return the show as button flag.
      */
-    public boolean isShowAsButton() {
+    @JsonProperty("show_as_button")
+    public Boolean isShowAsButton() {
         return showAsButton;
     }
 
@@ -202,7 +203,8 @@ public class Connection {
      *
      * @param showAsButton the show as button flag to set.
      */
-    public void setShowAsButton(boolean showAsButton) {
+    @JsonProperty("show_as_button")
+    public void setShowAsButton(Boolean showAsButton) {
         this.showAsButton = showAsButton;
     }
 
@@ -211,7 +213,7 @@ public class Connection {
      * @return the domain connection flag.
      */
     @JsonProperty("is_domain_connection")
-    public boolean isDomainConnection() {
+    public Boolean isDomainConnection() {
         return isDomainConnection;
     }
 
@@ -220,7 +222,7 @@ public class Connection {
      * @param domainConnection the domain connection flag to set.
      */
     @JsonProperty("is_domain_connection")
-    public void setDomainConnection(boolean domainConnection) {
+    public void setDomainConnection(Boolean domainConnection) {
         this.isDomainConnection = domainConnection;
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
@@ -247,7 +247,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body.size(), is(4));
+        assertThat(body.size(), is(2));
         assertThat(body, hasEntry("name", "my-connection"));
         assertThat(body, hasEntry("strategy", "auth0"));
 

--- a/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ConnectionsEntityTest.java
@@ -176,7 +176,10 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
 
     @Test
     public void shouldCreateConnection() throws Exception {
-        Request<Connection> request = api.connections().create(new Connection("my-connection", "auth0"));
+        Connection createConnection = new Connection("my-connection", "auth0");
+        createConnection.setDomainConnection(true);
+        createConnection.setShowAsButton(true);
+        Request<Connection> request = api.connections().create(createConnection);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(MGMT_CONNECTION, 200);
@@ -188,7 +191,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body.size(), is(5));
+        assertThat(body.size(), is(4));
         assertThat(body, hasEntry("name", "my-connection"));
         assertThat(body, hasEntry("strategy", "auth0"));
 
@@ -244,7 +247,7 @@ public class ConnectionsEntityTest extends BaseMgmtEntityTest {
         assertThat(recordedRequest, hasHeader("Authorization", "Bearer apiToken"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body.size(), is(5));
+        assertThat(body.size(), is(4));
         assertThat(body, hasEntry("name", "my-connection"));
         assertThat(body, hasEntry("strategy", "auth0"));
 

--- a/src/test/resources/mgmt/connection.json
+++ b/src/test/resources/mgmt/connection.json
@@ -8,6 +8,8 @@
     "ScKKdrpyUwfkhOQP6KXItH32INgZf7Rb"
   ],
   "metadata": {
-  	"key": "value"
-  }
+    "key": "value"
+  },
+  "is_domain_connection": true,
+  "show_as_button": true
 }


### PR DESCRIPTION
### Changes

- Made show_as_button and is_domain_connection optional

### References

[Create Connection](https://auth0.com/docs/api/management/v2/connections/post-connections)
[Update Connection](https://auth0.com/docs/api/management/v2/connections/patch-connections-by-id)

### Manual Testing

- Get accessToken, domain from your tenant Get accessToken

```

ManagementAPI api = ManagementAPI.newBuilder(domain, accessToken).build();

/* Create Connection */
Connection create = new Connection("Test-Connection", "ad");
create.setDomainConnection(true);

Request<Connection> createCon = api.connections().create(create);
Response<Connection> createConRes = createCon.execute();
Connection createConResp = createConRes.getBody();

/* Update Connection */
Connection update = new Connection();
update.setShowAsButton(true);
update.setDomainConnection(true);
Connection updateConResp = api.connections().update("<ConnectionID>", update).execute().getBody();

```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
