### PR TITLE
Create new method to add Email based OOB authenticator and tests

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -1396,7 +1396,7 @@ public class AuthAPI {
     }
 
     /**
-     * Associates or adds a new OOB authenticator for multi-factor authentication (MFA).
+     * Associates or adds a new phone based OOB authenticator for multi-factor authentication (MFA).
      * Confidential clients (Regular Web Apps) <strong>must</strong> have a client secret configured on this {@code AuthAPI} instance.
      * <pre>
      * {@code
@@ -1414,9 +1414,9 @@ public class AuthAPI {
      * @param oobChannels The type of OOB channels supported by the client. Must not be null.
      * @param phoneNumber The phone number for "sms" or "voice" channels. May be null if not using "sms" or "voice".
      * @return a Request to execute.
-     * @see <a href="https://auth0.com/docs/api/authentication#add-an-authenticator">Add an Authenticator API documentation</a>
+     * @see <a href="https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-challenge-sms-voice-authenticators#enroll-with-sms-or-voice">Enroll with SMS or voice</a>
      */
-    public Request<CreatedOobResponse> addOobAuthenticator(String mfaToken, List<String> oobChannels, String phoneNumber) {
+    public Request<CreatedOobResponse> addPhoneOobAuthenticator(String mfaToken, List<String> oobChannels, String phoneNumber) {
         Asserts.assertNotNull(mfaToken, "mfa token");
         Asserts.assertNotNull(oobChannels, "OOB channels");
 
@@ -1436,6 +1436,48 @@ public class AuthAPI {
         if (phoneNumber != null) {
             request.addParameter("phone_number", phoneNumber);
         }
+        addClientAuthentication(request, false);
+        request.addHeader("Authorization", "Bearer " + mfaToken);
+        return request;
+    }
+
+    /**
+     * Associates or adds a new email based OOB authenticator for multi-factor authentication (MFA).
+     * Confidential clients (Regular Web Apps) <strong>must</strong> have a client secret configured on this {@code AuthAPI} instance.
+     * <pre>
+     * {@code
+     * try {
+     *      CreatedOobResponse result = authAPI.addOobAuthenticator("the-mfa-token", "email-address")
+     *          .execute()
+     *          .getBody();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @param mfaToken The token received from mfa_required error. Must not be null.
+     * @param emailAddress The email address for "email" channel.
+     * @return a Request to execute.
+     * @see <a href="https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-email-authenticators#enroll-with-email">Enroll with email</a>
+     */
+    public Request<CreatedOobResponse> addEmailOobAuthenticator(String mfaToken, String emailAddress) {
+        Asserts.assertNotNull(mfaToken, "mfa token");
+
+        String url = baseUrl
+            .newBuilder()
+            .addPathSegment("mfa")
+            .addPathSegment("associate")
+            .build()
+            .toString();
+
+        BaseRequest<CreatedOobResponse> request = new BaseRequest<>(client, null, url, HttpMethod.POST, new TypeReference<CreatedOobResponse>() {
+        });
+
+        request.addParameter("authenticator_types", Collections.singletonList("oob"));
+        request.addParameter("oob_channels",  Collections.singletonList("email"));
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        request.addParameter("email", emailAddress);
         addClientAuthentication(request, false);
         request.addHeader("Authorization", "Bearer " + mfaToken);
         return request;

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1542,22 +1542,22 @@ public class AuthAPITest {
     }
 
     @Test
-    public void addOobAuthenticatorThrowsWhenTokenNull() {
+    public void addPhoneOobAuthenticatorThrowsWhenTokenNull() {
         verifyThrows(IllegalArgumentException.class,
-            () -> api.addOobAuthenticator(null, Collections.singletonList("otp"), null),
+            () -> api.addPhoneOobAuthenticator(null, Collections.singletonList("otp"), null),
             "'mfa token' cannot be null!");
     }
 
     @Test
-    public void addOobAuthenticatorThrowsWhenChannelsNull() {
+    public void addPhoneOobAuthenticatorThrowsWhenChannelsNull() {
         verifyThrows(IllegalArgumentException.class,
-            () -> api.addOobAuthenticator("mfaToken", null, null),
+            () -> api.addPhoneOobAuthenticator("mfaToken", null, null),
             "'OOB channels' cannot be null!");
     }
 
     @Test
     public void addOobAuthenticatorRequest() throws Exception {
-        Request<CreatedOobResponse> request = api.addOobAuthenticator("mfaToken", Collections.singletonList("sms"), "phone-number");
+        Request<CreatedOobResponse> request = api.addPhoneOobAuthenticator("mfaToken", Collections.singletonList("sms"), "phone-number");
 
         server.jsonResponse(AUTH_OOB_AUTHENTICATOR_RESPONSE, 200);
         CreatedOobResponse response = request.execute().getBody();
@@ -1570,6 +1570,37 @@ public class AuthAPITest {
         assertThat(body, hasEntry("authenticator_types", Collections.singletonList("oob")));
         assertThat(body, hasEntry("oob_channels", Collections.singletonList("sms")));
         assertThat(body, hasEntry("phone_number", "phone-number"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAuthenticatorType(), not(emptyOrNullString()));
+        assertThat(response.getOobChannel(), not(emptyOrNullString()));
+        assertThat(response.getOobCode(), not(emptyOrNullString()));
+        assertThat(response.getBarcodeUri(), not(emptyOrNullString()));
+        assertThat(response.getRecoveryCodes(), notNullValue());
+    }
+
+    @Test
+    public void addEmailOobAuthenticatorThrowsWhenTokenNull() {
+        verifyThrows(IllegalArgumentException.class,
+            () -> api.addEmailOobAuthenticator(null, null),
+            "'mfa token' cannot be null!");
+    }
+
+    @Test
+    public void addEmailOobAuthenticatorRequest() throws Exception {
+        Request<CreatedOobResponse> request = api.addEmailOobAuthenticator("mfaToken", "email-address");
+
+        server.jsonResponse(AUTH_OOB_AUTHENTICATOR_RESPONSE, 200);
+        CreatedOobResponse response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/mfa/associate"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("authenticator_types", Collections.singletonList("oob")));
+        assertThat(body, hasEntry("oob_channels", Collections.singletonList("email")));
+        assertThat(body, hasEntry("email", "email-address"));
 
         assertThat(response, is(notNullValue()));
         assertThat(response.getAuthenticatorType(), not(emptyOrNullString()));


### PR DESCRIPTION
### Changes

Currently there is no way to add an email channel oob authenticator because the existing `addOobAuthenticator` only supports adding a phone number even though you can set any oob channel. This PR will split `addOobAuthenticator` into `addPhoneOobAuthenticator` and `addEmailOobAuthenticator` along with test coverage for the email based method.

I was initially thinking of keeping the single method and consolidating all of the logic inside but I feel like a clear separation makes the code easier to understand and test.

### References

https://github.com/auth0/auth0-java/issues/603

### Testing

This can be manually tested by calling either `addPhoneOobAuthenticator` or `addEmailOobAuthenticator` in your projects and seeing either a valid response from the API or an error.

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
