### PR TITLE
Added ManagementAPI token provider customization

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -401,7 +401,7 @@ public class ManagementAPI {
      */
     public static class Builder {
         private final String domain;
-        private final String apiToken;
+        private TokenProvider tokenProvider
         private Auth0HttpClient httpClient = DefaultHttpClient.newBuilder().build();
 
         /**
@@ -411,7 +411,7 @@ public class ManagementAPI {
          */
         public Builder(String domain, String apiToken) {
             this.domain = domain;
-            this.apiToken = apiToken;
+            this.tokenProvider = SimpleTokenProvider.create(apiToken);
         }
 
         /**
@@ -426,11 +426,21 @@ public class ManagementAPI {
         }
 
         /**
+         * Configure the token provider with an {@link TokenProvider}.
+         * @param tokenProvider the API Token provider to use when making requests.
+         * @return the builder instance.
+         */
+        public Builder withTokenProvider(TokenProvider tokenProvider) {
+            this.tokenProvider = tokenProvider;
+            return this;
+        }
+
+        /**
          * Build a {@link ManagementAPI} instance using this builder's configuration.
          * @return the configured {@code ManagementAPI} instance.
          */
         public ManagementAPI build() {
-            return new ManagementAPI(domain, SimpleTokenProvider.create(apiToken), httpClient);
+            return new ManagementAPI(domain, tokenProvider, httpClient);
         }
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -68,7 +68,9 @@ public class ManagementAPITest {
         };
 
         ManagementAPI api = ManagementAPI.newBuilder(DOMAIN, API_TOKEN)
-            .withHttpClient(httpClient).build();
+            .withHttpClient(httpClient)
+            .withTokenProvider(SimpleTokenProvider.create(API_TOKEN))
+            .build();
         assertThat(api, is(notNullValue()));
         assertThat(api.getHttpClient(), is(httpClient));
     }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Classes and methods changed

`ManagementAPI` currently support only api token. Auth0 supports api auth with authenticate-with-private-key-jwt and so on. At that time, we need to change Token Provider.

### References

N/A

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
