### PR TITLE
Fix: Resource Server Scopes

### DIFF
--- a/src/main/java/com/auth0/json/mgmt/refreshtokens/ResourceServer.java
+++ b/src/main/java/com/auth0/json/mgmt/refreshtokens/ResourceServer.java
@@ -12,7 +12,7 @@ public class ResourceServer {
     @JsonProperty("audience")
     private String audience;
     @JsonProperty("scopes")
-    private List<String> scopes;
+    private String scopes;
 
     /**
      * @return Resource server ID
@@ -24,7 +24,7 @@ public class ResourceServer {
     /**
      * @return List of scopes for the refresh token
      */
-    public List<String> getScopes() {
+    public String getScopes() {
         return scopes;
     }
 }

--- a/src/test/java/com/auth0/json/mgmt/refreshtokens/RefreshTokenTest.java
+++ b/src/test/java/com/auth0/json/mgmt/refreshtokens/RefreshTokenTest.java
@@ -28,10 +28,7 @@ public class RefreshTokenTest extends JsonTest<RefreshToken> {
         "  \"resource_servers\": [\n" +
         "    {\n" +
         "      \"audience\": \"https://api.example.com\",\n" +
-        "      \"scopes\": [\n" +
-        "        \"read:examples\",\n" +
-        "        \"write:examples\"\n" +
-        "      ]\n" +
+        "      \"scopes\": \"offline_access\"\n" +
         "    }\n" +
         "  ],\n" +
         "  \"last_exchanged_at\": \"2024-07-03T09:10:26.643Z\"\n" +
@@ -69,8 +66,7 @@ public class RefreshTokenTest extends JsonTest<RefreshToken> {
         assertThat(refreshToken.getResourceServers(), is(notNullValue()));
         assertThat(refreshToken.getResourceServers().get(0).getAudience(), is("https://api.example.com"));
         assertThat(refreshToken.getResourceServers().get(0).getScopes(), is(notNullValue()));
-        assertThat(refreshToken.getResourceServers().get(0).getScopes().get(0), is("read:examples"));
-        assertThat(refreshToken.getResourceServers().get(0).getScopes().get(1), is("write:examples"));
+        assertThat(refreshToken.getResourceServers().get(0).getScopes(), is("offline_access"));
 
         assertThat(refreshToken.getLastExchangedAt(), is(parseJSONDate("2024-07-03T09:10:26.643Z")));
     }

--- a/src/test/java/com/auth0/json/mgmt/refreshtokens/RefreshTokensPageTest.java
+++ b/src/test/java/com/auth0/json/mgmt/refreshtokens/RefreshTokensPageTest.java
@@ -30,10 +30,7 @@ public class RefreshTokensPageTest extends JsonTest<RefreshTokensPage> {
         "      \"resource_servers\": [\n" +
         "        {\n" +
         "          \"audience\": \"https://api.example.com\",\n" +
-        "          \"scopes\": [\n" +
-        "            \"read:examples\",\n" +
-        "            \"write:examples\"\n" +
-        "          ]\n" +
+        "          \"scopes\": \"offline_access\"\n" +
         "        }\n" +
         "      ],\n" +
         "      \"last_exchanged_at\": \"2024-07-03T09:10:26.643Z\"\n" +
@@ -58,10 +55,7 @@ public class RefreshTokensPageTest extends JsonTest<RefreshTokensPage> {
         "      \"resource_servers\": [\n" +
         "        {\n" +
         "          \"audience\": \"https://api.example.com\",\n" +
-        "          \"scopes\": [\n" +
-        "            \"read:examples\",\n" +
-        "            \"write:examples\"\n" +
-        "          ]\n" +
+        "          \"scopes\": \"offline_access\"\n" +
         "        }\n" +
         "      ],\n" +
         "      \"last_exchanged_at\": \"2024-07-03T09:10:26.643Z\"\n" +
@@ -92,10 +86,7 @@ public class RefreshTokensPageTest extends JsonTest<RefreshTokensPage> {
         "      \"resource_servers\": [\n" +
         "        {\n" +
         "          \"audience\": \"https://api.example.com\",\n" +
-        "          \"scopes\": [\n" +
-        "            \"read:examples\",\n" +
-        "            \"write:examples\"\n" +
-        "          ]\n" +
+        "          \"scopes\": \"offline_access\"\n" +
         "        }\n" +
         "      ],\n" +
         "      \"last_exchanged_at\": \"2024-07-03T09:10:26.643Z\"\n" +
@@ -120,10 +111,7 @@ public class RefreshTokensPageTest extends JsonTest<RefreshTokensPage> {
         "      \"resource_servers\": [\n" +
         "        {\n" +
         "          \"audience\": \"https://api.example.com\",\n" +
-        "          \"scopes\": [\n" +
-        "            \"read:examples\",\n" +
-        "            \"write:examples\"\n" +
-        "          ]\n" +
+        "          \"scopes\": \"offline_access\"\n" +
         "        }\n" +
         "      ],\n" +
         "      \"last_exchanged_at\": \"2024-07-03T09:10:26.643Z\"\n" +
@@ -159,9 +147,7 @@ public class RefreshTokensPageTest extends JsonTest<RefreshTokensPage> {
 
         assertThat(page.getTokens().get(0).getResourceServers().size(), is(1));
         assertThat(page.getTokens().get(0).getResourceServers().get(0).getAudience(), is("https://api.example.com"));
-        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes().size(), is(2));
-        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes().get(0), is("read:examples"));
-        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes().get(1), is("write:examples"));
+        assertThat(page.getTokens().get(0).getResourceServers().get(0).getScopes(), is("offline_access"));
 
         assertThat(page.getTokens().get(0).getLastExchangedAt(), is(parseJSONDate("2024-07-03T09:10:26.643Z")));
     }

--- a/src/test/resources/mgmt/refresh_token.json
+++ b/src/test/resources/mgmt/refresh_token.json
@@ -18,10 +18,7 @@
   "resource_servers": [
     {
       "audience": "https://api.example.com",
-      "scopes": [
-        "read:examples",
-        "write:examples"
-      ]
+      "scopes": "offline_access"
     }
   ],
   "last_exchanged_at": "2024-07-03T09:10:26.643Z"

--- a/src/test/resources/mgmt/user_refresh_tokens.json
+++ b/src/test/resources/mgmt/user_refresh_tokens.json
@@ -20,10 +20,7 @@
       "resource_servers": [
         {
           "audience": "https://api.example.com",
-          "scopes": [
-            "read:examples",
-            "write:examples"
-          ]
+          "scopes": "offline_access"
         }
       ],
       "last_exchanged_at": "2024-07-03T09:10:26.643Z"
@@ -49,10 +46,7 @@
       "resource_servers": [
         {
           "audience": "https://api.example.com",
-          "scopes": [
-            "read:examples",
-            "write:examples"
-          ]
+          "scopes": "offline_access"
         }
       ],
       "last_exchanged_at": "2024-07-03T09:10:26.643Z"


### PR DESCRIPTION
### Changes

Fix: the scopes field for Refresh Token 

### References

https://auth0.com/docs/api/management/v2/users/get-refresh-tokens-for-user
https://auth0.com/docs/api/management/v2/refresh-tokens/get-refresh-token

### Manual Testing Snippet

Get domain and apiToken from tenant

ManagementAPI mgmt = ManagementAPI.newBuilder("{YOUR_DOMAIN}", "{YOUR_API_TOKEN}").build();
```
RefreshTokensPage page = api.users().listRefreshTokens("<USER_ID>", <FILTER>).execute().getBody();

RefreshToken refreshToken = api.refreshTokens().get("<REFRESH_TOKEN_ID>").execute().getBody();
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
