### PR TITLE
Fix parsing of UserUpdatedEvents

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/AsyncRawEventsClient.java
+++ b/src/main/java/com/auth0/client/mgmt/AsyncRawEventsClient.java
@@ -109,9 +109,10 @@ public class AsyncRawEventsClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new ManagementApiHttpResponse<>(
-                                Stream.fromSse(
+                                Stream.fromSseWithEventDiscrimination(
                                         EventStreamSubscribeEventsResponseContent.class,
-                                        new ResponseBodyReader(response)),
+                                        new ResponseBodyReader(response),
+                                        "type"),
                                 response));
                         return;
                     }

--- a/src/main/java/com/auth0/client/mgmt/RawEventsClient.java
+++ b/src/main/java/com/auth0/client/mgmt/RawEventsClient.java
@@ -100,8 +100,10 @@ public class RawEventsClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new ManagementApiHttpResponse<>(
-                        Stream.fromSse(
-                                EventStreamSubscribeEventsResponseContent.class, new ResponseBodyReader(response)),
+                        Stream.fromSseWithEventDiscrimination(
+                                EventStreamSubscribeEventsResponseContent.class,
+                                new ResponseBodyReader(response),
+                                "type"),
                         response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";

--- a/src/main/java/com/auth0/client/mgmt/core/SseEventParser.java
+++ b/src/main/java/com/auth0/client/mgmt/core/SseEventParser.java
@@ -75,6 +75,44 @@ public final class SseEventParser {
     }
 
     /**
+     * Parse an SSE event whose discriminator is not part of the SSE envelope shape (i.e.
+     * {@link #isEventLevelDiscrimination(String)} is {@code false}) but is also absent from the
+     * wire payload itself. Merges the SSE {@code event:} name into the root of the parsed
+     * {@code data:} object under {@code discriminatorProperty}, without overwriting a
+     * pre-existing value, then deserializes the merged object to the target type.
+     *
+     * @param eventType            The SSE event type (from event: field)
+     * @param data                 The SSE data content (from data: field)
+     * @param unionClass           The target union class
+     * @param discriminatorProperty The property name used for discrimination (e.g., "type")
+     * @param <T>                  The target type
+     * @return The deserialized object
+     */
+    public static <T> T parseWithInjectedDiscriminator(
+            String eventType, String data, Class<T> unionClass, String discriminatorProperty) {
+        Map<String, Object> parsedData = null;
+        if (data != null && !data.isEmpty()) {
+            try {
+                parsedData = ObjectMappers.JSON_MAPPER.readValue(data, new TypeReference<Map<String, Object>>() {});
+            } catch (Exception e) {
+                parsedData = null;
+            }
+        }
+        try {
+            if (parsedData == null) {
+                return parseDataLevelUnion(data, unionClass);
+            }
+            if (eventType != null) {
+                parsedData.putIfAbsent(discriminatorProperty, eventType);
+            }
+            String mergedJson = ObjectMappers.JSON_MAPPER.writeValueAsString(parsedData);
+            return ObjectMappers.JSON_MAPPER.readValue(mergedJson, unionClass);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse SSE event with injected discriminator", e);
+        }
+    }
+
+    /**
      * Parse an SSE event using data-level discrimination.
      * <p>
      * Simply parses the data field as JSON and deserializes it to the target type.

--- a/src/main/java/com/auth0/client/mgmt/core/Stream.java
+++ b/src/main/java/com/auth0/client/mgmt/core/Stream.java
@@ -410,14 +410,7 @@ public final class Stream<T> implements Iterable<T>, Closeable {
                     if (line.trim().isEmpty()) {
                         if (eventDataBuffer.length() > 0 || currentEventType != null) {
                             try {
-                                // Use SseEventParser for event-level discrimination
-                                nextItem = SseEventParser.parseEventLevelUnion(
-                                        currentEventType,
-                                        eventDataBuffer.toString(),
-                                        currentEventId,
-                                        currentRetry,
-                                        valueType,
-                                        discriminatorProperty);
+                                nextItem = parseCurrentEvent();
                                 hasNextItem = true;
                                 resetEventState();
                                 return true;
@@ -477,13 +470,7 @@ public final class Stream<T> implements Iterable<T>, Closeable {
                 // Handle any remaining buffered data at end of stream
                 if (eventDataBuffer.length() > 0 || currentEventType != null) {
                     try {
-                        nextItem = SseEventParser.parseEventLevelUnion(
-                                currentEventType,
-                                eventDataBuffer.toString(),
-                                currentEventId,
-                                currentRetry,
-                                valueType,
-                                discriminatorProperty);
+                        nextItem = parseCurrentEvent();
                         hasNextItem = true;
                         resetEventState();
                         return true;
@@ -508,6 +495,16 @@ public final class Stream<T> implements Iterable<T>, Closeable {
             currentEventType = null;
             currentEventId = null;
             currentRetry = null;
+        }
+
+        private T parseCurrentEvent() {
+            String data = eventDataBuffer.toString();
+            if (SseEventParser.isEventLevelDiscrimination(discriminatorProperty)) {
+                return SseEventParser.parseEventLevelUnion(
+                        currentEventType, data, currentEventId, currentRetry, valueType, discriminatorProperty);
+            }
+            return SseEventParser.parseWithInjectedDiscriminator(
+                    currentEventType, data, valueType, discriminatorProperty);
         }
     }
 }

--- a/src/main/java/com/auth0/client/mgmt/types/EventStreamCloudEventUserCreatedObjectIdentitiesItem.java
+++ b/src/main/java/com/auth0/client/mgmt/types/EventStreamCloudEventUserCreatedObjectIdentitiesItem.java
@@ -113,58 +113,56 @@ public final class EventStreamCloudEventUserCreatedObjectIdentitiesItem {
         public EventStreamCloudEventUserCreatedObjectIdentitiesItem deserialize(
                 JsonParser p, DeserializationContext context) throws IOException {
             Object value = p.readValueAs(Object.class);
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
+            if (value instanceof Map<?, ?>) {
+                Map<?, ?> map = (Map<?, ?>) value;
+                Object providerValue = map.get("provider");
+                String provider = providerValue == null ? null : providerValue.toString();
+                boolean isSocial = Boolean.TRUE.equals(map.get("isSocial"));
+
+                if (isSocial) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum.valueOf(provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum.valueOf(
+                                                provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum.valueOf(provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
                 try {
                     return of(ObjectMappers.JSON_MAPPER.convertValue(
                             value, EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial.class));
                 } catch (RuntimeException e) {
                 }
             }

--- a/src/main/java/com/auth0/client/mgmt/types/EventStreamCloudEventUserDeletedObjectIdentitiesItem.java
+++ b/src/main/java/com/auth0/client/mgmt/types/EventStreamCloudEventUserDeletedObjectIdentitiesItem.java
@@ -113,58 +113,56 @@ public final class EventStreamCloudEventUserDeletedObjectIdentitiesItem {
         public EventStreamCloudEventUserDeletedObjectIdentitiesItem deserialize(
                 JsonParser p, DeserializationContext context) throws IOException {
             Object value = p.readValueAs(Object.class);
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
+            if (value instanceof Map<?, ?>) {
+                Map<?, ?> map = (Map<?, ?>) value;
+                Object providerValue = map.get("provider");
+                String provider = providerValue == null ? null : providerValue.toString();
+                boolean isSocial = Boolean.TRUE.equals(map.get("isSocial"));
+
+                if (isSocial) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum.valueOf(provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum.valueOf(
+                                                provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum.valueOf(provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
                 try {
                     return of(ObjectMappers.JSON_MAPPER.convertValue(
                             value, EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial.class));
                 } catch (RuntimeException e) {
                 }
             }

--- a/src/main/java/com/auth0/client/mgmt/types/EventStreamCloudEventUserUpdatedObjectIdentitiesItem.java
+++ b/src/main/java/com/auth0/client/mgmt/types/EventStreamCloudEventUserUpdatedObjectIdentitiesItem.java
@@ -113,58 +113,56 @@ public final class EventStreamCloudEventUserUpdatedObjectIdentitiesItem {
         public EventStreamCloudEventUserUpdatedObjectIdentitiesItem deserialize(
                 JsonParser p, DeserializationContext context) throws IOException {
             Object value = p.readValueAs(Object.class);
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
+            if (value instanceof Map<?, ?>) {
+                Map<?, ?> map = (Map<?, ?>) value;
+                Object providerValue = map.get("provider");
+                String provider = providerValue == null ? null : providerValue.toString();
+                boolean isSocial = Boolean.TRUE.equals(map.get("isSocial"));
+
+                if (isSocial) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum.valueOf(provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum.valueOf(
+                                                provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
+                if (provider != null
+                        && EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum.valueOf(provider)
+                                        .getEnumValue()
+                                != EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum.Value
+                                        .UNKNOWN) {
+                    try {
+                        return of(ObjectMappers.JSON_MAPPER.convertValue(
+                                value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise.class));
+                    } catch (RuntimeException e) {
+                    }
+                }
                 try {
                     return of(ObjectMappers.JSON_MAPPER.convertValue(
                             value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless.class));
-                } catch (RuntimeException e) {
-                }
-            }
-            if (value instanceof Map<?, ?>
-                    && ((Map<?, ?>) value).containsKey("connection")
-                    && ((Map<?, ?>) value).containsKey("user_id")
-                    && ((Map<?, ?>) value).containsKey("provider")
-                    && ((Map<?, ?>) value).containsKey("isSocial")) {
-                try {
-                    return of(ObjectMappers.JSON_MAPPER.convertValue(
-                            value, EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial.class));
                 } catch (RuntimeException e) {
                 }
             }

--- a/src/test/java/com/auth0/client/mgmt/EventsSubscribeSseTest.java
+++ b/src/test/java/com/auth0/client/mgmt/EventsSubscribeSseTest.java
@@ -1,0 +1,148 @@
+package com.auth0.client.mgmt;
+
+import com.auth0.client.mgmt.types.EventStreamCloudEventUserUpdatedObjectIdentitiesItem;
+import com.auth0.client.mgmt.types.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom;
+import com.auth0.client.mgmt.types.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase;
+import com.auth0.client.mgmt.types.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise;
+import com.auth0.client.mgmt.types.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless;
+import com.auth0.client.mgmt.types.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial;
+import com.auth0.client.mgmt.types.EventStreamSubscribeEventsEventTypeEnum;
+import com.auth0.client.mgmt.types.EventStreamSubscribeEventsResponseContent;
+import com.auth0.client.mgmt.types.SubscribeEventsRequestParameters;
+import java.util.Arrays;
+import java.util.Iterator;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the Events API SSE subscription: the event must resolve to its typed variant
+ */
+public class EventsSubscribeSseTest {
+
+    private static final String USER_UPDATED_SSE_BODY = "event: user.updated\n" + "id: evt-anonymized-1\n"
+            + "data: {\"offset\":\"off-anonymized-1\",\"event\":{\"specversion\":\"1.0\",\"type\":\"user.updated\","
+            + "\"source\":\"urn:auth0:example-test.eu.auth0.com\",\"id\":\"evt_test_1\","
+            + "\"time\":\"2026-07-10T01:01:42.873Z\",\"data\":{\"object\":{"
+            + "\"user_id\":\"auth0|00000000-0000-0000-0000-000000000001\","
+            + "\"email\":\"user@example.com\",\"email_verified\":true,"
+            + "\"identities\":[{\"connection\":\"Example-Database\",\"isSocial\":false,\"provider\":\"auth0\","
+            + "\"user_id\":\"00000000-0000-0000-0000-000000000001\"}],"
+            + "\"created_at\":\"2026-05-08T09:33:01.503Z\",\"updated_at\":\"2026-07-10T01:01:42.868Z\"}},"
+            + "\"a0tenant\":\"example-test\",\"a0stream\":\"test-stream\"}}\n\n";
+
+    private MockWebServer server;
+    private ManagementApi client;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = ManagementApi.builder()
+                .url(server.url("/").toString())
+                .token("test-token")
+                .build();
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void subscribeResolvesUserUpdatedEventToTypedVariant() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(USER_UPDATED_SSE_BODY));
+
+        Iterable<EventStreamSubscribeEventsResponseContent> response = client.events()
+                .subscribe(SubscribeEventsRequestParameters.builder()
+                        .eventType(Arrays.asList(EventStreamSubscribeEventsEventTypeEnum.USER_UPDATED))
+                        .build());
+
+        RecordedRequest request = server.takeRequest();
+        Assertions.assertEquals("GET", request.getMethod());
+        HttpUrl requestUrl = request.getRequestUrl();
+        Assertions.assertNotNull(requestUrl);
+        Assertions.assertEquals("user.updated", requestUrl.queryParameter("event_type"));
+
+        Iterator<EventStreamSubscribeEventsResponseContent> iterator = response.iterator();
+        Assertions.assertTrue(iterator.hasNext());
+        EventStreamSubscribeEventsResponseContent event = iterator.next();
+        Assertions.assertFalse(iterator.hasNext(), "expected exactly one event");
+
+        Assertions.assertFalse(event._isUnknown());
+        Assertions.assertTrue(event.isUserUpdated());
+        Assertions.assertTrue(event.getUserUpdated().isPresent());
+
+        Assertions.assertEquals("off-anonymized-1", event.getUserUpdated().get().getOffset());
+        Assertions.assertEquals(
+                "auth0|00000000-0000-0000-0000-000000000001",
+                event.getUserUpdated().get().getEvent().getData().getObject().getUserId());
+
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItem identity = event.getUserUpdated()
+                .get()
+                .getEvent()
+                .getData()
+                .getObject()
+                .getIdentities()
+                .get(0);
+        Object resolvedIdentity =
+                identity.visit(new EventStreamCloudEventUserUpdatedObjectIdentitiesItem.Visitor<Object>() {
+                    @Override
+                    public Object visit(EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom value) {
+                        return value;
+                    }
+
+                    @Override
+                    public Object visit(EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase value) {
+                        return value;
+                    }
+
+                    @Override
+                    public Object visit(EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise value) {
+                        return value;
+                    }
+
+                    @Override
+                    public Object visit(EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless value) {
+                        return value;
+                    }
+
+                    @Override
+                    public Object visit(EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial value) {
+                        return value;
+                    }
+                });
+
+        Assertions.assertInstanceOf(
+                EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase.class, resolvedIdentity);
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase database =
+                (EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase) resolvedIdentity;
+        Assertions.assertEquals("Example-Database", database.getConnection());
+        Assertions.assertEquals("auth0", database.getProvider().toString());
+    }
+
+    @Test
+    public void unrecognizedEventTypeFallsBackToUnknownWithoutThrowing() throws Exception {
+        String body = "event: user.teleported\n" + "data: {\"foo\":\"bar\"}\n\n";
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(body));
+
+        Iterable<EventStreamSubscribeEventsResponseContent> response = client.events()
+                .subscribe(SubscribeEventsRequestParameters.builder().build());
+
+        Iterator<EventStreamSubscribeEventsResponseContent> iterator = response.iterator();
+        Assertions.assertTrue(iterator.hasNext());
+        EventStreamSubscribeEventsResponseContent event = Assertions.assertDoesNotThrow(iterator::next);
+        Assertions.assertTrue(event._isUnknown());
+    }
+}


### PR DESCRIPTION


### Changes

When I subscribed to UserUpdateEvents, all events are of the type: `EventStreamSubscribeEventsResponseContent._UnknownValue`, without readable data. This commit fixes this. Added a EventsSubscribeSseTest that shows the original problem.

### References


Example code to reproduce the bug:

```
	private void connect()
	{
		final SubscribeEventsRequestParameters.Builder settings = SubscribeEventsRequestParameters.builder()
			.eventType(EventStreamSubscribeEventsEventTypeEnum.USER_UPDATED);

		final Optional<String> offset = syncService.getOffset(EVENT_TYPE_KEY);
		if (offset.isPresent())
		{
			settings.from(offset.get());
		}
		else
		{
			settings.fromTimestamp(startOfDay());
		}

		log.info("Subscribing to Auth0 user.updated event stream (resuming from {})", offset.map(o -> "offset " + o).orElse("start of day"));
		final Iterable<EventStreamSubscribeEventsResponseContent> stream = apiProvider.getManagementApi().events().subscribe(settings.build());
		try
		{
			for (EventStreamSubscribeEventsResponseContent event : stream)
			{
				try
				{
					handleEvent(event);
				}
				catch (Exception e)
				{
					// A single malformed event must not tear down the whole stream.
					log.error("Failed to handle Auth0 event", e);
				}
			}
		}
		finally
		{
			closeQuietly(stream);
		}
	}

	private void handleEvent(EventStreamSubscribeEventsResponseContent event)
	{
		if (event.getUserUpdated().isPresent())
		{
			handleUserUpdated(event.getUserUpdated().get());
			return;
		}
		if (event.getOffsetOnly().isPresent())
		{
			handleOffsetOnly(event.getOffsetOnly().get());
			return;
		}
		if (event._isUnknown())
		{
			log.warn("Received unknown Auth0 event type, ignoring: {}", event);
		}
	}
```

All events will print `Received unknown Auth0 event type, ignoring: EventStreamSubscribeEventsResponseContent{type: null, value: null}`

This is because the response is not parsed correctly: the `value` of all events are of type `'_Unkown` instead of the correct value

I've added the EventsSubscribeSseTest wich mimics the example code.

Please include relevant links supporting this change:

- https://github.com/auth0/auth0-java/issues/897
- https://auth0.com/docs/customize/events/consume-events-with-events-api
 
### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

Tested with java 21 in our own project, and build the unit-tests with java 17 because spotless did not work with my later java versions. (com.sun libs missing)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
