### PR TITLE
Customize management api token provider

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementAPI.java
@@ -67,6 +67,17 @@ public class ManagementAPI {
         return new ManagementAPI.Builder(domain, apiToken);
     }
 
+    /**
+     * Instantiate a new {@link Builder} to configure and build a new ManagementAPI client.
+     *
+     * @param domain the tenant's domain. Must be a non-null valid HTTPS domain.
+     * @param tokenProvider the API Token provider to use when making requests.
+     * @return a Builder for further configuration.
+     */
+    public static ManagementAPI.Builder newBuilder(String domain, TokenProvider tokenProvider) {
+        return new ManagementAPI.Builder(domain, tokenProvider);
+    }
+
     private ManagementAPI(String domain, TokenProvider tokenProvider, Auth0HttpClient httpClient) {
         Asserts.assertNotNull(domain, "domain");
         Asserts.assertNotNull(tokenProvider, "token provider");
@@ -409,7 +420,7 @@ public class ManagementAPI {
      */
     public static class Builder {
         private final String domain;
-        private final String apiToken;
+        private final TokenProvider tokenProvider;
         private Auth0HttpClient httpClient = DefaultHttpClient.newBuilder().build();
 
         /**
@@ -418,8 +429,17 @@ public class ManagementAPI {
          * @param apiToken the API token used to make requests to the Auth0 Management API.
          */
         public Builder(String domain, String apiToken) {
+            this(domain, SimpleTokenProvider.create(apiToken));
+        }
+
+        /**
+         * Create a new Builder
+         * @param domain the domain of the tenant.
+         * @param tokenProvider the API Token provider to use when making requests.
+         */
+        public Builder(String domain, TokenProvider tokenProvider) {
             this.domain = domain;
-            this.apiToken = apiToken;
+            this.tokenProvider = tokenProvider;
         }
 
         /**

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -67,8 +67,12 @@ public class ManagementAPITest {
             }
         };
 
-        ManagementAPI api = ManagementAPI.newBuilder(DOMAIN, API_TOKEN)
-            .withHttpClient(httpClient).build();
+        ManagementAPI api = ManagementAPI.newBuilder(
+                DOMAIN,
+                SimpleTokenProvider.create(API_TOKEN)
+            )
+            .withHttpClient(httpClient)
+            .build();
         assertThat(api, is(notNullValue()));
         assertThat(api.getHttpClient(), is(httpClient));
     }
@@ -98,7 +102,7 @@ public class ManagementAPITest {
     @Test
     public void shouldThrowWhenApiTokenIsNull() {
         verifyThrows(IllegalArgumentException.class,
-            () -> ManagementAPI.newBuilder(DOMAIN, null).build(),
+            () -> ManagementAPI.newBuilder(DOMAIN, (String) null).build(),
             "'api token' cannot be null!");
     }
 

--- a/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementAPITest.java
@@ -54,7 +54,28 @@ public class ManagementAPITest {
     }
 
     @Test
-    public void shouldCreateWithHttpClient() {
+    public void shouldCreateWithHttpClientWithApiToken() {
+        Auth0HttpClient httpClient = new Auth0HttpClient() {
+            @Override
+            public Auth0HttpResponse sendRequest(Auth0HttpRequest request) {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<Auth0HttpResponse> sendRequestAsync(Auth0HttpRequest request) {
+                return null;
+            }
+        };
+
+        ManagementAPI api = ManagementAPI.newBuilder(DOMAIN, API_TOKEN)
+            .withHttpClient(httpClient).build();
+
+        assertThat(api, is(notNullValue()));
+        assertThat(api.getHttpClient(), is(httpClient));
+    }
+
+    @Test
+    public void shouldCreateWithHttpClientWithTokenProvider() {
         Auth0HttpClient httpClient = new Auth0HttpClient() {
             @Override
             public Auth0HttpResponse sendRequest(Auth0HttpRequest request) {
@@ -104,6 +125,13 @@ public class ManagementAPITest {
         verifyThrows(IllegalArgumentException.class,
             () -> ManagementAPI.newBuilder(DOMAIN, (String) null).build(),
             "'api token' cannot be null!");
+    }
+
+    @Test
+    public void shouldThrowWhenTokenProviderIsNull() {
+        verifyThrows(IllegalArgumentException.class,
+            () -> ManagementAPI.newBuilder(DOMAIN, (TokenProvider) null).build(),
+            "'token provider' cannot be null!");
     }
 
     @Test


### PR DESCRIPTION
### Changes

Support for TokenProvider in Builder:

Added a new static method: newBuilder(String domain, TokenProvider tokenProvider), allowing the creation of a ManagementAPI.Builder using a TokenProvider instead of a raw API token.
Updated the Builder class to accept either an API token (wrapped in a SimpleTokenProvider) or a TokenProvider directly.
The builder now stores a TokenProvider instead of a raw API token.
The build() method now uses the provided TokenProvider directly, instead of always wrapping an API token.

API Token Handling:
The constructor Builder(String domain, String apiToken) now delegates to Builder(String domain, TokenProvider tokenProvider) by wrapping the token in a SimpleTokenProvider.

### Credits 

Thanks @krrrr38 for raising #729.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
