### PR TITLE
 Chore: Add Automatic-Module-Name to JAR manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ java {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+jar {
+  manifest {
+    attributes 'Automatic-Module-Name': 'com.auth0.java'
+  }
+}
+
 tasks.withType(Javadoc) {
   failOnError false
   options.addStringOption('Xdoclint:none', '-quiet')


### PR DESCRIPTION
### Summary                                                                                                                                                                                                  
                                                                                                                                                                                                           
  - Adds `Automatic-Module-Name: com.auth0.java` to the JAR manifest, providing a stable module name for consumers using the Java Platform Module System (JPMS)                                              
                                                                                                                                                                                                                                                                                                                                                                                            
  