### PR TITLE
Release 3.0.0-beta.0

### DIFF
--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
 
-      - name: Test and Assemble and ApiDiff with Gradle
-        run: ./gradlew assemble apiDiff check jacocoTestReport --continue --console=plain
+      - name: Test and Assemble with Gradle
+        run: ./gradlew assemble check --continue --console=plain
 
       - id: get_version
         uses: ./.github/actions/get-version


### PR DESCRIPTION
>Warning This SDK is in beta and is subject to breaking changes. It is not recommended for production use, but your feedback and help in testing is appreciated!

Added

Complete rewrite of the Management API client using Fern code generation
Update OkHttp to 5.2.1
API attributes can set null for patch operations
Nullability annotations to POJO classes
Fully compatible Authentication API client — no breaking changes
[Migration guide](https://github.com/auth0/auth0-java/blob/v3/MIGRATION_GUIDE.md) available for upgrading from v2.x