### PR TITLE
Make DefaultHttpClient extensible, Issue #754

### DIFF
--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -38,10 +38,10 @@ public class DefaultHttpClient implements Auth0HttpClient {
     }
 
     /**
-     * For testing purposes only.
-     * @param client The client to inject for testing purposes.
+     * For extensibility or testing purposes.
+     * @param client The pre-built client to use.
      */
-    DefaultHttpClient(OkHttpClient client) {
+    protected DefaultHttpClient(OkHttpClient client) {
         this.client = client;
     }
 


### PR DESCRIPTION
### Changes

The package scoped constructor of DefaultHttpClient has been made protected so that custom implementations can extend DefaultHttpClient to provide a pre-build OkHttp client delegate.

I considered making the constructor public so we didn't need to extend, but that felt like a step too far and leaks to the world that the DefaultHttpClient implementation is using OkHttp

### References

Please include relevant links supporting this change such as a:

https://github.com/auth0/auth0-java/issues/754

### Testing

The existing automated tests run.

- [ ] This change adds test coverage
- [X] This change has been tested on the latest version of the platform/language

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
