### PR TITLE
ci: set read-only workflow token permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ["master", "main", "v3"]
 
+
+permissions:
+  contents: read
 jobs:
   gradle:
     runs-on:  ubuntu-latest

--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["master"]
 
+
+permissions:
+  contents: read
 jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main


### PR DESCRIPTION
## Summary
- set explicit read-only `GITHUB_TOKEN` permissions for CI workflows that only need repository checkout/read access
- leave release/deploy/write-capable workflows unchanged

## Why
This follows GitHub Actions least-privilege guidance and reduces the default token scope available to routine CI jobs without changing the test/build commands.

## Verification
- Parsed the changed workflow YAML with PyYAML.
- Ran `git diff --check`.
