### PR TITLE
feat: Add Token Vault support to the Authentication API

### DIFF
--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -60,11 +60,7 @@ public class AuthAPI {
     private static final String KEY_SUBJECT_TOKEN = "subject_token";
     private static final String KEY_SUBJECT_TOKEN_TYPE = "subject_token_type";
     private static final String KEY_REQUESTED_TOKEN_TYPE = "requested_token_type";
-    private static final String GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
-            "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
-    private static final String SUBJECT_TOKEN_TYPE_REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token";
-    private static final String REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
-            "http://auth0.com/oauth/token-type/federated-connection-access-token";
+    private static final String KEY_LOGIN_HINT = "login_hint";
     private static final String PATH_OAUTH = "oauth";
     private static final String PATH_TOKEN = "token";
     private static final String PATH_DBCONNECTIONS = "dbconnections";
@@ -855,8 +851,7 @@ public class AuthAPI {
      * <pre>
      * {@code
      * try {
-     *      TokenHolder result = authAPI.getTokenForConnection("google-oauth2", refreshToken)
-     *          .setLoginHint("google-user-id")
+     *      TokenHolder result = authAPI.getTokenForConnection("google-oauth2", refreshToken, "google-user-id")
      *          .execute()
      *          .getBody();
      *      String federatedAccessToken = result.getAccessToken();
@@ -870,19 +865,27 @@ public class AuthAPI {
      * @param connection the name of the federated connection to obtain an access token for
      *                   (for example {@code google-oauth2}). Must not be null.
      * @param refreshToken a valid Auth0 refresh token to exchange. Must not be null.
+     * @param loginHint the user's ID within the identity provider specified by the connection
+     *                  (for example, the Google user ID when the connection is {@code google-oauth2}).
+     *                  May be null, in which case no {@code login_hint} is sent.
      * @return a Request to configure and execute.
      */
-    public TokenRequest getTokenForConnection(String connection, String refreshToken) {
+    public TokenRequest getTokenForConnection(String connection, String refreshToken, String loginHint) {
         Asserts.assertNotNull(connection, "connection");
         Asserts.assertNotNull(refreshToken, "refresh token");
 
         TokenRequest request = new TokenRequest(client, getTokenUrl());
         request.addParameter(KEY_CLIENT_ID, clientId);
-        request.addParameter(KEY_GRANT_TYPE, GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN);
+        request.addParameter(
+                KEY_GRANT_TYPE, "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token");
         request.addParameter(KEY_SUBJECT_TOKEN, refreshToken);
-        request.addParameter(KEY_SUBJECT_TOKEN_TYPE, SUBJECT_TOKEN_TYPE_REFRESH_TOKEN);
-        request.addParameter(KEY_REQUESTED_TOKEN_TYPE, REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN);
+        request.addParameter(KEY_SUBJECT_TOKEN_TYPE, "urn:ietf:params:oauth:token-type:refresh_token");
+        request.addParameter(
+                KEY_REQUESTED_TOKEN_TYPE, "http://auth0.com/oauth/token-type/federated-connection-access-token");
         request.addParameter(KEY_CONNECTION, connection);
+        if (loginHint != null) {
+            request.addParameter(KEY_LOGIN_HINT, loginHint);
+        }
         addClientAuthentication(request, true);
         return request;
     }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -59,6 +59,13 @@ public class AuthAPI {
     private static final String KEY_CLIENT_ASSERTION_TYPE = "client_assertion_type";
     private static final String KEY_SUBJECT_TOKEN = "subject_token";
     private static final String KEY_SUBJECT_TOKEN_TYPE = "subject_token_type";
+    private static final String KEY_REQUESTED_TOKEN_TYPE = "requested_token_type";
+    private static final String GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
+        "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
+    private static final String SUBJECT_TOKEN_TYPE_REFRESH_TOKEN =
+        "urn:ietf:params:oauth:token-type:refresh_token";
+    private static final String REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
+        "http://auth0.com/oauth/token-type/federated-connection-access-token";
     private static final String PATH_OAUTH = "oauth";
     private static final String PATH_TOKEN = "token";
     private static final String PATH_DBCONNECTIONS = "dbconnections";
@@ -836,6 +843,47 @@ public class AuthAPI {
         request.addParameter(KEY_GRANT_TYPE, "urn:ietf:params:oauth:grant-type:token-exchange");
         request.addParameter(KEY_SUBJECT_TOKEN, subjectToken);
         request.addParameter(KEY_SUBJECT_TOKEN_TYPE, subjectTokenType);
+        addClientAuthentication(request, true);
+        return request;
+    }
+
+    /**
+     * Creates a request to exchange an Auth0 refresh token for a federated identity provider's access token
+     * using the Token Vault grant
+     * {@code urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token}.
+     * The connection must have the token vault enabled, and client authentication
+     * (client secret or client assertion) is required as this must be a private client.
+     * <pre>
+     * {@code
+     * try {
+     *      TokenHolder result = authAPI.getTokenForConnection("google-oauth2", refreshToken)
+     *          .setLoginHint("google-user-id")
+     *          .execute()
+     *          .getBody();
+     *      String federatedAccessToken = result.getAccessToken();
+     * } catch (Auth0Exception e) {
+     *      //Something happened
+     * }
+     * }
+     * </pre>
+     *
+     * @see <a href="https://auth0.com/docs/secure/tokens/token-vault">Token Vault documentation</a>
+     * @param connection the name of the federated connection to obtain an access token for
+     *                   (for example {@code google-oauth2}). Must not be null.
+     * @param refreshToken a valid Auth0 refresh token to exchange. Must not be null.
+     * @return a Request to configure and execute.
+     */
+    public TokenRequest getTokenForConnection(String connection, String refreshToken) {
+        Asserts.assertNotNull(connection, "connection");
+        Asserts.assertNotNull(refreshToken, "refresh token");
+
+        TokenRequest request = new TokenRequest(client, getTokenUrl());
+        request.addParameter(KEY_CLIENT_ID, clientId);
+        request.addParameter(KEY_GRANT_TYPE, GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN);
+        request.addParameter(KEY_SUBJECT_TOKEN, refreshToken);
+        request.addParameter(KEY_SUBJECT_TOKEN_TYPE, SUBJECT_TOKEN_TYPE_REFRESH_TOKEN);
+        request.addParameter(KEY_REQUESTED_TOKEN_TYPE, REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN);
+        request.addParameter(KEY_CONNECTION, connection);
         addClientAuthentication(request, true);
         return request;
     }

--- a/src/main/java/com/auth0/client/auth/AuthAPI.java
+++ b/src/main/java/com/auth0/client/auth/AuthAPI.java
@@ -61,11 +61,10 @@ public class AuthAPI {
     private static final String KEY_SUBJECT_TOKEN_TYPE = "subject_token_type";
     private static final String KEY_REQUESTED_TOKEN_TYPE = "requested_token_type";
     private static final String GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
-        "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
-    private static final String SUBJECT_TOKEN_TYPE_REFRESH_TOKEN =
-        "urn:ietf:params:oauth:token-type:refresh_token";
+            "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
+    private static final String SUBJECT_TOKEN_TYPE_REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token";
     private static final String REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
-        "http://auth0.com/oauth/token-type/federated-connection-access-token";
+            "http://auth0.com/oauth/token-type/federated-connection-access-token";
     private static final String PATH_OAUTH = "oauth";
     private static final String PATH_TOKEN = "token";
     private static final String PATH_DBCONNECTIONS = "dbconnections";

--- a/src/main/java/com/auth0/net/TokenRequest.java
+++ b/src/main/java/com/auth0/net/TokenRequest.java
@@ -46,4 +46,17 @@ public class TokenRequest extends BaseRequest<TokenHolder> {
         super.addParameter("scope", scope);
         return this;
     }
+
+    /**
+     * Setter for the login hint value to request. For the Token Vault federated connection
+     * token exchange, this is the user's ID within the identity provider specified by the
+     * connection (for example, the Google user ID when the connection is {@code google-oauth2}).
+     *
+     * @param loginHint the login hint to request
+     * @return this request instance.
+     */
+    public TokenRequest setLoginHint(String loginHint) {
+        super.addParameter("login_hint", loginHint);
+        return this;
+    }
 }

--- a/src/main/java/com/auth0/net/TokenRequest.java
+++ b/src/main/java/com/auth0/net/TokenRequest.java
@@ -46,17 +46,4 @@ public class TokenRequest extends BaseRequest<TokenHolder> {
         super.addParameter("scope", scope);
         return this;
     }
-
-    /**
-     * Setter for the login hint value to request. For the Token Vault federated connection
-     * token exchange, this is the user's ID within the identity provider specified by the
-     * connection (for example, the Google user ID when the connection is {@code google-oauth2}).
-     *
-     * @param loginHint the login hint to request
-     * @return this request instance.
-     */
-    public TokenRequest setLoginHint(String loginHint) {
-        super.addParameter("login_hint", loginHint);
-        return this;
-    }
 }

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1041,7 +1041,7 @@ public class AuthAPITest {
     public void shouldThrowOnGetTokenForConnectionWithNullConnection() {
         verifyThrows(
                 IllegalArgumentException.class,
-                () -> api.getTokenForConnection(null, "test-refresh-token"),
+                () -> api.getTokenForConnection(null, "test-refresh-token", null),
                 "'connection' cannot be null!");
     }
 
@@ -1049,13 +1049,13 @@ public class AuthAPITest {
     public void shouldThrowOnGetTokenForConnectionWithNullRefreshToken() {
         verifyThrows(
                 IllegalArgumentException.class,
-                () -> api.getTokenForConnection("google-oauth2", null),
+                () -> api.getTokenForConnection("google-oauth2", null, null),
                 "'refresh token' cannot be null!");
     }
 
     @Test
     public void shouldCreateGetTokenForConnectionRequest() throws Exception {
-        TokenRequest request = api.getTokenForConnection("google-oauth2", "test-refresh-token");
+        TokenRequest request = api.getTokenForConnection("google-oauth2", "test-refresh-token", null);
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
@@ -1088,8 +1088,7 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateGetTokenForConnectionRequestWithLoginHint() throws Exception {
-        TokenRequest request =
-                api.getTokenForConnection("google-oauth2", "test-refresh-token").setLoginHint("google-user-id");
+        TokenRequest request = api.getTokenForConnection("google-oauth2", "test-refresh-token", "google-user-id");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);
@@ -1108,7 +1107,7 @@ public class AuthAPITest {
     public void getTokenForConnectionRequiresClientAuthentication() {
         verifyThrows(
                 IllegalStateException.class,
-                () -> apiNoClientAuthentication.getTokenForConnection("google-oauth2", "test-refresh-token"),
+                () -> apiNoClientAuthentication.getTokenForConnection("google-oauth2", "test-refresh-token", null),
                 "A client secret or client assertion signing key is required for this operation");
     }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1066,14 +1066,19 @@ public class AuthAPITest {
         assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
 
         Map<String, Object> body = bodyFromRequest(recordedRequest);
-        assertThat(body, hasEntry("grant_type",
-                "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token"));
+        assertThat(
+                body,
+                hasEntry(
+                        "grant_type",
+                        "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token"));
         assertThat(body, hasEntry("client_id", CLIENT_ID));
         assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
         assertThat(body, hasEntry("subject_token", "test-refresh-token"));
         assertThat(body, hasEntry("subject_token_type", "urn:ietf:params:oauth:token-type:refresh_token"));
-        assertThat(body, hasEntry("requested_token_type",
-                "http://auth0.com/oauth/token-type/federated-connection-access-token"));
+        assertThat(
+                body,
+                hasEntry(
+                        "requested_token_type", "http://auth0.com/oauth/token-type/federated-connection-access-token"));
         assertThat(body, hasEntry("connection", "google-oauth2"));
         assertThat(body, not(hasKey("login_hint")));
 
@@ -1083,8 +1088,8 @@ public class AuthAPITest {
 
     @Test
     public void shouldCreateGetTokenForConnectionRequestWithLoginHint() throws Exception {
-        TokenRequest request = api.getTokenForConnection("google-oauth2", "test-refresh-token")
-                .setLoginHint("google-user-id");
+        TokenRequest request =
+                api.getTokenForConnection("google-oauth2", "test-refresh-token").setLoginHint("google-user-id");
         assertThat(request, is(notNullValue()));
 
         server.jsonResponse(AUTH_TOKENS, 200);

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -1035,6 +1035,78 @@ public class AuthAPITest {
         assertThat(response.getAccessToken(), not(emptyOrNullString()));
     }
 
+    // Token Vault - Federated Connection Access Token
+
+    @Test
+    public void shouldThrowOnGetTokenForConnectionWithNullConnection() {
+        verifyThrows(
+                IllegalArgumentException.class,
+                () -> api.getTokenForConnection(null, "test-refresh-token"),
+                "'connection' cannot be null!");
+    }
+
+    @Test
+    public void shouldThrowOnGetTokenForConnectionWithNullRefreshToken() {
+        verifyThrows(
+                IllegalArgumentException.class,
+                () -> api.getTokenForConnection("google-oauth2", null),
+                "'refresh token' cannot be null!");
+    }
+
+    @Test
+    public void shouldCreateGetTokenForConnectionRequest() throws Exception {
+        TokenRequest request = api.getTokenForConnection("google-oauth2", "test-refresh-token");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        assertThat(recordedRequest, hasMethodAndPath(HttpMethod.POST, "/oauth/token"));
+        assertThat(recordedRequest, hasHeader("Content-Type", "application/json"));
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("grant_type",
+                "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token"));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("client_secret", CLIENT_SECRET));
+        assertThat(body, hasEntry("subject_token", "test-refresh-token"));
+        assertThat(body, hasEntry("subject_token_type", "urn:ietf:params:oauth:token-type:refresh_token"));
+        assertThat(body, hasEntry("requested_token_type",
+                "http://auth0.com/oauth/token-type/federated-connection-access-token"));
+        assertThat(body, hasEntry("connection", "google-oauth2"));
+        assertThat(body, not(hasKey("login_hint")));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+    }
+
+    @Test
+    public void shouldCreateGetTokenForConnectionRequestWithLoginHint() throws Exception {
+        TokenRequest request = api.getTokenForConnection("google-oauth2", "test-refresh-token")
+                .setLoginHint("google-user-id");
+        assertThat(request, is(notNullValue()));
+
+        server.jsonResponse(AUTH_TOKENS, 200);
+        TokenHolder response = request.execute().getBody();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        Map<String, Object> body = bodyFromRequest(recordedRequest);
+        assertThat(body, hasEntry("connection", "google-oauth2"));
+        assertThat(body, hasEntry("login_hint", "google-user-id"));
+
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getAccessToken(), not(emptyOrNullString()));
+    }
+
+    @Test
+    public void getTokenForConnectionRequiresClientAuthentication() {
+        verifyThrows(
+                IllegalStateException.class,
+                () -> apiNoClientAuthentication.getTokenForConnection("google-oauth2", "test-refresh-token"),
+                "A client secret or client assertion signing key is required for this operation");
+    }
+
     // Login with Passwordless
 
     @Test


### PR DESCRIPTION
## Summary

This PR adds support for the **Token Vault** federated-connection token exchange grant
(`urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token`) to the
Authentication API. This lets a private client exchange an Auth0 refresh token for a federated
identity provider's access token (e.g. Google, Facebook), so applications can call those
providers' APIs on the user's behalf.

## Changes

### Token Vault token exchange

Added `AuthAPI.getTokenForConnection(String connection, String refreshToken)`, which returns a `TokenRequest`.

- Uses the Token Vault grant:
  `urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token`
- Hardcodes `subject_token_type` to `urn:ietf:params:oauth:token-type:refresh_token` (the only
  value the endpoint currently supports) and `requested_token_type` to
  `http://auth0.com/oauth/token-type/federated-connection-access-token`.
- Sends the caller-supplied `connection` and the refresh token as `subject_token`.
- Requires client authentication (client secret or client assertion) - this must be a private client.

Added `TokenRequest.setLoginHint(String)` for the optional `login_hint` (the user's ID within the
federated identity provider), following the existing `setScope` / `setAudience` setter pattern.

### Example

```java
TokenHolder tokens = authAPI
    .getTokenForConnection("google-oauth2", refreshToken)
    .setLoginHint("google-user-id") // optional
    .execute()
    .getBody();

String federatedAccessToken = tokens.getAccessToken();
```

## Test Plan

- ✅ `./gradlew test --tests "com.auth0.client.auth.AuthAPITest"`
- ✅ Full test suite passes: `./gradlew test`
- ✅ Ran spotless: `./gradlew spotlessCheck`
- Added unit tests covering: all request parameters, `login_hint` present/absent,
  null-argument validation (`connection`, `refreshToken`), and the client-authentication requirement.