### PR TITLE
feat: allow custom telemetry for SDKs built on auth0-java

### DIFF
--- a/src/main/java/com/auth0/client/mgmt/ManagementApiBuilder.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementApiBuilder.java
@@ -5,6 +5,7 @@ package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.core.*;
 import com.auth0.net.Telemetry;
+import com.auth0.utils.Asserts;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -203,7 +204,9 @@ public class ManagementApiBuilder {
      * @return This builder for method chaining
      */
     public ManagementApiBuilder withTelemetry(String name, String version) {
-        this.telemetry = new Telemetry(name, version, Telemetry.class.getPackage().getImplementationVersion());
+        Asserts.assertNotNull(name, "name");
+        this.telemetry =
+                new Telemetry(name, version, Telemetry.class.getPackage().getImplementationVersion());
         return this;
     }
 

--- a/src/main/java/com/auth0/client/mgmt/ManagementApiBuilder.java
+++ b/src/main/java/com/auth0/client/mgmt/ManagementApiBuilder.java
@@ -4,6 +4,7 @@
 package com.auth0.client.mgmt;
 
 import com.auth0.client.mgmt.core.*;
+import com.auth0.net.Telemetry;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +27,8 @@ public class ManagementApiBuilder {
     private Optional<LogConfig> logging = Optional.empty();
 
     private String customDomain = null;
+
+    private Telemetry telemetry = null;
 
     // Domain-based initialization fields
     private String domain = null;
@@ -188,6 +191,22 @@ public class ManagementApiBuilder {
         return this;
     }
 
+    /**
+     * Configure the telemetry sent to Auth0 on every request. Use this when building an SDK on top of
+     * auth0-java so that requests are attributed to the wrapping library, with auth0-java reported as the
+     * underlying library in the telemetry environment.
+     *
+     * <p>If not set, telemetry defaults to identifying this library as {@code auth0-java}.
+     *
+     * @param name The name of the library sending the requests (e.g. the wrapping SDK's name)
+     * @param version The version of the library sending the requests
+     * @return This builder for method chaining
+     */
+    public ManagementApiBuilder withTelemetry(String name, String version) {
+        this.telemetry = new Telemetry(name, version, Telemetry.class.getPackage().getImplementationVersion());
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -202,6 +221,9 @@ public class ManagementApiBuilder {
         if (this.customDomain != null) {
             builder.addHeader(CustomDomainInterceptor.HEADER_NAME, this.customDomain);
             builder.addInterceptor(new CustomDomainInterceptor());
+        }
+        if (this.telemetry != null) {
+            builder.telemetry(this.telemetry);
         }
         setAdditional(builder);
         return builder.build();

--- a/src/main/java/com/auth0/client/mgmt/core/ClientOptions.java
+++ b/src/main/java/com/auth0/client/mgmt/core/ClientOptions.java
@@ -27,6 +27,8 @@ public final class ClientOptions {
 
     private final int maxRetries;
 
+    private final Telemetry telemetry;
+
     private ClientOptions(
             Environment environment,
             Map<String, String> headers,
@@ -49,6 +51,7 @@ public final class ClientOptions {
         this.httpClient = httpClient;
         this.timeout = timeout;
         this.maxRetries = maxRetries;
+        this.telemetry = telemetry;
     }
 
     public Environment environment() {
@@ -92,6 +95,32 @@ public final class ClientOptions {
 
     public int maxRetries() {
         return this.maxRetries;
+    }
+
+    /**
+     * The telemetry explicitly configured on this instance, or {@code null} if it was left to
+     * default to {@code auth0-java}. Package-private so {@link Builder#from(ClientOptions)} can
+     * carry it over; not part of the public API.
+     */
+    Telemetry telemetry() {
+        return this.telemetry;
+    }
+
+    /**
+     * The static headers configured on this instance, including the resolved {@code Auth0-Client}
+     * header. Package-private so {@link Builder#from(ClientOptions)} can carry them over; not part
+     * of the public API.
+     */
+    Map<String, String> headers() {
+        return this.headers;
+    }
+
+    /**
+     * The dynamic header suppliers configured on this instance. Package-private so
+     * {@link Builder#from(ClientOptions)} can carry them over; not part of the public API.
+     */
+    Map<String, Supplier<String>> headerSuppliers() {
+        return this.headerSuppliers;
     }
 
     public static Builder builder() {
@@ -230,13 +259,22 @@ public final class ClientOptions {
         }
 
         /**
-         * Create a new Builder initialized with values from an existing ClientOptions
+         * Create a new Builder initialized with values from an existing ClientOptions.
+         *
+         * <p>Interceptors and logging are not copied explicitly: they are already baked into the
+         * {@link OkHttpClient} carried over here, and {@link #build()} preserves them via
+         * {@code newBuilder()}. Copying them would attach them a second time. The same applies to
+         * the retry interceptor, hence {@code maxRetries} is carried over for reporting only.
          */
         public static Builder from(ClientOptions clientOptions) {
             Builder builder = new Builder();
             builder.environment = clientOptions.environment();
             builder.timeout = Optional.of(clientOptions.timeout(null));
             builder.httpClient = clientOptions.httpClient();
+            builder.maxRetries = clientOptions.maxRetries();
+            builder.telemetry = clientOptions.telemetry();
+            builder.headers.putAll(clientOptions.headers());
+            builder.headerSuppliers.putAll(clientOptions.headerSuppliers());
             return builder;
         }
     }

--- a/src/main/java/com/auth0/client/mgmt/core/ClientOptions.java
+++ b/src/main/java/com/auth0/client/mgmt/core/ClientOptions.java
@@ -178,9 +178,10 @@ public final class ClientOptions {
         }
 
         /**
-         * Configure the telemetry sent to Auth0 on every request. Used when building an SDK on top of
-         * auth0-java so requests are attributed to the wrapping library. If not set, telemetry defaults
-         * to identifying this library as {@code auth0-java}.
+         * Internal plumbing. Sets the pre-built {@link Telemetry} used for the {@code Auth0-Client}
+         * header. Prefer {@link com.auth0.client.mgmt.ManagementApiBuilder#withTelemetry(String, String)},
+         * which constructs the telemetry with the correct auth0-java version. Passing a hand-built
+         * {@link Telemetry} here bypasses that and is not a supported way to identify a wrapping SDK.
          */
         public Builder telemetry(Telemetry telemetry) {
             this.telemetry = telemetry;

--- a/src/main/java/com/auth0/client/mgmt/core/ClientOptions.java
+++ b/src/main/java/com/auth0/client/mgmt/core/ClientOptions.java
@@ -33,15 +33,17 @@ public final class ClientOptions {
             Map<String, Supplier<String>> headerSuppliers,
             OkHttpClient httpClient,
             int timeout,
-            int maxRetries) {
+            int maxRetries,
+            Telemetry telemetry) {
         this.environment = environment;
         this.headers = new HashMap<>();
         this.headers.putAll(headers);
 
-        Telemetry telemetry =
-                new Telemetry("auth0-java", Telemetry.class.getPackage().getImplementationVersion());
-        if (telemetry.getValue() != null) {
-            this.headers.put("Auth0-Client", telemetry.getValue());
+        Telemetry resolvedTelemetry = telemetry != null
+                ? telemetry
+                : new Telemetry("auth0-java", Telemetry.class.getPackage().getImplementationVersion());
+        if (resolvedTelemetry.getValue() != null) {
+            this.headers.put("Auth0-Client", resolvedTelemetry.getValue());
         }
         this.headerSuppliers = headerSuppliers;
         this.httpClient = httpClient;
@@ -113,6 +115,8 @@ public final class ClientOptions {
 
         private LogConfig logging = null;
 
+        private Telemetry telemetry = null;
+
         public Builder environment(Environment environment) {
             this.environment = environment;
             return this;
@@ -173,6 +177,16 @@ public final class ClientOptions {
             return this;
         }
 
+        /**
+         * Configure the telemetry sent to Auth0 on every request. Used when building an SDK on top of
+         * auth0-java so requests are attributed to the wrapping library. If not set, telemetry defaults
+         * to identifying this library as {@code auth0-java}.
+         */
+        public Builder telemetry(Telemetry telemetry) {
+            this.telemetry = telemetry;
+            return this;
+        }
+
         public ClientOptions build() {
             OkHttpClient.Builder httpClientBuilder =
                     this.httpClient != null ? this.httpClient.newBuilder() : new OkHttpClient.Builder();
@@ -205,7 +219,13 @@ public final class ClientOptions {
             this.timeout = Optional.of(httpClient.callTimeoutMillis() / 1000);
 
             return new ClientOptions(
-                    environment, headers, headerSuppliers, httpClient, this.timeout.get(), this.maxRetries);
+                    environment,
+                    headers,
+                    headerSuppliers,
+                    httpClient,
+                    this.timeout.get(),
+                    this.maxRetries,
+                    this.telemetry);
         }
 
         /**

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -5,6 +5,7 @@ import com.auth0.client.ProxyOptions;
 import com.auth0.net.RateLimitInterceptor;
 import com.auth0.net.Telemetry;
 import com.auth0.net.TelemetryInterceptor;
+import com.auth0.utils.Asserts;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -354,6 +355,7 @@ public class DefaultHttpClient implements Auth0HttpClient {
          * @return this builder instance.
          */
         public Builder withTelemetry(String name, String version) {
+            Asserts.assertNotNull(name, "name");
             this.telemetry =
                     new Telemetry(name, version, Telemetry.class.getPackage().getImplementationVersion());
             return this;

--- a/src/main/java/com/auth0/net/client/DefaultHttpClient.java
+++ b/src/main/java/com/auth0/net/client/DefaultHttpClient.java
@@ -3,6 +3,7 @@ package com.auth0.net.client;
 import com.auth0.client.LoggingOptions;
 import com.auth0.client.ProxyOptions;
 import com.auth0.net.RateLimitInterceptor;
+import com.auth0.net.Telemetry;
 import com.auth0.net.TelemetryInterceptor;
 import java.io.IOException;
 import java.util.HashMap;
@@ -57,7 +58,7 @@ public class DefaultHttpClient implements Auth0HttpClient {
         clientBuilder.readTimeout(sanitizeTimeout(builder.readTimeout), TimeUnit.SECONDS);
         clientBuilder.connectTimeout(sanitizeTimeout(builder.connectTimeout), TimeUnit.SECONDS);
         clientBuilder.addInterceptor(getLoggingInterceptor(builder.loggingOptions));
-        clientBuilder.addInterceptor(getTelemetryInterceptor(builder.telemetryEnabled));
+        clientBuilder.addInterceptor(getTelemetryInterceptor(builder.telemetryEnabled, builder.telemetry));
         clientBuilder.addInterceptor(getRateLimitInterceptor(builder.maxRetries));
         clientBuilder.dispatcher(getDispatcher(builder.maxRequests, builder.maxRequestsPerHost));
 
@@ -243,8 +244,11 @@ public class DefaultHttpClient implements Auth0HttpClient {
         }
     }
 
-    private TelemetryInterceptor getTelemetryInterceptor(boolean telemetryEnabled) {
+    private TelemetryInterceptor getTelemetryInterceptor(boolean telemetryEnabled, Telemetry telemetry) {
         TelemetryInterceptor interceptor = new TelemetryInterceptor();
+        if (telemetry != null) {
+            interceptor.setTelemetry(telemetry);
+        }
         interceptor.setEnabled(telemetryEnabled);
         return interceptor;
     }
@@ -279,6 +283,7 @@ public class DefaultHttpClient implements Auth0HttpClient {
         private ProxyOptions proxyOptions;
         private LoggingOptions loggingOptions;
         private boolean telemetryEnabled = true;
+        private Telemetry telemetry;
         private int maxRetries = 3;
         private int maxRequests = 64;
         private int maxRequestsPerHost = 5;
@@ -334,6 +339,23 @@ public class DefaultHttpClient implements Auth0HttpClient {
          */
         public Builder telemetryEnabled(boolean telemetryEnabled) {
             this.telemetryEnabled = telemetryEnabled;
+            return this;
+        }
+
+        /**
+         * Configure the telemetry sent to Auth0 on every request. Use this when building an SDK on top of
+         * auth0-java so that requests are attributed to the wrapping library, with auth0-java reported as the
+         * underlying library in the telemetry environment.
+         * <p>
+         * If not set, telemetry defaults to identifying this library as {@code auth0-java}.
+         *
+         * @param name    the name of the library sending the requests (e.g. the wrapping SDK's name).
+         * @param version the version of the library sending the requests.
+         * @return this builder instance.
+         */
+        public Builder withTelemetry(String name, String version) {
+            this.telemetry =
+                    new Telemetry(name, version, Telemetry.class.getPackage().getImplementationVersion());
             return this;
         }
 

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -20,13 +20,16 @@ import com.auth0.json.auth.*;
 import com.auth0.net.BaseRequest;
 import com.auth0.net.Request;
 import com.auth0.net.SignUpRequest;
+import com.auth0.net.Telemetry;
 import com.auth0.net.TokenRequest;
 import com.auth0.net.client.Auth0HttpClient;
 import com.auth0.net.client.Auth0HttpRequest;
 import com.auth0.net.client.Auth0HttpResponse;
+import com.auth0.net.client.DefaultHttpClient;
 import com.auth0.net.client.HttpMethod;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.FileReader;
 import java.net.URLDecoder;
@@ -263,24 +266,26 @@ public class AuthAPITest {
 
     // Telemetry
 
+    private JsonNode decodeTelemetryHeader(RecordedRequest request) throws Exception {
+        String header = request.getHeader("Auth0-Client");
+        assertThat(header, is(notNullValue()));
+        return ObjectMapperProvider.getMapper().readTree(Base64.getUrlDecoder().decode(header));
+    }
+
     @Test
     public void shouldSendDefaultTelemetry() throws Exception {
         Request<UserInfo> request = api.userInfo("accessToken");
         server.jsonResponse(AUTH_USER_INFO, 200);
         request.execute();
-        RecordedRequest recordedRequest = server.takeRequest();
 
-        String header = recordedRequest.getHeader("Auth0-Client");
-        assertThat(header, is(notNullValue()));
-        com.fasterxml.jackson.databind.JsonNode telemetry = ObjectMapperProvider.getMapper()
-                .readTree(java.util.Base64.getUrlDecoder().decode(header));
+        JsonNode telemetry = decodeTelemetryHeader(server.takeRequest());
         assertThat(telemetry.get("name").asText(), is("auth0-java"));
     }
 
     @Test
     public void shouldSendCustomTelemetryWhenConfigured() throws Exception {
         AuthAPI customApi = AuthAPI.newBuilder(server.getBaseUrl(), CLIENT_ID, CLIENT_SECRET)
-                .withHttpClient(com.auth0.net.client.DefaultHttpClient.newBuilder()
+                .withHttpClient(DefaultHttpClient.newBuilder()
                         .withTelemetry("my-wrapper-sdk", "1.2.3")
                         .build())
                 .build();
@@ -288,15 +293,29 @@ public class AuthAPITest {
         Request<UserInfo> request = customApi.userInfo("accessToken");
         server.jsonResponse(AUTH_USER_INFO, 200);
         request.execute();
-        RecordedRequest recordedRequest = server.takeRequest();
 
-        String header = recordedRequest.getHeader("Auth0-Client");
-        assertThat(header, is(notNullValue()));
-        com.fasterxml.jackson.databind.JsonNode telemetry = ObjectMapperProvider.getMapper()
-                .readTree(java.util.Base64.getUrlDecoder().decode(header));
+        JsonNode telemetry = decodeTelemetryHeader(server.takeRequest());
         assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
         assertThat(telemetry.get("version").asText(), is("1.2.3"));
-        assertThat(telemetry.get("env"), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldNestAuth0JavaInTelemetryEnv() throws Exception {
+        String value = new Telemetry("my-wrapper-sdk", "1.2.3", "auth0-java-9.9.9").getValue();
+
+        JsonNode telemetry =
+                ObjectMapperProvider.getMapper().readTree(Base64.getUrlDecoder().decode(value));
+        assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
+        assertThat(telemetry.get("version").asText(), is("1.2.3"));
+        assertThat(telemetry.get("env").get("auth0-java").asText(), is("auth0-java-9.9.9"));
+    }
+
+    @Test
+    public void shouldThrowWhenTelemetryNameIsNull() {
+        verifyThrows(
+                IllegalArgumentException.class,
+                () -> DefaultHttpClient.newBuilder().withTelemetry(null, "1.2.3"),
+                "'name' cannot be null!");
     }
 
     // Reset Password

--- a/src/test/java/com/auth0/client/auth/AuthAPITest.java
+++ b/src/test/java/com/auth0/client/auth/AuthAPITest.java
@@ -261,6 +261,44 @@ public class AuthAPITest {
         assertThat(identities.get(0), hasEntry("isSocial", false));
     }
 
+    // Telemetry
+
+    @Test
+    public void shouldSendDefaultTelemetry() throws Exception {
+        Request<UserInfo> request = api.userInfo("accessToken");
+        server.jsonResponse(AUTH_USER_INFO, 200);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        String header = recordedRequest.getHeader("Auth0-Client");
+        assertThat(header, is(notNullValue()));
+        com.fasterxml.jackson.databind.JsonNode telemetry = ObjectMapperProvider.getMapper()
+                .readTree(java.util.Base64.getUrlDecoder().decode(header));
+        assertThat(telemetry.get("name").asText(), is("auth0-java"));
+    }
+
+    @Test
+    public void shouldSendCustomTelemetryWhenConfigured() throws Exception {
+        AuthAPI customApi = AuthAPI.newBuilder(server.getBaseUrl(), CLIENT_ID, CLIENT_SECRET)
+                .withHttpClient(com.auth0.net.client.DefaultHttpClient.newBuilder()
+                        .withTelemetry("my-wrapper-sdk", "1.2.3")
+                        .build())
+                .build();
+
+        Request<UserInfo> request = customApi.userInfo("accessToken");
+        server.jsonResponse(AUTH_USER_INFO, 200);
+        request.execute();
+        RecordedRequest recordedRequest = server.takeRequest();
+
+        String header = recordedRequest.getHeader("Auth0-Client");
+        assertThat(header, is(notNullValue()));
+        com.fasterxml.jackson.databind.JsonNode telemetry = ObjectMapperProvider.getMapper()
+                .readTree(java.util.Base64.getUrlDecoder().decode(header));
+        assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
+        assertThat(telemetry.get("version").asText(), is("1.2.3"));
+        assertThat(telemetry.get("env"), is(notNullValue()));
+    }
+
     // Reset Password
 
     @Test

--- a/src/test/java/com/auth0/client/mgmt/ManagementApiTelemetryTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementApiTelemetryTest.java
@@ -1,0 +1,53 @@
+package com.auth0.client.mgmt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.auth0.json.ObjectMapperProvider;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ManagementApiTelemetryTest {
+
+    private JsonNode decodeTelemetry(ManagementApi api) throws Exception {
+        Map<String, String> headers = api.clientOptions.headers(null);
+        String value = headers.get("Auth0-Client");
+        assertThat(value, is(notNullValue()));
+        byte[] json = Base64.getUrlDecoder().decode(value);
+        return ObjectMapperProvider.getMapper().readTree(json);
+    }
+
+    @Test
+    public void shouldSendDefaultTelemetryWhenNotConfigured() throws Exception {
+        ManagementApi api = ManagementApi.builder()
+                .domain("my-tenant.auth0.com")
+                .token("test-token")
+                .build();
+
+        JsonNode telemetry = decodeTelemetry(api);
+        assertThat(telemetry.get("name").asText(), is("auth0-java"));
+    }
+
+    @Test
+    public void shouldSendCustomTelemetryWhenConfigured() throws Exception {
+        ManagementApi api = ManagementApi.builder()
+                .domain("my-tenant.auth0.com")
+                .token("test-token")
+                .withTelemetry("my-wrapper-sdk", "1.2.3")
+                .build();
+
+        JsonNode telemetry = decodeTelemetry(api);
+        assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
+        assertThat(telemetry.get("version").asText(), is("1.2.3"));
+        assertThat(telemetry.get("env"), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturnBuilderFromWithTelemetry() {
+        ManagementApiBuilder builder = ManagementApi.builder();
+        ManagementApiBuilder result = builder.withTelemetry("my-wrapper-sdk", "1.2.3");
+        assertThat(result, is(sameInstance(builder)));
+    }
+}

--- a/src/test/java/com/auth0/client/mgmt/ManagementApiTelemetryTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementApiTelemetryTest.java
@@ -1,9 +1,12 @@
 package com.auth0.client.mgmt;
 
+import static com.auth0.AssertsUtil.verifyThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import com.auth0.client.mgmt.core.ClientOptions;
 import com.auth0.json.ObjectMapperProvider;
+import com.auth0.net.Telemetry;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Base64;
 import java.util.Map;
@@ -41,7 +44,22 @@ public class ManagementApiTelemetryTest {
         JsonNode telemetry = decodeTelemetry(api);
         assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
         assertThat(telemetry.get("version").asText(), is("1.2.3"));
-        assertThat(telemetry.get("env"), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldNestAuth0JavaInTelemetryEnv() throws Exception {
+        ClientOptions options = ClientOptions.builder()
+                .environment(com.auth0.client.mgmt.core.Environment.DEFAULT)
+                .telemetry(new Telemetry("my-wrapper-sdk", "1.2.3", "auth0-java-9.9.9"))
+                .build();
+
+        String value = options.headers(null).get("Auth0-Client");
+        assertThat(value, is(notNullValue()));
+        JsonNode telemetry =
+                ObjectMapperProvider.getMapper().readTree(Base64.getUrlDecoder().decode(value));
+        assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
+        assertThat(telemetry.get("version").asText(), is("1.2.3"));
+        assertThat(telemetry.get("env").get("auth0-java").asText(), is("auth0-java-9.9.9"));
     }
 
     @Test
@@ -49,5 +67,13 @@ public class ManagementApiTelemetryTest {
         ManagementApiBuilder builder = ManagementApi.builder();
         ManagementApiBuilder result = builder.withTelemetry("my-wrapper-sdk", "1.2.3");
         assertThat(result, is(sameInstance(builder)));
+    }
+
+    @Test
+    public void shouldThrowWhenTelemetryNameIsNull() {
+        verifyThrows(
+                IllegalArgumentException.class,
+                () -> ManagementApi.builder().withTelemetry(null, "1.2.3"),
+                "'name' cannot be null!");
     }
 }

--- a/src/test/java/com/auth0/client/mgmt/ManagementApiTelemetryTest.java
+++ b/src/test/java/com/auth0/client/mgmt/ManagementApiTelemetryTest.java
@@ -63,6 +63,28 @@ public class ManagementApiTelemetryTest {
     }
 
     @Test
+    public void shouldPreserveTelemetryAndHeadersWhenCopyingOptions() throws Exception {
+        ClientOptions original = ClientOptions.builder()
+                .environment(com.auth0.client.mgmt.core.Environment.DEFAULT)
+                .telemetry(new Telemetry("my-wrapper-sdk", "1.2.3"))
+                .addHeader("Authorization", "Bearer test-token")
+                .addHeader("X-Dynamic", () -> "dynamic-value")
+                .maxRetries(5)
+                .build();
+
+        ClientOptions copy = ClientOptions.Builder.from(original).build();
+
+        Map<String, String> headers = copy.headers(null);
+        JsonNode telemetry =
+                ObjectMapperProvider.getMapper().readTree(Base64.getUrlDecoder().decode(headers.get("Auth0-Client")));
+        assertThat(telemetry.get("name").asText(), is("my-wrapper-sdk"));
+        assertThat(telemetry.get("version").asText(), is("1.2.3"));
+        assertThat(headers.get("Authorization"), is("Bearer test-token"));
+        assertThat(headers.get("X-Dynamic"), is("dynamic-value"));
+        assertThat(copy.maxRetries(), is(5));
+    }
+
+    @Test
     public void shouldReturnBuilderFromWithTelemetry() {
         ManagementApiBuilder builder = ManagementApi.builder();
         ManagementApiBuilder result = builder.withTelemetry("my-wrapper-sdk", "1.2.3");


### PR DESCRIPTION
# Description

## Summary

Restores the ability for SDKs built on top of `auth0-java` to identify themselves in the `Auth0-Client` telemetry header, while still reporting `auth0-java` as the underlying library.

Adds a `withTelemetry(name, version)` builder hook to **both** the Authentication and Management API clients so telemetry is consistent regardless of which API a wrapping SDK calls. Previously, even if the Auth side were addressed, Management API requests remained hardcoded to `auth0-java`.

## Changes

* **Auth API** - `DefaultHttpClient.Builder.withTelemetry(name, version)`; applied to the existing `TelemetryInterceptor` via `setTelemetry(...)`.
* **Management API** - `ManagementApiBuilder.withTelemetry(name, version)`, threaded through `ClientOptions` so the `Auth0-Client` header honors the custom telemetry when set.
* When used, requests report the `name`/`version` of the wrapper with `auth0-java` nested under `env.auth0-java`.

## Behavior

```java
// Wrapping SDK
ManagementApi.builder()
    .domain("tenant.auth0.com")
    .token(token)
    .withTelemetry("my-wrapper-sdk", "1.2.3")
    .build();
```

Decoded `Auth0-Client` header:

```json
{
  "name": "my-wrapper-sdk",
  "version": "1.2.3",
  "env": {
    "java": "17",
    "auth0-java": "4.2.0"
  }
}
```

## Test Plan

* `ManagementApiTelemetryTest`

  * Default name
  * Custom name/version/env
  * Builder chaining
* `AuthAPITest`

  * Default telemetry
  * Custom telemetry asserted from the decoded `Auth0-Client` header
* `./gradlew test --rerun-tasks` passes for the targeted tests.
