### PR TITLE
docs: whitespace-only verification change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > As part of our ongoing commitment to best security practices, we have rotated the signing keys used to sign previous releases of this SDK. As a result, new patch builds have been released using the new signing key. Please upgrade at your earliest convenience.
 >
 > While this change won't affect most developers, if you have implemented a dependency signature validation step in your build process, you may notice a warning that past releases can't be verified. This is expected, and a result of the key rotation process. Updating to the latest version will resolve this for you.
-> 
+>
 > We are improving our API specs which introduces minor breaking changes.
 
 ![A Java client library for the Auth0 Authentication and Management APIs.](https://cdn.auth0.com/website/sdks/banners/auth0-java-banner.png)


### PR DESCRIPTION
Minimal external-PR workflow verification change. This PR only removes a trailing space in README for CI behavior observation.