### PR TITLE
ci: GitHub Actions against script injection

### DIFF
--- a/.github/actions/maven-publish/action.yml
+++ b/.github/actions/maven-publish/action.yml
@@ -22,11 +22,13 @@ runs:
 
     - name: Setup Java
       shell: bash
+      env:
+        JAVA_VERSION: ${{ inputs.java-version }}
       run: |
         curl -s "https://get.sdkman.io" | bash
         source "/home/runner/.sdkman/bin/sdkman-init.sh"
         sdk list java
-        sdk install java ${{ inputs.java-version }} && sdk default java ${{ inputs.java-version }}
+        sdk install java "$JAVA_VERSION" && sdk default java "$JAVA_VERSION"
         export JAVA_HOME=${SDKMAN_DIR}/candidates/java/current
         echo "JAVA_HOME is set to $JAVA_HOME"
 

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -53,8 +53,10 @@ jobs:
         uses: ./.github/actions/get-version
 
       - name: Create tgz build artifact
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
         run: |
-          tar -czvf ${{ inputs.artifact-name }} *
+          tar -czvf "$ARTIFACT_NAME" *
 
       - name: Run RL Scanner
         id: rl-scan-conclusion


### PR DESCRIPTION
### Changes

Pass workflow inputs through environment variables instead of interpolating them directly into shell scripts, preventing shell command injection via untrusted input.

   - maven-publish: java-version -> JAVA_VERSION env var
   - rl-scanner: artifact-name -> ARTIFACT_NAME env var
