### PR TITLE
Fix the Jackson mapping for a response when search from a checkpoint log ID

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/RawLogsClient.java
+++ b/src/main/java/com/auth0/client/mgmt/RawLogsClient.java
@@ -20,8 +20,10 @@ import com.auth0.client.mgmt.types.GetLogResponseContent;
 import com.auth0.client.mgmt.types.ListLogOffsetPaginatedResponseContent;
 import com.auth0.client.mgmt.types.ListLogsRequestParameters;
 import com.auth0.client.mgmt.types.Log;
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import okhttp3.Headers;
@@ -187,8 +189,19 @@ public class RawLogsClient {
             ResponseBody responseBody = response.body();
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             if (response.isSuccessful()) {
-                ListLogOffsetPaginatedResponseContent parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
-                        responseBodyString, ListLogOffsetPaginatedResponseContent.class);
+                ListLogOffsetPaginatedResponseContent parsedResponse;
+                try {
+                    parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(
+                            responseBodyString, ListLogOffsetPaginatedResponseContent.class);
+                } catch (JacksonException e) {
+                    if (requestOptions == null || !requestOptions.getQueryParameters().containsKey("from")) {
+                        throw e;
+                    }
+                    List<Log> logs =
+                        Arrays.asList(ObjectMappers.JSON_MAPPER.readValue(responseBodyString, Log[].class));
+                    parsedResponse = ListLogOffsetPaginatedResponseContent.builder().logs(logs).build();
+                }
                 int newPageNumber =
                         request.getPage().map((Integer page) -> page + 1).orElse(1);
                 ListLogsRequestParameters nextRequest = ListLogsRequestParameters.builder()


### PR DESCRIPTION
Hi there

I use log events, and in the v2 it works fine, now I'm trying to migrate to v3 and see the decoding issue like:

```logs
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `com.auth0.client.mgmt.types.ListLogOffsetPaginatedResponseContent$Builder` from Array value (token `JsonToken.START_ARRAY`) at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1]
```

This is because "search from a checkpoint log ID" gives another response structure like an array of logs `[{..}]` (see docs https://auth0.com/docs/api/management/v2/logs/get-logs) and it cannot be decoded to `ListLogOffsetPaginatedResponseContent`.

Some code for debugging the issue:

```java
public static void main(String[] args) {
    final var response =
        ManagementApi.builder()
            .domain("xxx.auth0.com")
            .clientCredentials("***", "***")
            .build()
            .logs()
            .list(
                ListLogsRequestParameters.builder().fields("logs").includeFields(true).build(),
                RequestOptions.builder()
                    .addQueryParameter("from", "90020260710082608309772000000000000001223372072903441213")
                    .addQueryParameter("take", "10")
                    .build());

    System.out.println(response);
  }
```


Raw request example
```log
Request{method=GET, url=https://xxx.auth0.com/api/v2/logs?page=0&per_page=50&fields=logs&include_fields=true&include_totals=true&take=10&from=90020260710082608309772000000000000001223372072903441213, headers=[...]}
```

Raw response example
```log
[{"date":"2026-07-10T08:36:34.434Z","type":"seccft","description":"","connection_id":"","client_id":"SXXXN", "log_id":"90020260710083634443881000000000000001223372072904089442"}]
```